### PR TITLE
fix(pg): create forward rule fails with database error under Owner scope

### DIFF
--- a/crates/panel/src/db/pg_repo/rules.rs
+++ b/crates/panel/src/db/pg_repo/rules.rs
@@ -96,7 +96,7 @@ impl RuleRepository for PgRepository {
     ) -> Result<(), DbError> {
         // Scope guard: under Owner scope, no-op unless the rule is owned by uid.
         if let Some(uid) = scope.owner_id() {
-            let owned: Option<(i64,)> =
+            let owned: Option<(i32,)> =
                 sqlx::query_as("SELECT 1 FROM forward_rules WHERE id = $1 AND uid = $2")
                     .bind(rule_id)
                     .bind(uid)


### PR DESCRIPTION
## Problem

Creating a forward rule on a **PostgreSQL** deployment fails with a generic `database error` toast. Panel log:

```
create_rule: replace_rule_targets failed: database error: error occurred while
decoding column 0: mismatched types; Rust type `i64` (as SQL type `INT8`) is not
compatible with SQL type `INT4`
```

Registration / login work fine — only rule creation is affected, and only on PostgreSQL.

## Root cause

In `replace_rule_targets`, the Owner-scope ownership guard decoded `SELECT 1` as `(i64,)`:

```rust
let owned: Option<(i64,)> =
    sqlx::query_as("SELECT 1 FROM forward_rules WHERE id = $1 AND uid = $2")
```

In PostgreSQL an integer **literal** like `1` has type `INT4`, but `i64` maps to `INT8`. sqlx's strict decoder rejects the mismatch. SQLite is dynamically typed, so the bug was invisible there — it only surfaces on PG, and only when `scope.owner_id()` is `Some` (i.e. the ownership guard runs during rule creation).

## Fix

Decode as `(i32,)` to match the `INT4` literal, consistent with the identical guards already using `(i32,)` in `pg_repo/users.rs`.

One-line change. No schema migration needed — the table columns were never the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)