### PR TITLE
fix: update link anchor

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -33,7 +33,7 @@ const IGNORED_KEY = 'relaypanel_ignored_version';
 // The "Update Now" button points here. README.md is the user-facing entry
 // doc with the one-line install + a dedicated upgrade section, so it's a better
 // landing page than the (more ops-focused) docs/DEPLOYMENT.md.
-const DEPLOY_DOC_URL = 'https://github.com/MoeShinX/relay-panel/blob/main/README.md#更新';
+const DEPLOY_DOC_URL = 'https://github.com/MoeShinX/relay-panel/blob/main/README.md#-更新';
 
 export default function Dashboard() {
   const { t } = useI18n();


### PR DESCRIPTION
「马上更新」按钮锚点修正：`#更新` → `#-更新`（GitHub 对 emoji heading 的锚点格式）。