### PR TITLE
feat(ui): 石墨靛蓝主题 + 思源黑体 + 改密文案 (v1.0.3 PR2)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/charts": "^2.6.7",
         "@ant-design/icons": "^6.2.5",
+        "@fontsource/noto-sans-sc": "^5.2.9",
         "antd": "^6.4.4",
         "axios": "^1.18.0",
         "flag-icons": "^7.5.0",
@@ -1618,6 +1619,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-sc": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-sc/-/noto-sans-sc-5.2.9.tgz",
+      "integrity": "sha512-bTUIWGBgJDpwi5qAr+x0/lcgv80IHTB9vl6s2f6EymZEa7qYV99yNRBZuKFT+SYDKVunZrjCEhWtpxqmbXWl5Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ant-design/charts": "^2.6.7",
     "@ant-design/icons": "^6.2.5",
+    "@fontsource/noto-sans-sc": "^5.2.9",
     "antd": "^6.4.4",
     "axios": "^1.18.0",
     "flag-icons": "^7.5.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ConfigProvider } from 'antd';
 import zhCN_antd from 'antd/locale/zh_CN';
 import enUS_antd from 'antd/locale/en_US';
 import { router } from './router';
+import { rpTheme } from './styles/antdTheme';
 import { LanguageProvider } from './i18n';
 import { useI18n } from './i18n/context';
 import { AuthProvider } from './auth/AuthContext';
