### PR TITLE
docs: clean up README and docs for v1.0.1 public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![Debian Compat](https://github.com/MoeShinX/relay-panel/actions/workflows/debian-compat.yml/badge.svg)](https://github.com/MoeShinX/relay-panel/actions/workflows/debian-compat.yml)
 
 A self-hosted **TCP/UDP forwarding management panel** built in Rust. Manage
-port-forwarding rules, device groups, traffic accounting, and live node status
+port-forwarding rules, device groups, traffic quotas, and live node status
 through a web UI — lightweight: one ~7 MB panel binary + a ~4 MB node binary
-per forwarding host (Docker images ~140 MB).
+per forwarding host.
 
-**Target OS:** Linux (Debian 11 / 12 / 13) · **Deploy:** Docker Compose only ·
+**Deploy:** Docker Compose · **Database:** SQLite (default) or PostgreSQL ·
 **Version:** `1.0.1`
 
 ---
@@ -19,72 +19,61 @@ per forwarding host (Docker images ~140 MB).
 
 ```
  ┌─────────────┐    WebSocket (config push) + HTTP (status/traffic)   ┌──────────────┐
- │  Browser    +<-----+                                          +---<+ relay-node  │
- │  (React UI) │       │                                          │    │ (Tokio TCP/ │
- └─────────────┘       │   ┌──────────────────┐                    │    │  UDP engine)│
-                       +--->│   relay-panel    │+<-------------------+    └──────────────┘
-                           │  (Axum + SQLite) │              │
-                           │  serves UI + API │              v
+ │  Browser    │◄──────┐                                          ┌───►│ relay-node   │
+ │  (React UI) │       │                                          │    │ (Tokio TCP/  │
+ └─────────────┘       │   ┌──────────────────┐                   │    │  UDP engine)  │
+                       └──►│   relay-panel     │◄──────────────────┘    └──────────────┘
+                           │  (Axum + SQLite/  │              │
+                           │   PostgreSQL)     │              ▼
                            └──────────────────┘        forwards traffic
-                                       ^               to real targets
+                                       ▲               to real targets
                                        │
                               ┌────────┴────────┐
-                              │  SQLite (data)  │
+                              │  SQLite / PG    │
                               └─────────────────┘
 ```
 
-- **Panel** — Axum HTTP server: serves the React SPA + REST API, persists state
-  in SQLite. JWT auth, bcrypt passwords.
+- **Panel** — Axum HTTP server: serves the React SPA + REST API. JWT auth,
+  bcrypt passwords. SQLite (zero-config) or PostgreSQL.
 - **Node** — runs on each forwarding host. Opens TCP/UDP listeners, forwards
-  traffic, reports status + traffic back. Outbound-only (no NAT traversal).
-- **Config delivery** — WebSocket for real-time push (25 s heartbeat) + HTTP
-  poll every 10 s as fallback. WS failure never stops forwarding.
-- **Auth** — every node request carries `Authorization: Bearer <NODE_TOKEN>`
-  (never in the query string, so it can't leak into access/proxy logs).
-- **Accounting** — traffic is attributed to `rule_id` (not the listen port),
-  then propagated to the rule and its owning user.
+  traffic, reports status + traffic back.
+- **Config delivery** — WebSocket real-time push (25 s heartbeat) + HTTP poll
+  every 10 s as fallback. WS failure never stops forwarding.
 
-## Repository layout
+## Features
 
-```
-relay-panel/
-├── crates/
-│   ├── shared/             # protocol types + DB models (panel + node)
-│   ├── panel/              # the Axum panel binary
-│   └── node/               # the Tokio forwarding node binary
-├── frontend/               # React + TypeScript + antd SPA
-├── docs/                   # user-facing docs (DEPLOYMENT, NODE, VERSIONS…)
-├── scripts/                # install / release-check helpers
-├── tests/e2e_test.py       # automated TCP+UDP forwarding test
-├── install.sh              # one-line panel installer
-├── deploy.sh               # panel deployer (pulls GHCR images + compose up)
-├── docker-compose.yaml     # source-build compose
-├── docker-compose.release.yaml  # pre-built-image compose
-└── Caddyfile               # Caddy TLS reverse proxy (Compose profile)
-```
+- **Forwarding rules** — TCP/UDP port forwarding with multi-target support,
+  per-target circuit breaker (3 failures → 30 s cooldown), failover and
+  round-robin load balancing.
+- **Dashboard** — node status overview, traffic statistics, version update
+  check.
+- **Traffic & quotas** — per-rule and per-user traffic tracking with
+  configurable limits (rule count, bandwidth, traffic cap).
+- **Multi-plan registration** — admins configure allowed plans; users choose
+  on sign-up.
+- **User management** — admin can manage any user's rules, reset traffic,
+  reset password, ban/unban.
+- **Live node status** — CPU, memory, connections, version, GeoIP country
+  flag per node.
+- **GeoIP** — built-in providers (ipinfo.io Lite + ipwho.is fallback),
+  enabled by default. Opt out with `GEOIP_ENABLED=false`.
+- **Dual database** — SQLite (default, zero-config) or PostgreSQL.
+- **Security** — first login forces password change; node auth via
+  `Authorization: Bearer` header (never in query string).
 
 ## Quick start
 
-**Production (one command — installs deps, clones, starts the panel):**
+**Production (one command):**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MoeShinX/relay-panel/main/install.sh | bash
 ```
 
-Full deployment guide (secrets, upgrades, reverse proxy, troubleshooting):
-**[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** ·
-Reverse proxy guide: **[docs/REVERSE-PROXY.md](docs/REVERSE-PROXY.md)** ·
-Forwarding node setup: **[docs/NODE.md](docs/NODE.md)**
+> **Default login `admin` / `admin123` — first login forces a password change.**
 
-> v0.4.15 added node-level GeoIP (a country flag next to each node). As of
-> v0.4.16 it is **enabled by default**; v0.4.19 switched to built-in primary
-> (ipinfo.io Lite) + fallback (ipwho.is) providers. To opt out set
-> `GEOIP_ENABLED=false` — see
-> [GeoIP setup](docs/DEPLOYMENT.md#geoip--node-region-resolution-optional-enabled-by-default-since-v0416).
-
-> **Default login `admin` / `admin123` — the first login forces a password
-> change, so pick a strong one.**
-> See the [security checklist](docs/DEPLOYMENT.md#deploy-with-docker-compose).
+Full deployment guide: **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** ·
+Reverse proxy: **[docs/REVERSE-PROXY.md](docs/REVERSE-PROXY.md)** ·
+Node setup: **[docs/NODE.md](docs/NODE.md)**
 
 **Local dev:**
 
@@ -96,36 +85,26 @@ python3 tests/e2e_test.py                   # end-to-end TCP+UDP forwarding test
 
 ## Update
 
-**Update an existing install** (pull new images + restart containers):
-
 ```bash
 cd /opt/relay-panel && git pull --quiet && ./deploy.sh
 ```
 
-> ⚠️ **We strongly recommend backing up your data before updating.** Copy your
-> `.env` and your database (the `data/` directory for SQLite, or a `pg_dump` for
-> PostgreSQL) somewhere safe first, so you can roll back if an upgrade goes wrong.
+> ⚠️ **Back up before updating.** Copy `.env` and your database (`data/` for
+> SQLite, `pg_dump` for PostgreSQL) first.
 
-> Forwarding nodes update from the panel: **Device Groups → Copy Install Command**,
-> paste it on the node (same command installs and upgrades). See
-> [docs/NODE.md](docs/NODE.md#update).
+Forwarding nodes: **Device Groups → Copy Install Command** → paste on the
+node. See [docs/NODE.md](docs/NODE.md#update).
 
 ## Tech stack
 
-| Layer    | Choice                              |
+| Layer    | Choice                               |
 |----------|--------------------------------------|
-| Backend  | Rust, Axum 0.8, Tokio, sqlx, SQLite  |
+| Backend  | Rust, Axum 0.8, Tokio, sqlx          |
+| Database | SQLite / PostgreSQL                  |
 | Auth     | JWT (jsonwebtoken), bcrypt           |
-| Forward  | Tokio async TCP (`io::copy`) + UDP   |
+| Forward  | Tokio async TCP + UDP                |
 | Frontend | React 19, TypeScript, antd 6, Vite   |
 | Deploy   | Docker multi-stage, docker-compose   |
-
-## Status
-
-MVP, verified end-to-end. WebSocket real-time config + HTTP poll fallback,
-per-rule traffic accounting, editable users/traffic reset, and live node status
-(CPU/mem/conns/version). Pre-release — enforced
-per-user quotas are future work.
 
 ## License & Disclaimer
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,9 +6,10 @@
 [![Debian Compat](https://github.com/MoeShinX/relay-panel/actions/workflows/debian-compat.yml/badge.svg)](https://github.com/MoeShinX/relay-panel/actions/workflows/debian-compat.yml)
 
 自托管的 **TCP/UDP 端口转发管理面板**，用 Rust 编写。通过 Web UI 管理端口转发规则、
-设备分组、流量统计和实时节点状态 —— 轻量：单个约 7 MB 的 panel 二进制 + 约 4 MB 的 node 二进制（Docker 镜像约 140 MB）。
+设备分组、流量配额和实时节点状态 —— 轻量：单个约 7 MB 的 panel 二进制 + 约 4 MB
+的 node 二进制。
 
-**目标系统：** Linux（Debian 11 / 12 / 13） · **部署：** 仅 Docker Compose ·
+**部署：** Docker Compose · **数据库：** SQLite（默认）或 PostgreSQL ·
 **当前版本：** `1.0.1`
 
 ---
@@ -19,63 +20,53 @@
  ┌─────────────┐    WebSocket（配置推送）+ HTTP（状态/流量上报）   ┌──────────────┐
  │  浏览器     │◄──────┐                                          ┌───►│ relay-node  │
  │  (React UI) │       │                                          │    │ (Tokio TCP/ │
- └─────────────┘       │   ┌──────────────────┐                    │    │  UDP 引擎)  │
-                       └──►│   relay-panel    │◄────────────────────┘    └──────────────┘
-                           │ (Axum + SQLite)  │              │
-                           │ 提供 UI + API    │              ▼
+ └─────────────┘       │   ┌──────────────────┐                   │    │  UDP 引擎)  │
+                       └──►│   relay-panel     │◄──────────────────┘    └──────────────┘
+                           │ (Axum + SQLite/   │              │
+                           │  PostgreSQL)      │              ▼
                            └──────────────────┘       转发流量到真实目标
                                        ▲
                                        │
                               ┌────────┴────────┐
-                              │  SQLite (数据)  │
+                              │  SQLite / PG    │
                               └─────────────────┘
 ```
 
-- **Panel** — Axum HTTP 服务器：提供 React SPA + REST API，用 SQLite 持久化状态。JWT 鉴权，bcrypt 密码哈希。
-- **Node** — 运行在每个转发主机上。开启 TCP/UDP 监听器转发流量，回报状态与流量。仅需对外访问（无 NAT 穿透）。
-- **配置下发** — WebSocket 实时推送（25 秒心跳）+ HTTP 每 10 秒轮询兜底。WS 失败绝不中断转发。
-- **鉴权** — Node 每个请求带 `Authorization: Bearer <NODE_TOKEN>`（绝不放查询字符串，避免泄露到访问/代理日志）。
-- **计费** — 流量按 `rule_id` 归因（不是监听端口），再同步累加到规则和所属用户。
+- **Panel** — Axum HTTP 服务器：提供 React SPA + REST API。JWT 鉴权，bcrypt 密码。
+  支持 SQLite（零配置）或 PostgreSQL。
+- **Node** — 运行在每个转发主机上，开启 TCP/UDP 监听器转发流量，回报状态与流量。
+- **配置下发** — WebSocket 实时推送（25 秒心跳）+ HTTP 每 10 秒轮询兜底。WS 失败
+  绝不中断转发。
 
-## 仓库结构
+## 功能亮点
 
-```
-relay-panel/
-├── crates/
-│   ├── shared/             # 协议类型 + 数据库模型（panel + node 共享）
-│   ├── panel/              # Axum panel 二进制
-│   └── node/               # Tokio 转发节点二进制
-├── frontend/               # React + TypeScript + antd 单页应用
-├── docs/                   # 用户文档（DEPLOYMENT、NODE、VERSIONS…）
-├── scripts/                # 安装 / release-check 辅助脚本
-├── tests/e2e_test.py       # TCP + UDP 转发自动化测试
-├── install.sh              # 一行 panel 安装器
-├── deploy.sh               # panel 部署器（拉取 GHCR 镜像 + compose up）
-├── docker-compose.yaml     # 源码构建 compose
-├── docker-compose.release.yaml  # 预构建镜像 compose
-└── Caddyfile               # Caddy TLS 反向代理（Compose profile）
-```
+- **转发规则** — TCP/UDP 端口转发，多目标支持，单目标熔断（3 次失败 → 30 秒冷却），
+  故障转移与轮询负载均衡。
+- **仪表盘** — 节点状态总览、流量统计、版本更新检查。
+- **流量与配额** — 按规则、按用户计量流量，可设规则数/带宽/流量上限。
+- **多套餐注册** — 管理员配置允许注册的套餐，用户注册时自行选择。
+- **用户管理** — 管理员可从用户管理页直接管理任意用户的规则、重置流量、重置密码、
+  封禁/解封。
+- **实时节点状态** — CPU、内存、连接数、版本、GeoIP 国旗。
+- **GeoIP** — 内置主源（ipinfo.io Lite）+ 备用源（ipwho.is），默认开启。
+  `GEOIP_ENABLED=false` 关闭。
+- **双数据库** — SQLite（默认，零配置）或 PostgreSQL。
+- **安全** — 首次登录强制改密码；节点鉴权走 `Authorization: Bearer` 头（不走
+  查询字符串，不泄露到日志）。
 
 ## 快速开始
 
-**生产部署（一条命令 —— 自动装依赖、克隆、启动 panel）：**
+**生产部署（一条命令）：**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MoeShinX/relay-panel/main/install.sh | bash
 ```
 
-完整部署指南（密钥、升级、反向代理、故障排查）：
-**[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** ·
-反向代理指南：**[docs/REVERSE-PROXY.md](docs/REVERSE-PROXY.md)** ·
-转发节点安装：**[docs/NODE.zh-CN.md](docs/NODE.zh-CN.md)**
+> **默认账号 `admin` / `admin123`，首次登录强制修改密码。**
 
-> v0.4.15 新增节点级 GeoIP（在每个节点旁显示国家/地区旗标）。自 v0.4.16 起
-> **默认开启**；v0.4.19 切换为内置主源（ipinfo.io Lite）+ 备用源（ipwho.is）。
-> 如需关闭请设置 `GEOIP_ENABLED=false` —— 详见
-> [GeoIP 配置](docs/DEPLOYMENT.md#geoip--node-region-resolution-optional-enabled-by-default-since-v0416)。
-
-> **默认账号 `admin` / `admin123`，首次登录会强制要求修改密码，请设置强口令。**
-> 详见 [安全检查清单](docs/DEPLOYMENT.md#deploy-with-docker-compose)。
+完整部署指南：**[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** ·
+反向代理：**[docs/REVERSE-PROXY.md](docs/REVERSE-PROXY.md)** ·
+节点安装：**[docs/NODE.zh-CN.md](docs/NODE.zh-CN.md)**
 
 **本地开发：**
 
@@ -87,32 +78,26 @@ python3 tests/e2e_test.py                   # 端到端 TCP+UDP 转发测试
 
 ## 更新
 
-**更新已有部署**（拉取新镜像 + 重启容器）：
-
 ```bash
 cd /opt/relay-panel && git pull --quiet && ./deploy.sh
 ```
 
-> ⚠️ **强烈建议您更新前备份数据。** 请先把 `.env` 和数据库（SQLite 为 `data/`
-> 目录，PostgreSQL 用 `pg_dump`）复制到安全位置，以便升级出问题时回滚。
+> ⚠️ **更新前请备份数据。** 先把 `.env` 和数据库（SQLite 为 `data/` 目录，
+> PostgreSQL 用 `pg_dump`）复制到安全位置。
 
-> 转发节点更新：在面板「设备分组 → 复制对接命令」，粘贴到节点服务器执行
-> （同一条命令兼顾安装与升级）。详见 [docs/NODE.zh-CN.md](docs/NODE.zh-CN.md#更新)。
+转发节点更新：**设备分组 → 复制对接命令** → 粘贴到节点执行。
+详见 [docs/NODE.zh-CN.md](docs/NODE.zh-CN.md#更新)。
 
 ## 技术栈
 
-| 层级     | 选型                                |
+| 层级     | 选型                                 |
 |----------|--------------------------------------|
-| 后端     | Rust, Axum 0.8, Tokio, sqlx, SQLite  |
+| 后端     | Rust, Axum 0.8, Tokio, sqlx          |
+| 数据库   | SQLite / PostgreSQL                  |
 | 鉴权     | JWT (jsonwebtoken), bcrypt           |
-| 转发     | Tokio 异步 TCP (`io::copy`) + UDP    |
+| 转发     | Tokio 异步 TCP + UDP                 |
 | 前端     | React 19, TypeScript, antd 6, Vite   |
 | 部署     | Docker 多阶段构建，docker-compose    |
-
-## 项目状态
-
-MVP 已完成并通过端到端验证。WebSocket 实时配置 + HTTP 轮询兜底、按规则流量计费、
-用户编辑/流量重置、实时节点状态（CPU/内存/连接数/版本）。预发布阶段 —— 强制按用户配额是后续工作。
 
 ## 许可证与免责声明
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -115,7 +115,7 @@ NODE_TOKEN=<paste a node token from the UI later>
 # Optional: set when the panel is behind a domain/reverse proxy so the
 # "Copy Install Command" button emits the right URL for nodes.
 PUBLIC_PANEL_URL=https://panel.example.com
-# v0.4.3+: DATABASE_URL controls the database backend.  Defaults to SQLite.
+# DATABASE_URL controls the database backend.  Defaults to SQLite.
 # See "Database modes" section below.
 DATABASE_URL=sqlite:/app/data/data.db?mode=rwc
 EOF
@@ -126,7 +126,7 @@ EOF
     > in the panel UI after first login, copy its token, then update `.env` and
     > `docker compose restart node`.
 
-    ### Database modes (v0.4.3+)
+    ### Database modes
 
     RelayPanel supports three database modes, controlled by `DATABASE_URL`:
 
@@ -136,7 +136,7 @@ EOF
     | **PostgreSQL (embedded)** | `postgres://user:pass@postgres:5432/db` | `deploy.sh` starts a `postgres` container (profile), waits for healthy, then starts panel. Set `RELAYPANEL_DB_MODE=embedded-postgres` + `POSTGRES_DB`/`POSTGRES_USER`/`POSTGRES_PASSWORD` in `.env`. |
     | **PostgreSQL (external)** | `postgres://user:pass@host:port/db` | `deploy.sh` verifies connectivity with a real `psql` query before starting the panel. Set `RELAYPANEL_DB_MODE=external-postgres`. |
 
-    - `DATABASE_URL` is the **canonical** env var (v0.4.3+).
+    - `DATABASE_URL` is the **canonical** env var.
     - `DATABASE_PATH` is a **legacy fallback** — it still works, but new
       deployments should use `DATABASE_URL`. On upgrade, `deploy.sh` wraps a
       legacy `DATABASE_PATH` into a `sqlite:` URL **at the same location** (the
@@ -173,19 +173,19 @@ embeds it into the one-line install command.
 - A `localhost` / `127.0.0.1` / `0.0.0.0` value triggers a warning in the
   install-command modal, since nodes on other hosts cannot connect to those.
 
-    #### GeoIP — node region resolution (optional, **enabled by default since v0.4.16**)
+    #### GeoIP — node region resolution
 
 The panel can display a country flag + name next to each node's public IP on the
-node-status board. v0.4.15 shipped this opt-in (off by default); **v0.4.16
+node-status board. GeoIP is **enabled by default** with built-in providers.
 flips the default to ON**, so a fresh install shows country flags without any
 extra configuration. To opt out, set `GEOIP_ENABLED=false`.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `GEOIP_ENABLED` | `true` (since v0.4.16; was `false` in v0.4.15) | Master switch. Set to `false` / `0` to disable region resolution entirely. |
+| `GEOIP_ENABLED` | `true` | Master switch. Set to `false` / `0` to disable region resolution entirely. |
 | `GEOIP_CACHE_TTL` | `604800` (7 days) | How long a resolved country is cached (seconds) before a re-lookup. |
 
-**Since v0.4.19, the GeoIP provider URLs are built-in and no longer
+**The GeoIP provider URLs are built-in and no longer
 user-configurable.** The panel uses **ipinfo.io Lite** as primary, with
 automatic fallback to **ipwho.is** if the primary fails (timeout, error, or
 missing `country_code`). The old `GEOIP_API_URL` env var is ignored;
@@ -201,7 +201,6 @@ Privacy / safety notes:
 - Failures degrade gracefully to "unknown" and **never** affect node status,
   online state, or forwarding. The third-party response body is not logged.
 - To disable entirely, set `GEOIP_ENABLED=false`.
-- **Upgrading from v0.4.18:** if you previously set `GEOIP_API_URL` in `.env`,
   remove that line — it is no longer read. The panel always uses its built-in
   primary + fallback pair.
 
@@ -285,7 +284,7 @@ pulls the new GHCR images, and restarts the `panel`/`node` containers:
 > **Note on the admin password:** `deploy.sh` decides success by the container
 > state + port reachability + the `GET /api/v1/health` endpoint (a real JSON
 > health probe — status:"ok" + version). It does **not** log in as
-> `admin`/`admin123` at all (that probe was removed in v0.3.2 — it was a
+> `admin`/`admin123` at all (that probe was removed — it was a
 > needless login that could trip rate-limiting). So an upgrade on a deployment
 > where you've already changed the default password reports success exactly
 > like a first deploy.

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -75,9 +75,9 @@ Use this if you cannot run the installer (no systemd, custom paths, air-gapped
 server where you copy the binary over manually).
 
 ```bash
-# 1. Download the right binary for your arch (replace v0.2.0 with your release)
+# 1. Download the right binary for your arch (replace with your release version)
 ARCH=amd64   # or arm64
-VERSION=0.2.0
+VERSION=1.0.1
 curl -fL -o relay-node \
   "https://github.com/MoeShinX/relay-panel/releases/download/v${VERSION}/relay-node-linux-${ARCH}"
 
@@ -179,7 +179,7 @@ After install:
 ```bash
 # 1. Version should print instantly and exit (does NOT start the service)
 timeout 3 /opt/relay-node/relay-node --version
-# expected: relay-node 0.2.0
+# expected: relay-node 1.0.1
 
 # 2. Service status
 systemctl status relay-node
@@ -189,7 +189,7 @@ journalctl -u relay-node -f
 ```
 
 In the logs you should see:
-- `RelayNode 0.2.0 starting, panel=...`
+- `RelayNode 1.0.1 starting, panel=...`
 - `websocket connected` (if your reverse proxy supports WS)
 - `TCP listening on <port> (rule <id>)` / `UDP listening on ...` for each rule
 - `report_traffic HTTP 200` (the per-report status line; the detailed per-cycle
@@ -268,13 +268,13 @@ rm -rf /opt/relay-node
   within 30 seconds (3x the default poll interval)
 
 ### `websocket error: ... sec-websocket-key ...`
-This was fixed in v0.1.7+. Make sure you are on v0.2.0 or later:
+Make sure you are on the latest version:
 `/opt/relay-node/relay-node --version`. If it still happens, your reverse proxy
 may not be passing the WebSocket Upgrade headers - but note WS is only the
 control channel; forwarding + status reporting work over plain HTTP regardless.
 
 ### WebSocket keeps disconnecting / reconnecting every ~2 minutes
-Since v0.2.0 the node sends a 25s heartbeat Ping so the connection is not
+The node sends a 25s heartbeat Ping so the connection is not
 treated as idle. If you still see periodic disconnects, your reverse proxy /
 CDN may have an idle timeout shorter than 25s, or may not be forwarding
 Pong frames. Occasional reconnects are harmless (config is re-synced), but if
@@ -334,10 +334,7 @@ of inactivity. Generate real traffic and the count moves.
    (only warnings/errors). Set `RUST_LOG=debug` only when diagnosing issues
    (it prints every status report + every connection open/close).
 
-8. **Transport options.** v0.4.0+ supports `raw` (plain TCP/UDP), `ws`
-   (plaintext WebSocket), and `tls_simple` (node terminates TLS via rustls,
-   v0.4.1). Business WSS (WebSocket Secure via reverse proxy) was removed in
-   v0.4.1 — use TLS Simple for encrypted ingress.
+8. **Transport options.** Raw (plain TCP/UDP) is the default transport.
 
 ---
 
@@ -348,13 +345,13 @@ the `main` branch, and it downloads the binary version compiled into itself
 (the `SCRIPT_VERSION` at the top of the script). So `main`'s installer always
 installs the **latest** release.
 
-If you need to **pin a specific older version** (e.g. stay on v0.1.9 while
+If you need to **pin a specific older version** (e.g. stay on a specific version while
 testing), do NOT use the `main` installer — download that release's binary
 directly and install by hand (see [Manual install](#option-b-manual-install)):
 
 ```bash
-# Example: pin to v0.1.9 on amd64
-VERSION=0.1.9
+# Example: pin to a specific version on amd64
+VERSION=1.0.1
 ARCH=amd64   # or arm64
 curl -fL -o relay-node \
   "https://github.com/MoeShinX/relay-panel/releases/download/v${VERSION}/relay-node-linux-${ARCH}"

--- a/docs/NODE.zh-CN.md
+++ b/docs/NODE.zh-CN.md
@@ -72,9 +72,9 @@ bash <(curl -fsSL https://raw.githubusercontent.com/MoeShinX/relay-panel/main/sc
 适用于无法跑脚本的情况（没有 systemd、自定义路径、离线服务器手动拷贝二进制）。
 
 ```bash
-# 1. 下载对应架构的二进制（把 v0.2.0 换成你要的版本）
+# 1. 下载对应架构的二进制（替换为你要的版本）
 ARCH=amd64   # 或 arm64
-VERSION=0.2.0
+VERSION=1.0.1
 curl -fL -o relay-node \
   "https://github.com/MoeShinX/relay-panel/releases/download/v${VERSION}/relay-node-linux-${ARCH}"
 
@@ -173,7 +173,7 @@ systemctl status relay-node   # 应显示 active (running)
 ```bash
 # 1. 版本号应该秒退（不会启动服务）
 timeout 3 /opt/relay-node/relay-node --version
-# 期望输出：relay-node 0.2.0
+# 期望输出：relay-node 1.0.1
 
 # 2. 服务状态
 systemctl status relay-node
@@ -183,7 +183,7 @@ journalctl -u relay-node -f
 ```
 
 日志里应该看到：
-- `RelayNode 0.2.0 starting, panel=...`
+- `RelayPanel 1.0.1 starting, panel=...`
 - `websocket connected`（如果你的反代支持 WS）
 - `TCP listening on <端口> (rule <id>)` / `UDP listening on ...` 每条规则一行
 - `report_traffic HTTP 200`（每次上报的状态码；详细的周期指标在 `debug` 级别）
@@ -250,13 +250,13 @@ rm -rf /opt/relay-node
 - 在线判定阈值：超过 30 秒（默认轮询周期的 3 倍）没收到状态上报就判离线
 
 ### `websocket error: ... sec-websocket-key ...`
-这在 v0.1.7+ 已修复。确认你在 v0.2.0 或更高版本：
+确认你在最新版本：
 `/opt/relay-node/relay-node --version`。如果还出现，可能是你的反代没透传
 WebSocket Upgrade 头 —— 但注意 WS 只是控制通道，转发和状态上报走的是纯
 HTTP，不受影响。
 
 ### WebSocket 每隔约 2 分钟断开重连
-v0.2.0 起节点每 25 秒发一次心跳 Ping，连接不会被当空闲。如果仍然周期性
+节点每 25 秒发一次心跳 Ping，连接不会被当空闲。如果仍然周期性
 断开，可能是反代 / CDN 的空闲超时短于 25 秒，或没转发 Pong 帧。偶尔重连
 无害（配置会重新同步），但如果很频繁，检查反代的 WebSocket 超时设置。
 注意：任何 WS 中断期间节点照常转发。
@@ -323,12 +323,12 @@ GitHub Releases 在国内访问可能很慢。可以：
 二进制版本由脚本自身的 `SCRIPT_VERSION` 决定。所以 `main` 上的脚本总是装
 **最新**版本。
 
-如果你需要**固定某个旧版本**（比如暂时留在 v0.1.9 测试），**不要**用 `main`
+如果你需要**固定某个旧版本**（比如暂时留在某个版本测试），**不要**用 `main`
 的脚本 —— 直接下载那个版本的二进制手动安装（见上文[手动安装](#方式-b手动安装)）：
 
 ```bash
-# 示例：固定到 v0.1.9，amd64
-VERSION=0.1.9
+# 示例：固定到某个版本，amd64
+VERSION=1.0.1
 ARCH=amd64   # 或 arm64
 curl -fL -o relay-node \
   "https://github.com/MoeShinX/relay-panel/releases/download/v${VERSION}/relay-node-linux-${ARCH}"

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -18,7 +18,7 @@ Current target: **1.0.1**
 | 4 | `crates/panel/src/config.rs` | `COMPILED_APP_VERSION` (the panel's own version, shown in the update-check UI). Overridable at runtime via the `APP_VERSION` env var. | 1.0.1 |
 | 5 | `README.md` | the `**Version:** \`x.y.z\`` badge line | 1.0.1 |
 | 6 | `README.zh-CN.md` | the `**当前版本：** \`x.y.z\`` badge line | 1.0.1 |
-| 7 | `crates/panel/Cargo.toml` | `version = "x.y.z"` (the panel crate version). **v0.3.5: now release-sync'd — `release-check.sh` FAILs if it drifts.** It was missed in v0.3.4 (stayed 0.3.3). `Cargo.lock` carries it too, so run `cargo check` after bumping. | 1.0.1 |
+| 7 | `crates/panel/Cargo.toml` | `version = "x.y.z"` (the panel crate version). `release-check.sh` FAILs if it drifts. `Cargo.lock` carries it too, so run `cargo check` after bumping. | 1.0.1 |
 
 Also bump, but not part of the "must match" set:
 - `CHANGELOG.md` — add a new `## [x.y.z] - YYYY-MM-DD` section describing the
@@ -26,7 +26,7 @@ Also bump, but not part of the "must match" set:
   The section MUST be non-empty: `release-check.sh` + the Binary Release
   workflow extract it via `scripts/extract-changelog.sh` to build the GitHub
   Release body, and both FAIL on a missing / empty section (this prevents the
-  v0.3.4 `body: null` bug where the dashboard "view changelog" was blank).
+  release body extraction bug).
 
 ---
 
@@ -45,7 +45,7 @@ appears, fix it before continuing — do not tag with a failing check.
 For a quick manual grep (e.g. hunting for a leftover old version):
 
 ```powershell
-$v = '0.2.0'  # the version you are migrating FROM
+$v = '1.0.1'  # the version you are migrating FROM
 Get-ChildItem -Recurse -File -Include *.toml,*.sh,*.yaml,*.yml,*.md,*.rs,Dockerfile |
   Where-Object { $_.FullName -notmatch '\\(target|node_modules|\.git)\\' -and $_.Name -ne 'CHANGELOG.md' -and $_.Name -ne 'Cargo.lock' -and $_.Name -ne 'VERSIONS.md' } |
   Select-String -Pattern $v -SimpleMatch
@@ -62,7 +62,7 @@ grep -A1 'name = "relay-node"' Cargo.lock   # should show the new version
 
 ## Release flow (correct order)
 
-This order matters — it avoids the v0.1.9 mistake where the tag ended up
+This order matters — it avoids a mistake where the tag ended up
 behind `main` by a commit:
 
 1. Update all 7 places above + CHANGELOG.
@@ -107,5 +107,5 @@ change, and vice versa). If they ever diverge, document which is which here.
 
 All releases so far are marked `prerelease: true` on GitHub. The update check
 (`crates/panel/src/api/system.rs`) sets `ALLOW_PRERELEASE_UPDATES = true`, so
-the dashboard will offer pre-release updates. Once a stable `1.0` ships, flip
+the dashboard will offer pre-release updates. Once you want to disable pre-release updates, flip
 that constant to `false` to only notify about stable releases.


### PR DESCRIPTION
清理所有面向用户的文档,去掉 v0.x 历史版本引用,按 v1.0.1 当前功能重写。

## 改动
- README 英文/中文:GeoIP 描述去掉版本变迁历史,直接描述当前行为;「项目状态」改为「功能亮点」,去掉"预发布"
- NODE 英文/中文:示例版本号 0.2.0 → 1.0.1,清理历史版本叙述
- DEPLOYMENT.md:去掉 v0.4.x 版本标注,GeoIP 段落简化
- VERSIONS.md:清理旧版本引用
- 代码注释里的历史说明(兼容逻辑注释)保留不动

🤖 Generated with [Claude Code](https://claude.com/claude-code)