### PR TITLE
fix(ui): 规则导出按钮补上"导出/Export"文字 (v1.0.3 PR3)

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -484,7 +484,7 @@ export default function Rules() {
           </Button>
           <Button size="small" type="text" icon={<EditOutlined />} onClick={() => handleEdit(r)}>{t('edit')}</Button>
           <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => handleCopy(r)}>{t('copy')}</Button>
-          <Button size="small" type="text" icon={<DownloadOutlined />} onClick={() => handleExportOne(r)} />
+          <Button size="small" type="text" icon={<DownloadOutlined />} onClick={() => handleExportOne(r)}>{t('export')}</Button>
           {/* v0.4.9: diagnosis is TCP-only — disable for pure-UDP rules. */}
           <Button size="small" type="text" icon={<MedicineBoxOutlined />} disabled={r.protocol === 'udp'} onClick={() => handleDiagnose(r)} title={r.protocol === 'udp' ? t('diagnoseUdpUnsupported') : t('diagnose')}>{t('diagnose')}</Button>
           <Popconfirm title={t('deleteRuleConfirm')} onConfirm={() => handleDelete(r.id)}>


### PR DESCRIPTION
v1.0.3 PR3.

规则列表「操作」列里的单条导出按钮原来只有图标(下载图标),旁边的暂停/编辑/复制/诊断都是图标+文字,用户看不出它是干嘛的。补上 `{t('export')}` 文字(i18n key 已存在:导出 / Export)。

一行改动,`npm run build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)