@@ -10,7 +11,7 @@ import { AuthProvider } from './auth/AuthContext';
 function AppInner() {
   const { lang } = useI18n();
   return (
-    <ConfigProvider locale={lang === 'zh-CN' ? zhCN_antd : enUS_antd}>
+    <ConfigProvider theme={rpTheme} locale={lang === 'zh-CN' ? zhCN_antd : enUS_antd}>
       {/* v0.4.10: AuthProvider wraps the router so every route + the axios
           client can read auth state via useAuth / the unauthorized handler. */}
       <AuthProvider>

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -440,7 +440,7 @@ export const enUS: Dict = {
   registrationSettingsHint: 'When enabled, users can self-register and are bound to the default plan.',
   // v0.4.10 PR4: password reset + forced change
   forcePasswordChange: 'Change your password',
-  forcePasswordChangeDesc: 'An admin reset your password. Set a new one and log in again; other features are unavailable until you do.',
+  forcePasswordChangeDesc: 'An admin requires you to set a new password before continuing. Set a new one and log in again; other features are unavailable until you do.',
   resetPassword: 'Reset password',
   confirmReset: 'Confirm reset',
   resetPasswordWarning: 'Resetting immediately invalidates all of this user\'s sessions; they must log in again with the new temporary password.',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -439,7 +439,7 @@ export const zhCN = {
   registrationSettingsHint: '开启后，用户可自行注册账户并绑定默认套餐。',
   // v0.4.10 PR4: password reset + forced change
   forcePasswordChange: '请修改密码',
-  forcePasswordChangeDesc: '管理员已重置你的密码。请设置新密码后重新登录，期间无法使用其他功能。',
+  forcePasswordChangeDesc: '管理员要求你设置新密码后才能继续。请设置新密码并重新登录，期间无法使用其他功能。',
   resetPassword: '重置密码',
   confirmReset: '确认重置',
   resetPasswordWarning: '重置后该用户的所有登录会话立即失效，需使用新的临时密码重新登录。',

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,13 @@ import { createRoot } from 'react-dom/client'
 // flag-icons MUST load before our own styles so theme.css can override the
 // .fi sizing for the pill wrapper.
 import 'flag-icons/css/flag-icons.min.css';
+// Self-hosted Noto Sans SC (思源黑体, OFL). Sharded woff2 + unicode-range:
+// the browser only fetches the glyph blocks each page uses. 400 = body text,
+// 500 = headings/menu. font-display: swap, so text shows in the system font
+// first, then swaps in without blocking. Clean, well-hinted, reads crisp at
+// small sizes — unlike MiSans which rendered heavy/blurry on Windows.
+import '@fontsource/noto-sans-sc/400.css';
+import '@fontsource/noto-sans-sc/500.css';
 import './index.css'
 import App from './App.tsx'
 

--- a/frontend/src/styles/antdTheme.ts
+++ b/frontend/src/styles/antdTheme.ts
@@ -1,0 +1,54 @@
+import type { ThemeConfig } from 'antd';
+
+// RelayPanel — "石墨靛蓝 / Graphite + Indigo" theme.
+// Token-driven: every antd component (buttons, tables, tags, inputs, menu…)
+// picks this up via ConfigProvider, so we don't touch individual components.
+// Layout chrome (sidebar bg, radii, custom tags) lives in styles/theme.css.
+export const rpTheme: ThemeConfig = {
+  token: {
+    colorPrimary: '#6366f1',
+    colorInfo: '#6366f1',
+    colorSuccess: '#059669',
+    colorWarning: '#d97706',
+    colorError: '#ef4444',
+    colorLink: '#6366f1',
+    borderRadius: 8,
+    colorBgLayout: '#fafafa',
+    colorBorderSecondary: '#ececef',
+    fontWeightStrong: 500,
+    fontFamily:
+      '"Noto Sans SC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", ' +
+      '"PingFang SC", "Microsoft YaHei", "Helvetica Neue", Arial, sans-serif',
+  },
+  components: {
+    // Dark graphite sidebar: transparent items so the Sider's #18181b shows
+    // through, indigo-tinted selection instead of antd's solid blue bar.
+    Menu: {
+      darkItemBg: 'transparent',
+      darkSubMenuItemBg: 'transparent',
+      darkItemColor: '#a1a1aa',
+      darkItemHoverColor: '#fafafa',
+      darkItemHoverBg: 'rgba(255,255,255,0.05)',
+      darkItemSelectedBg: 'rgba(99,102,241,0.18)',
+      darkItemSelectedColor: '#c7d2fe',
+    },
+    // Flat buttons — drop antd's default control shadow for a cleaner look.
+    Button: {
+      primaryShadow: 'none',
+      defaultShadow: 'none',
+      dangerShadow: 'none',
+    },
+    Card: {
+      borderRadiusLG: 12,
+    },
+    Table: {
+      headerBg: '#fafafa',
+      rowHoverBg: '#f5f5ff',
+      borderColor: '#ececef',
+    },
+    Layout: {
+      bodyBg: '#fafafa',
+      headerBg: '#ffffff',
+    },
+  },
+};

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,48 +1,50 @@
-/* RelayPanel global theme — clean, professional admin panel.
-   Inspired by NyanPass: white/light-gray bg, ample whitespace,
-   comfortable table rows, muted accents. No marketing glitz. */
+/* RelayPanel global theme — "石墨靛蓝 / Graphite + Indigo".
+   Near-black graphite sidebar, indigo accent, larger radii, hairline
+   borders. Premium admin look (Linear / Vercel direction), no template feel.
+   Component colors are driven by styles/antdTheme.ts; this file owns the
+   layout chrome + custom (non-antd) elements. */
 
 :root {
   /* Layout */
-  --rp-sidebar-bg: #001529;
+  --rp-sidebar-bg: #18181b;
   --rp-sidebar-width: 220px;
   --rp-header-height: 56px;
   --rp-content-padding: 24px;
 
   /* Colors — muted, not garish */
-  --rp-bg: #f5f6f8;
+  --rp-bg: #fafafa;
   --rp-card-bg: #ffffff;
-  --rp-border: #e8eaed;
-  --rp-text: #1f2329;
+  --rp-border: #ececef;
+  --rp-text: #18181b;
   --rp-text-secondary: #646a73;
   --rp-text-tertiary: #8f959e;
 
-  /* Accents */
-  --rp-primary: #1677ff;
-  --rp-primary-bg: #e8f3ff;
-  --rp-success: #00a878;
-  --rp-warning: #ed7b2f;
-  --rp-danger: #f54a45;
+  /* Accents — indigo */
+  --rp-primary: #6366f1;
+  --rp-primary-bg: #eef2ff;
+  --rp-success: #059669;
+  --rp-warning: #d97706;
+  --rp-danger: #ef4444;
 
   /* Tags — desaturated for admin comfort */
-  --rp-tag-tcp: #1677ff;
-  --rp-tag-udp: #722ed1;
-  --rp-tag-in: #389e0d;
-  --rp-tag-out: #08979c;
-  --rp-tag-admin: #d48806;
+  --rp-tag-tcp: #6366f1;
+  --rp-tag-udp: #7c3aed;
+  --rp-tag-in: #059669;
+  --rp-tag-out: #0d9488;
+  --rp-tag-admin: #d97706;
 
   /* Radii & shadows — subtle */
-  --rp-radius: 6px;
-  --rp-radius-sm: 4px;
+  --rp-radius: 10px;
+  --rp-radius-sm: 8px;
   --rp-shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
   --rp-shadow: 0 2px 8px rgba(0,0,0,0.06);
 
   /* Table */
-  --rp-table-header-bg: #fafbfc;
-  --rp-table-row-hover: #f0f7ff;
+  --rp-table-header-bg: #fafafa;
+  --rp-table-row-hover: #f5f5ff;
 
   /* Font */
-  --rp-font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+  --rp-font: "Noto Sans SC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     "PingFang SC", "Microsoft YaHei", "Helvetica Neue", Arial, sans-serif;
   --rp-font-mono: "SF Mono", "Cascadia Code", "JetBrains Mono", Consolas,
     "Courier New", monospace;
@@ -69,7 +71,7 @@ html, body, #root {
 }
 .ant-table-thead > tr > th {
   background: var(--rp-table-header-bg) !important;
-  font-weight: 600;
+  font-weight: 500;
   color: var(--rp-text-secondary);
   border-bottom: 1px solid var(--rp-border) !important;
 }
@@ -126,7 +128,7 @@ html, body, #root {
 /* ---- Layout helpers ---- */
 .rp-page-title {
   font-size: 18px;
-  font-weight: 600;
+  font-weight: 500;
   color: var(--rp-text);
   margin: 0 0 16px 0;
   display: flex;
@@ -152,7 +154,7 @@ html, body, #root {
 }
 .rp-stat-card .ant-statistic-content {
   font-size: 28px;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 /* Mono fields in tables */


### PR DESCRIPTION
前端美化三件套,本地 `npm run dev` 实测通过。

## 1. 石墨靛蓝主题 (Graphite + Indigo)

之前 `ConfigProvider` 只设了 locale,没接 antd theme token,所以全是出厂默认「深蓝侧栏 + 蓝」,有廉价模板感。

- 新增 `frontend/src/styles/antdTheme.ts`:注入 antd v6 token —— 靛蓝主色 `#6366f1`、暗色菜单选中改靛蓝半透明高亮、扁平按钮、卡片 12px 圆角、`fontWeightStrong: 500`
- `theme.css`:侧栏 `#001529` → 石墨 `#18181b`、圆角 6→10px、边框更细、标签去饱和
- `App.tsx`:`ConfigProvider` 注入 `theme={rpTheme}`

业务组件零改动,纯 token 换肤。

## 2. 思源黑体 (Noto Sans SC)

自托管 `@fontsource/noto-sans-sc`(OFL),替换系统默认字体。分片 woff2 + unicode-range,`font-display: swap`,只加载页面用到的字形块。小字号清晰。

> 先试了 MiSans,但在 Windows 下渲染偏重/发糊(「用力过猛」),换思源后清秀清晰。

## 3. 强制改密文案

`forcePasswordChangeDesc`(中英)改为更通用的措辞,兼顾「管理员重置密码」和「建号要求首次改密」两种场景,不再只说「管理员已重置」。

## 验证

- `npm run build` 通过
- 本地 dev 实测:登录页、仪表盘、侧栏、表格、强制改密页配色与字体均符合预期

🤖 Generated with [Claude Code](https://claude.com/claude-code)