### PR TITLE
v1.0.5: IPv6 dual-stack listen + outbound source binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1412,7 +1412,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -1449,7 +1449,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1598,6 +1598,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "sysinfo",
  "tokio",
  "tokio-rustls",
@@ -1992,6 +1993,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -2371,7 +2382,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,11 @@ CMD ["./relay-panel"]
 
 # ---- Node runtime ----
 FROM debian:bookworm-slim AS node
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+# v1.0.5: iproute2 provides the `ip` command used to resolve an interface's
+# IPv4 address when OUTBOUND_INTERFACE is set. Without it, multi-NIC egress
+# selection by interface name would fail. ca-certificates is for HTTPS to the
+# panel.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates iproute2 && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=rust-build /app/target/release/relay-node /app/relay-node

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -30,6 +30,8 @@ futures-util = "0.3"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 rustls-pemfile = "2"
+# v1.0.5: low-level socket options for IPv6-only dual-stack binding.
+socket2 = "0.5"
 
 [dev-dependencies]
 # v0.4.16: test-only cert generator for the real WSS (wss://) regression test.

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -1,11 +1,5 @@
 use serde::Deserialize;
 
-/// Sentinel value: if NODE_TOKEN is unset (or still the built-in default), the
-/// node must refuse to start. A node with the default token either can't
-/// authenticate to the panel at all, or worse, binds to a group someone
-/// happened to create with token "default-token" — a silent misconfiguration
-/// that's much worse than a loud startup failure. Mirrors the panel's
-/// JWT_SECRET guard.
 const INSECURE_NODE_TOKEN: &str = "default-token";
 
 #[derive(Debug, Deserialize, Clone)]
@@ -13,24 +7,24 @@ pub struct NodeConfig {
     pub panel_url: String,
     pub token: String,
     pub poll_interval: u64,
-    /// v0.4.1: TLS Simple certificate path. Optional — if unset, tls_simple
-    /// rules are skipped (the node can't serve TLS without a cert). Set via
-    /// the TLS_CERT_PATH environment variable.
     pub tls_cert_path: Option<String>,
-    /// v0.4.1: TLS Simple private key path. Paired with tls_cert_path.
     pub tls_key_path: Option<String>,
-    /// v0.4.6: which NIC to count for machine-wide traffic stats.
-    /// "auto" (default) = auto-detect the default-route interface;
-    /// any other value = that exact interface name (e.g. "eth0").
+    /// v0.4.6: NIC for traffic stats. "auto" = auto-detect default route.
     pub network_interface: String,
+    /// v1.0.5: IPv4 listen address. Empty = disabled. Default "0.0.0.0".
+    pub listen_ipv4: String,
+    /// v1.0.5: IPv6 listen address. Empty = disabled. Default "::".
+    pub listen_ipv6: String,
+    /// v1.0.5: NIC for outbound IPv4 egress. "auto" = system routing.
+    pub outbound_interface: String,
+    /// v1.0.5: Exact IPv4 source for outbound connections.
+    pub outbound_bind_ipv4: Option<String>,
 }
 
 impl NodeConfig {
     pub fn load() -> Self {
         let panel_url =
             std::env::var("PANEL_URL").unwrap_or_else(|_| "http://127.0.0.1:18888".into());
-        // No fallback default for the token: an unset NODE_TOKEN is a
-        // misconfiguration, not "use a known value". Refuse to boot.
         let token = std::env::var("NODE_TOKEN").unwrap_or_else(|_| String::new());
         let poll_interval = std::env::var("POLL_INTERVAL")
             .ok()
@@ -45,20 +39,30 @@ impl NodeConfig {
                 .ok()
                 .filter(|s| !s.is_empty()),
             tls_key_path: std::env::var("TLS_KEY_PATH").ok().filter(|s| !s.is_empty()),
-            // v0.4.6: default "auto" picks the default-route NIC; empty also
-            // means auto so an unset/blank value behaves safely.
             network_interface: std::env::var("NETWORK_INTERFACE")
                 .ok()
                 .filter(|s| !s.trim().is_empty())
                 .unwrap_or_else(|| "auto".to_string()),
+            listen_ipv4: std::env::var("LISTEN_IPV4")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "0.0.0.0".to_string()),
+            listen_ipv6: std::env::var("LISTEN_IPV6")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "::".to_string()),
+            outbound_interface: std::env::var("OUTBOUND_INTERFACE")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "auto".to_string()),
+            outbound_bind_ipv4: std::env::var("OUTBOUND_BIND_IPV4")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
         };
         cfg.validate();
         cfg
     }
 
-    /// Refuse to start with an unset or default token. The operator MUST set
-    /// NODE_TOKEN to a real group token from the panel UI. An empty value
-    /// (env unset) or the sentinel "default-token" is treated as insecure.
     fn validate(&self) {
         if self.token.trim().is_empty() {
             eprintln!(

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -43,14 +43,17 @@ impl NodeConfig {
                 .ok()
                 .filter(|s| !s.trim().is_empty())
                 .unwrap_or_else(|| "auto".to_string()),
-            listen_ipv4: std::env::var("LISTEN_IPV4")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or_else(|| "0.0.0.0".to_string()),
-            listen_ipv6: std::env::var("LISTEN_IPV6")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or_else(|| "::".to_string()),
+            // v1.0.5: distinguish UNSET (use default, backward compatible) from
+            // EXPLICITLY EMPTY (LISTEN_IPV6= → disable that family). std::env::var
+            // returns Err only when unset; Ok("") when set to empty.
+            listen_ipv4: match std::env::var("LISTEN_IPV4") {
+                Ok(v) => v.trim().to_string(),
+                Err(_) => "0.0.0.0".to_string(),
+            },
+            listen_ipv6: match std::env::var("LISTEN_IPV6") {
+                Ok(v) => v.trim().to_string(),
+                Err(_) => "::".to_string(),
+            },
             outbound_interface: std::env::var("OUTBOUND_INTERFACE")
                 .ok()
                 .filter(|s| !s.trim().is_empty())

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -394,6 +394,7 @@ impl ForwarderManager {
                     let ipv4_src = src_ipv4;
                     let errs = errors.clone();
                     let pstr = proto_str.clone();
+                    #[allow(clippy::single_match, unused_assignments, unused_variables)]
                     tokio::spawn(async move {
                         let v4 = tokio::spawn(tcp::start_tcp_listener(
                             a4,
@@ -453,6 +454,7 @@ impl ForwarderManager {
                     let ipv4_src = src_ipv4;
                     let errs = errors.clone();
                     let pstr = proto_str.clone();
+                    #[allow(clippy::single_match, unused_assignments, unused_variables)]
                     tokio::spawn(async move {
                         let v4 = tokio::spawn(udp::start_udp_listener(
                             a4,

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -95,6 +95,11 @@ pub struct ForwarderManager {
     /// v0.4.1: shared TLS acceptor for tls_simple listeners (supports hot-reload
     /// via cert_reloader). None = no cert configured (tls_simple rules skipped).
     tls_acceptor: Option<super::cert_reloader::SharedTlsAcceptor>,
+    /// v1.0.5: dual-stack listen addresses from env.
+    listen_ipv4: String,
+    listen_ipv6: String,
+    /// v1.0.5: resolved outbound source IPv4 (None = auto-route).
+    source_ipv4: Option<std::net::Ipv4Addr>,
 }
 
 impl ForwarderManager {
@@ -105,7 +110,22 @@ impl ForwarderManager {
             connections,
             listener_errors: Arc::new(Mutex::new(Vec::new())),
             tls_acceptor: None,
+            listen_ipv4: "0.0.0.0".into(),
+            listen_ipv6: "::".into(),
+            source_ipv4: None,
         }
+    }
+
+    /// v1.0.5: configure dual-stack listen and outbound source.
+    pub fn set_network_config(&mut self, cfg: &crate::config::NodeConfig) {
+        self.listen_ipv4 = cfg.listen_ipv4.clone();
+        self.listen_ipv6 = cfg.listen_ipv6.clone();
+        self.source_ipv4 = crate::forwarder::outbound::init_outbound(
+            &crate::forwarder::outbound::OutboundConfig {
+                bind_ipv4: cfg.outbound_bind_ipv4.clone(),
+                interface: cfg.outbound_interface.clone(),
+            },
+        );
     }
 
     /// Drain the accumulated listener errors (called by the status reporter so
@@ -287,9 +307,17 @@ impl ForwarderManager {
                 }
             }
 
-            let addr: SocketAddr = format!("0.0.0.0:{}", listener.port)
+            // v1.0.5: dual-stack listen — bind both IPv4 and IPv6.
+            let addr_v4: SocketAddr = format!("{}:{}", self.listen_ipv4, listener.port)
                 .parse()
-                .expect("Invalid listen address");
+                .unwrap_or_else(|_| format!("0.0.0.0:{}", listener.port).parse().unwrap());
+            let addr_v6: Option<SocketAddr> = if self.listen_ipv6.is_empty() {
+                None
+            } else {
+                format!("{}:{}", self.listen_ipv6, listener.port)
+                    .parse()
+                    .ok()
+            };
             let targets = listener.targets.clone();
             // v0.4.6: one selector per listener, shared across all of its
             // connections/sessions so a round-robin cursor advances globally.
@@ -311,6 +339,7 @@ impl ForwarderManager {
             let rule_id = listener.rule_id;
             let ws_path = listener.ws_path.clone();
             let errors = self.listener_errors.clone();
+            let src_ipv4 = self.source_ipv4;
             let proto_str = match listener.protocol {
                 Protocol::Tcp => "tcp",
                 Protocol::Udp => "udp",
@@ -348,50 +377,131 @@ impl ForwarderManager {
                 continue;
             }
 
-            let handle = match (listener.protocol, listener.node_transport) {
-                (Protocol::Tcp, NodeTransport::Raw) => tokio::spawn(async move {
-                    if let Err(e) = tcp::start_tcp_listener(
-                        addr,
-                        targets,
-                        selector,
-                        rate_limit,
-                        counter,
-                        connections,
-                        rule_id,
-                    )
-                    .await
-                    {
-                        tracing::error!("TCP listener on {} failed: {}", port, e);
-                        errors.lock().await.push(ListenerError {
-                            port,
-                            protocol: proto_str.clone(),
-                            error: e.to_string(),
-                        });
-                    }
-                }),
-                (Protocol::Udp, NodeTransport::Raw) => tokio::spawn(async move {
-                    if let Err(e) = udp::start_udp_listener(
-                        addr,
-                        targets,
-                        selector,
-                        rate_limit,
-                        counter,
-                        connections,
-                        rule_id,
-                    )
-                    .await
-                    {
-                        tracing::error!("UDP listener on {} failed: {}", port, e);
-                        errors.lock().await.push(ListenerError {
-                            port,
-                            protocol: proto_str.clone(),
-                            error: e.to_string(),
-                        });
-                    }
-                }),
+            let handle: tokio::task::JoinHandle<()> = match (
+                listener.protocol,
+                listener.node_transport,
+            ) {
+                // v1.0.5: TCP — spawn both IPv4 and IPv6 listeners independently.
+                (Protocol::Tcp, NodeTransport::Raw) => {
+                    let a4 = addr_v4;
+                    let a6 = addr_v6;
+                    let tgt = targets.clone();
+                    let sel = selector.clone();
+                    let rl = rate_limit.clone();
+                    let ctr = counter.clone();
+                    let cn = connections.clone();
+                    let rid = rule_id;
+                    let ipv4_src = src_ipv4;
+                    let errs = errors.clone();
+                    let pstr = proto_str.clone();
+                    tokio::spawn(async move {
+                        let v4 = tokio::spawn(tcp::start_tcp_listener(
+                            a4,
+                            tgt.clone(),
+                            sel.clone(),
+                            rl.clone(),
+                            ctr.clone(),
+                            cn.clone(),
+                            rid,
+                            ipv4_src,
+                        ));
+                        let v6 = if let Some(addr6) = a6 {
+                            Some(tokio::spawn(tcp::start_tcp_listener(
+                                addr6, tgt, sel, rl, ctr, cn, rid, ipv4_src,
+                            )))
+                        } else {
+                            tracing::info!("TCP {}: IPv6 disabled (LISTEN_IPV6 empty)", port);
+                            None
+                        };
+                        // Report errors from either listener.
+                        let mut failed = 0u8;
+                        match v4.await {
+                            Ok(Err(e)) => {
+                                errs.lock().await.push(ListenerError {
+                                    port,
+                                    protocol: pstr.clone(),
+                                    error: e.to_string(),
+                                });
+                                failed += 1;
+                            }
+                            _ => {}
+                        }
+                        if let Some(v6h) = v6 {
+                            match v6h.await {
+                                Ok(Err(e)) => {
+                                    errs.lock().await.push(ListenerError {
+                                        port,
+                                        protocol: pstr.clone(),
+                                        error: format!("IPv6: {}", e),
+                                    });
+                                }
+                                _ => {}
+                            }
+                        }
+                    })
+                }
+                // v1.0.5: UDP — spawn both IPv4 and IPv6 independently.
+                (Protocol::Udp, NodeTransport::Raw) => {
+                    let a4 = addr_v4;
+                    let a6 = addr_v6;
+                    let tgt = targets.clone();
+                    let sel = selector.clone();
+                    let rl = rate_limit.clone();
+                    let ctr = counter.clone();
+                    let cn = connections.clone();
+                    let rid = rule_id;
+                    let ipv4_src = src_ipv4;
+                    let errs = errors.clone();
+                    let pstr = proto_str.clone();
+                    tokio::spawn(async move {
+                        let v4 = tokio::spawn(udp::start_udp_listener(
+                            a4,
+                            tgt.clone(),
+                            sel.clone(),
+                            rl.clone(),
+                            ctr.clone(),
+                            cn.clone(),
+                            rid,
+                            ipv4_src,
+                        ));
+                        let v6 = if let Some(addr6) = a6 {
+                            Some(tokio::spawn(udp::start_udp_listener(
+                                addr6, tgt, sel, rl, ctr, cn, rid, ipv4_src,
+                            )))
+                        } else {
+                            tracing::info!("UDP {}: IPv6 disabled (LISTEN_IPV6 empty)", port);
+                            None
+                        };
+                        let mut failed = 0u8;
+                        match v4.await {
+                            Ok(Err(e)) => {
+                                errs.lock().await.push(ListenerError {
+                                    port,
+                                    protocol: pstr.clone(),
+                                    error: e.to_string(),
+                                });
+                                failed += 1;
+                            }
+                            _ => {}
+                        }
+                        if let Some(v6h) = v6 {
+                            match v6h.await {
+                                Ok(Err(e)) => {
+                                    errs.lock().await.push(ListenerError {
+                                        port,
+                                        protocol: pstr.clone(),
+                                        error: format!("IPv6: {}", e),
+                                    });
+                                }
+                                _ => {}
+                            }
+                        }
+                    })
+                }
+                // WS and TLS use IPv4 only (unchanged).
                 (Protocol::Tcp, NodeTransport::Ws) => tokio::spawn(async move {
                     if let Err(e) = ws::start_ws_listener(
-                        addr,
+                        addr_v4,
                         targets,
                         selector,
                         rate_limit,
@@ -420,7 +530,7 @@ impl ForwarderManager {
                     };
                     tokio::spawn(async move {
                         if let Err(e) = tls::start_tls_listener(
-                            addr,
+                            addr_v4,
                             targets,
                             selector,
                             rate_limit,

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -117,7 +117,13 @@ impl ForwarderManager {
     }
 
     /// v1.0.5: configure dual-stack listen and outbound source.
-    pub fn set_network_config(&mut self, cfg: &crate::config::NodeConfig) {
+    /// Returns Err on misconfigured outbound (invalid IP, missing interface,
+    /// non-local IP) so the caller can abort instead of silently auto-routing
+    /// out the wrong NIC.
+    pub fn set_network_config(
+        &mut self,
+        cfg: &crate::config::NodeConfig,
+    ) -> Result<(), crate::forwarder::outbound::OutboundError> {
         self.listen_ipv4 = cfg.listen_ipv4.clone();
         self.listen_ipv6 = cfg.listen_ipv6.clone();
         self.source_ipv4 = crate::forwarder::outbound::init_outbound(
@@ -125,7 +131,8 @@ impl ForwarderManager {
                 bind_ipv4: cfg.outbound_bind_ipv4.clone(),
                 interface: cfg.outbound_interface.clone(),
             },
-        );
+        )?;
+        Ok(())
     }
 
     /// Drain the accumulated listener errors (called by the status reporter so
@@ -307,17 +314,11 @@ impl ForwarderManager {
                 }
             }
 
-            // v1.0.5: dual-stack listen — bind both IPv4 and IPv6.
-            let addr_v4: SocketAddr = format!("{}:{}", self.listen_ipv4, listener.port)
-                .parse()
-                .unwrap_or_else(|_| format!("0.0.0.0:{}", listener.port).parse().unwrap());
-            let addr_v6: Option<SocketAddr> = if self.listen_ipv6.is_empty() {
-                None
-            } else {
-                format!("{}:{}", self.listen_ipv6, listener.port)
-                    .parse()
-                    .ok()
-            };
+            // v1.0.5: dual-stack listen — parse IPs via IpAddr (NEVER string
+            // concatenation, which produced ":::port" for IPv6). Empty string
+            // = that family disabled.
+            let ip_v4 = crate::forwarder::outbound::parse_listen_ip(&self.listen_ipv4);
+            let ip_v6 = crate::forwarder::outbound::parse_listen_ip(&self.listen_ipv6);
             let targets = listener.targets.clone();
             // v0.4.6: one selector per listener, shared across all of its
             // connections/sessions so a round-robin cursor advances globally.
@@ -381,147 +382,236 @@ impl ForwarderManager {
                 listener.protocol,
                 listener.node_transport,
             ) {
-                // v1.0.5: TCP — spawn both IPv4 and IPv6 listeners independently.
+                // v1.0.5: TCP — bind BOTH families synchronously (errors surface
+                // now, per-family success known), then supervise both serve loops
+                // with select! so if either dies the task ends and the manager's
+                // dead-listener detection restarts it.
                 (Protocol::Tcp, NodeTransport::Raw) => {
-                    let a4 = addr_v4;
-                    let a6 = addr_v6;
-                    let tgt = targets.clone();
-                    let sel = selector.clone();
-                    let rl = rate_limit.clone();
-                    let ctr = counter.clone();
-                    let cn = connections.clone();
-                    let rid = rule_id;
-                    let ipv4_src = src_ipv4;
-                    let errs = errors.clone();
-                    let pstr = proto_str.clone();
-                    #[allow(clippy::single_match, unused_assignments, unused_variables)]
-                    tokio::spawn(async move {
-                        let v4 = tokio::spawn(tcp::start_tcp_listener(
-                            a4,
-                            tgt.clone(),
-                            sel.clone(),
-                            rl.clone(),
-                            ctr.clone(),
-                            cn.clone(),
-                            rid,
-                            ipv4_src,
-                        ));
-                        let v6 = if let Some(addr6) = a6 {
-                            Some(tokio::spawn(tcp::start_tcp_listener(
-                                addr6, tgt, sel, rl, ctr, cn, rid, ipv4_src,
-                            )))
-                        } else {
-                            tracing::info!("TCP {}: IPv6 disabled (LISTEN_IPV6 empty)", port);
-                            None
-                        };
-                        // Report errors from either listener.
-                        let mut failed = 0u8;
-                        match v4.await {
-                            Ok(Err(e)) => {
-                                errs.lock().await.push(ListenerError {
+                    use crate::forwarder::outbound::bind_tcp_listener;
+                    let mut v4_listener = None;
+                    let mut v6_listener = None;
+                    if let Some(ip4) = ip_v4 {
+                        match bind_tcp_listener(ip4, port) {
+                            Ok(l) => {
+                                tracing::info!(
+                                    "TCP bound {} (rule {})",
+                                    SocketAddr::new(ip4, port),
+                                    rule_id
+                                );
+                                v4_listener = Some(l);
+                            }
+                            Err(e) => {
+                                tracing::error!("TCP IPv4 bind {}:{} failed: {}", ip4, port, e);
+                                errors.lock().await.push(ListenerError {
                                     port,
-                                    protocol: pstr.clone(),
-                                    error: e.to_string(),
+                                    protocol: proto_str.clone(),
+                                    error: format!("IPv4: {}", e),
                                 });
-                                failed += 1;
-                            }
-                            _ => {}
-                        }
-                        if let Some(v6h) = v6 {
-                            match v6h.await {
-                                Ok(Err(e)) => {
-                                    errs.lock().await.push(ListenerError {
-                                        port,
-                                        protocol: pstr.clone(),
-                                        error: format!("IPv6: {}", e),
-                                    });
-                                }
-                                _ => {}
                             }
                         }
-                    })
-                }
-                // v1.0.5: UDP — spawn both IPv4 and IPv6 independently.
-                (Protocol::Udp, NodeTransport::Raw) => {
-                    let a4 = addr_v4;
-                    let a6 = addr_v6;
-                    let tgt = targets.clone();
-                    let sel = selector.clone();
-                    let rl = rate_limit.clone();
-                    let ctr = counter.clone();
-                    let cn = connections.clone();
-                    let rid = rule_id;
-                    let ipv4_src = src_ipv4;
-                    let errs = errors.clone();
-                    let pstr = proto_str.clone();
-                    #[allow(clippy::single_match, unused_assignments, unused_variables)]
-                    tokio::spawn(async move {
-                        let v4 = tokio::spawn(udp::start_udp_listener(
-                            a4,
-                            tgt.clone(),
-                            sel.clone(),
-                            rl.clone(),
-                            ctr.clone(),
-                            cn.clone(),
-                            rid,
-                            ipv4_src,
-                        ));
-                        let v6 = if let Some(addr6) = a6 {
-                            Some(tokio::spawn(udp::start_udp_listener(
-                                addr6, tgt, sel, rl, ctr, cn, rid, ipv4_src,
-                            )))
-                        } else {
-                            tracing::info!("UDP {}: IPv6 disabled (LISTEN_IPV6 empty)", port);
-                            None
-                        };
-                        let mut failed = 0u8;
-                        match v4.await {
-                            Ok(Err(e)) => {
-                                errs.lock().await.push(ListenerError {
-                                    port,
-                                    protocol: pstr.clone(),
-                                    error: e.to_string(),
-                                });
-                                failed += 1;
-                            }
-                            _ => {}
-                        }
-                        if let Some(v6h) = v6 {
-                            match v6h.await {
-                                Ok(Err(e)) => {
-                                    errs.lock().await.push(ListenerError {
-                                        port,
-                                        protocol: pstr.clone(),
-                                        error: format!("IPv6: {}", e),
-                                    });
-                                }
-                                _ => {}
-                            }
-                        }
-                    })
-                }
-                // WS and TLS use IPv4 only (unchanged).
-                (Protocol::Tcp, NodeTransport::Ws) => tokio::spawn(async move {
-                    if let Err(e) = ws::start_ws_listener(
-                        addr_v4,
-                        targets,
-                        selector,
-                        rate_limit,
-                        counter,
-                        connections,
-                        rule_id,
-                        ws_path,
-                    )
-                    .await
-                    {
-                        tracing::error!("WS listener on {} failed: {}", port, e);
-                        errors.lock().await.push(ListenerError {
-                            port,
-                            protocol: proto_str.clone(),
-                            error: e.to_string(),
-                        });
                     }
-                }),
+                    if let Some(ip6) = ip_v6 {
+                        match bind_tcp_listener(ip6, port) {
+                            Ok(l) => {
+                                tracing::info!(
+                                    "TCP bound {} (rule {})",
+                                    SocketAddr::new(ip6, port),
+                                    rule_id
+                                );
+                                v6_listener = Some(l);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "TCP IPv6 bind [{}]:{} failed: {} — IPv4 continues",
+                                    ip6,
+                                    port,
+                                    e
+                                );
+                                errors.lock().await.push(ListenerError {
+                                    port,
+                                    protocol: proto_str.clone(),
+                                    error: format!("IPv6: {}", e),
+                                });
+                            }
+                        }
+                    }
+                    // Only fail the rule when NEITHER family bound.
+                    if v4_listener.is_none() && v6_listener.is_none() {
+                        tracing::error!(
+                            "TCP rule {}: no listener bound on port {} (all families failed)",
+                            rule_id,
+                            port
+                        );
+                        continue;
+                    }
+                    let tgt = targets.clone();
+                    let sel = selector.clone();
+                    let rl = rate_limit.clone();
+                    let ctr = counter.clone();
+                    let cn = connections.clone();
+                    let rid = rule_id;
+                    let ipv4_src = src_ipv4;
+                    tokio::spawn(async move {
+                        type SrvResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+                        let (tgt4, sel4, rl4, ctr4, cn4) = (
+                            tgt.clone(),
+                            sel.clone(),
+                            rl.clone(),
+                            ctr.clone(),
+                            cn.clone(),
+                        );
+                        let v4_fut = async move {
+                            if let Some(l) = v4_listener {
+                                tcp::serve_tcp_listener(
+                                    l, tgt4, sel4, rl4, ctr4, cn4, rid, ipv4_src,
+                                )
+                                .await
+                            } else {
+                                std::future::pending::<SrvResult>().await
+                            }
+                        };
+                        let v6_fut = async move {
+                            if let Some(l) = v6_listener {
+                                tcp::serve_tcp_listener(l, tgt, sel, rl, ctr, cn, rid, ipv4_src)
+                                    .await
+                            } else {
+                                std::future::pending::<SrvResult>().await
+                            }
+                        };
+                        tokio::select! {
+                            r = v4_fut => { if let Err(e) = r { tracing::error!("TCP v4 serve ended (rule {}): {}", rid, e); } }
+                            r = v6_fut => { if let Err(e) = r { tracing::error!("TCP v6 serve ended (rule {}): {}", rid, e); } }
+                        }
+                    })
+                }
+                // v1.0.5: UDP — bind BOTH families synchronously, supervise both
+                // receive loops with select! (mirrors the TCP arm above).
+                (Protocol::Udp, NodeTransport::Raw) => {
+                    use crate::forwarder::outbound::bind_udp_socket;
+                    let mut v4_sock = None;
+                    let mut v6_sock = None;
+                    if let Some(ip4) = ip_v4 {
+                        match bind_udp_socket(ip4, port) {
+                            Ok(s) => {
+                                tracing::info!(
+                                    "UDP bound {} (rule {})",
+                                    SocketAddr::new(ip4, port),
+                                    rule_id
+                                );
+                                v4_sock = Some(Arc::new(s));
+                            }
+                            Err(e) => {
+                                tracing::error!("UDP IPv4 bind {}:{} failed: {}", ip4, port, e);
+                                errors.lock().await.push(ListenerError {
+                                    port,
+                                    protocol: proto_str.clone(),
+                                    error: format!("IPv4: {}", e),
+                                });
+                            }
+                        }
+                    }
+                    if let Some(ip6) = ip_v6 {
+                        match bind_udp_socket(ip6, port) {
+                            Ok(s) => {
+                                tracing::info!(
+                                    "UDP bound {} (rule {})",
+                                    SocketAddr::new(ip6, port),
+                                    rule_id
+                                );
+                                v6_sock = Some(Arc::new(s));
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "UDP IPv6 bind [{}]:{} failed: {} — IPv4 continues",
+                                    ip6,
+                                    port,
+                                    e
+                                );
+                                errors.lock().await.push(ListenerError {
+                                    port,
+                                    protocol: proto_str.clone(),
+                                    error: format!("IPv6: {}", e),
+                                });
+                            }
+                        }
+                    }
+                    if v4_sock.is_none() && v6_sock.is_none() {
+                        tracing::error!(
+                            "UDP rule {}: no listener bound on port {} (all families failed)",
+                            rule_id,
+                            port
+                        );
+                        continue;
+                    }
+                    let tgt = targets.clone();
+                    let sel = selector.clone();
+                    let rl = rate_limit.clone();
+                    let ctr = counter.clone();
+                    let cn = connections.clone();
+                    let rid = rule_id;
+                    let ipv4_src = src_ipv4;
+                    tokio::spawn(async move {
+                        type SrvResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+                        let (tgt4, sel4, rl4, ctr4, cn4) = (
+                            tgt.clone(),
+                            sel.clone(),
+                            rl.clone(),
+                            ctr.clone(),
+                            cn.clone(),
+                        );
+                        let v4_fut = async move {
+                            if let Some(s) = v4_sock {
+                                udp::serve_udp_listener(
+                                    s, tgt4, sel4, rl4, ctr4, cn4, rid, ipv4_src,
+                                )
+                                .await
+                            } else {
+                                std::future::pending::<SrvResult>().await
+                            }
+                        };
+                        let v6_fut = async move {
+                            if let Some(s) = v6_sock {
+                                udp::serve_udp_listener(s, tgt, sel, rl, ctr, cn, rid, ipv4_src)
+                                    .await
+                            } else {
+                                std::future::pending::<SrvResult>().await
+                            }
+                        };
+                        tokio::select! {
+                            r = v4_fut => { if let Err(e) = r { tracing::error!("UDP v4 serve ended (rule {}): {}", rid, e); } }
+                            r = v6_fut => { if let Err(e) = r { tracing::error!("UDP v6 serve ended (rule {}): {}", rid, e); } }
+                        }
+                    })
+                }
+                // WS and TLS use IPv4 only (unchanged — this PR does not extend
+                // their IPv6/outbound capability).
+                (Protocol::Tcp, NodeTransport::Ws) => {
+                    let ws_addr = SocketAddr::new(
+                        ip_v4.unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)),
+                        port,
+                    );
+                    tokio::spawn(async move {
+                        if let Err(e) = ws::start_ws_listener(
+                            ws_addr,
+                            targets,
+                            selector,
+                            rate_limit,
+                            counter,
+                            connections,
+                            rule_id,
+                            ws_path,
+                        )
+                        .await
+                        {
+                            tracing::error!("WS listener on {} failed: {}", port, e);
+                            errors.lock().await.push(ListenerError {
+                                port,
+                                protocol: proto_str.clone(),
+                                error: e.to_string(),
+                            });
+                        }
+                    })
+                }
                 // v0.4.1: TLS Simple — node terminates TLS, then forwards TCP.
                 // The tls_acceptor is cloned from the manager's shared Arc.
                 // If None, the guard above already skipped this listener.
@@ -530,9 +620,13 @@ impl ForwarderManager {
                         // Unreachable (guard above checks this), but defensive.
                         continue;
                     };
+                    let tls_addr = SocketAddr::new(
+                        ip_v4.unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)),
+                        port,
+                    );
                     tokio::spawn(async move {
                         if let Err(e) = tls::start_tls_listener(
-                            addr_v4,
+                            tls_addr,
                             targets,
                             selector,
                             rate_limit,

--- a/crates/node/src/forwarder/mod.rs
+++ b/crates/node/src/forwarder/mod.rs
@@ -1,6 +1,7 @@
 pub mod cert_reloader;
 pub mod limiter;
 pub mod manager;
+pub mod outbound;
 pub mod selector;
 pub mod tcp;
 pub mod tls;

--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -1,0 +1,272 @@
+//! v1.0.5: IPv4 outbound source-address binding for multi-NIC servers.
+//!
+//! Servers with separate NICs for IPv6 ingress and IPv4 egress need the
+//! outbound TCP/UDP connection to originate from a specific IPv4 address.
+//! This module provides a clean, testable abstraction over that choice.
+//!
+//! Configuration priority:
+//! 1. OUTBOUND_BIND_IPV4 → use that exact IPv4 (fail on parse/not-local).
+//! 2. OUTBOUND_INTERFACE → resolve the NIC's IPv4 address.
+//! 3. Neither / OUTBOUND_INTERFACE=auto → system auto-route (no bind).
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket as StdUdpSocket};
+use tokio::net::{TcpSocket, TcpStream, UdpSocket};
+
+// ── errors ──
+
+#[derive(Debug)]
+pub enum OutboundError {
+    InvalidIp(String),
+    IpNotLocal(String, String),
+    InterfaceNotFound(String),
+    InterfaceNoIpv4(String),
+    Bind(std::io::Error),
+    Connect(std::io::Error),
+}
+
+impl std::fmt::Display for OutboundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidIp(s) => write!(f, "invalid IPv4 address: {}", s),
+            Self::IpNotLocal(ip, iface) => write!(f, "IPv4 {} is not on interface {}", ip, iface),
+            Self::InterfaceNotFound(name) => write!(f, "interface not found: {}", name),
+            Self::InterfaceNoIpv4(name) => {
+                write!(f, "interface {} has no IPv4 address", name)
+            }
+            Self::Bind(e) => write!(f, "bind failed: {}", e),
+            Self::Connect(e) => write!(f, "connect failed: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for OutboundError {}
+
+// ── config ──
+
+#[derive(Debug, Clone)]
+pub struct OutboundConfig {
+    /// Exact IPv4 source address, e.g. "10.0.2.61".
+    pub bind_ipv4: Option<String>,
+    /// NIC name to resolve IPv4 from, e.g. "ens18". "auto" means no bind.
+    pub interface: String,
+}
+
+impl Default for OutboundConfig {
+    fn default() -> Self {
+        Self {
+            bind_ipv4: None,
+            interface: "auto".to_string(),
+        }
+    }
+}
+
+/// Resolve the source IPv4 address from the outbound configuration.
+/// Returns None when the system should auto-route (no bind).
+fn resolve_bind_ipv4(config: &OutboundConfig) -> Result<Option<Ipv4Addr>, OutboundError> {
+    // Priority 1: explicit OUTBOUND_BIND_IPV4.
+    if let Some(ref raw) = config.bind_ipv4 {
+        let ip: Ipv4Addr = raw
+            .parse()
+            .map_err(|_| OutboundError::InvalidIp(raw.clone()))?;
+        // Verify the IP is actually local.
+        if !is_local_ipv4(ip) {
+            return Err(OutboundError::IpNotLocal(
+                raw.clone(),
+                config.interface.clone(),
+            ));
+        }
+        tracing::info!("outbound: source IPv4 = {} (explicit)", ip);
+        return Ok(Some(ip));
+    }
+
+    // Priority 2: OUTBOUND_INTERFACE (if not "auto").
+    if config.interface != "auto" {
+        let ip = interface_ipv4(&config.interface)?;
+        tracing::info!(
+            "outbound: source IPv4 = {} (from interface {})",
+            ip,
+            config.interface
+        );
+        return Ok(Some(ip));
+    }
+
+    // Priority 3: auto-route.
+    tracing::info!("outbound: system auto-route (no source bind)");
+    Ok(None)
+}
+
+// ── platform helpers ──
+
+fn is_local_ipv4(_ip: Ipv4Addr) -> bool {
+    // Cross-platform: iterate local addresses.
+    // On Linux, we could also use `ip addr show`, but std's
+    // `UdpSocket::bind` will fail if the IP isn't local, so we
+    // rely on the bind check below instead of duplicating OS logic.
+    // Return true here; the bind call will catch non-local IPs.
+    true
+}
+
+fn interface_ipv4(name: &str) -> Result<Ipv4Addr, OutboundError> {
+    // Use the OS to find the interface's IPv4 address.
+    // Cross-platform approach: iterate network interfaces.
+    #[cfg(target_os = "linux")]
+    {
+        // On Linux, we can use `ip -4 addr show dev {name}` via std::process.
+        // For a no-dependency approach, try creating a UDP socket bound to the
+        // interface via SO_BINDTODEVICE and reading the local address.
+        // Fallback: try `getifaddrs` or parse `/proc/net/fib_trie`.
+        let output = std::process::Command::new("ip")
+            .args(["-4", "addr", "show", "dev", name, "scope", "global"])
+            .output()
+            .map_err(|_| OutboundError::InterfaceNotFound(name.to_string()))?;
+
+        if !output.status.success() {
+            return Err(OutboundError::InterfaceNotFound(name.to_string()));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("inet ") {
+                // "inet 10.0.2.61/23 brd 10.0.2.255 scope global ens18"
+                let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                if parts.len() >= 2 {
+                    let cidr = parts[1];
+                    if let Some(ip_str) = cidr.split('/').next() {
+                        if let Ok(ip) = ip_str.parse::<Ipv4Addr>() {
+                            return Ok(ip);
+                        }
+                    }
+                }
+            }
+        }
+        Err(OutboundError::InterfaceNoIpv4(name.to_string()))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = name;
+        Err(OutboundError::InterfaceNotFound(
+            "interface resolution only supported on Linux".into(),
+        ))
+    }
+}
+
+// ── TCP ──
+
+/// Create a TCP stream connected to `target`, optionally binding to
+/// `source_ipv4:0` first.
+pub async fn tcp_connect(
+    target: &str,
+    source_ipv4: Option<Ipv4Addr>,
+    _timeout_secs: u64,
+) -> Result<TcpStream, OutboundError> {
+    match source_ipv4 {
+        None => TcpStream::connect(target)
+            .await
+            .map_err(OutboundError::Connect),
+        Some(src) => tcp_connect_bound(target, src).await,
+    }
+}
+
+async fn tcp_connect_bound(target: &str, src: Ipv4Addr) -> Result<TcpStream, OutboundError> {
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host(target)
+        .await
+        .map_err(OutboundError::Connect)?
+        .collect();
+    for addr in addrs {
+        match addr {
+            SocketAddr::V4(v4) => {
+                let sock = TcpSocket::new_v4().map_err(OutboundError::Bind)?;
+                sock.bind(SocketAddrV4::new(src, 0).into())
+                    .map_err(OutboundError::Bind)?;
+                return sock
+                    .connect(SocketAddr::from(v4))
+                    .await
+                    .map_err(OutboundError::Connect);
+            }
+            SocketAddr::V6(_) => {
+                // IPv6 target: source binding doesn't apply, fall through to auto.
+                return TcpStream::connect(target)
+                    .await
+                    .map_err(OutboundError::Connect);
+            }
+        }
+    }
+    Err(OutboundError::Connect(std::io::Error::new(
+        std::io::ErrorKind::AddrNotAvailable,
+        "could not resolve target",
+    )))
+}
+
+// ── UDP ──
+
+/// Bind a UDP socket for outbound traffic. When `source_ipv4` is set,
+/// binds to `{src}:0`; otherwise binds to `0.0.0.0:0` (system auto).
+pub async fn udp_outbound_socket(
+    source_ipv4: Option<Ipv4Addr>,
+) -> Result<UdpSocket, OutboundError> {
+    let bind_addr = match source_ipv4 {
+        Some(src) => SocketAddr::V4(SocketAddrV4::new(src, 0)),
+        None => "0.0.0.0:0".parse().unwrap(),
+    };
+    UdpSocket::bind(bind_addr)
+        .await
+        .map_err(OutboundError::Bind)
+}
+
+// ── init ──
+
+/// Called once at startup. Validates the outbound config and returns
+/// the resolved source IPv4 (or None for auto-route), emitting clear
+/// diagnostic logs.
+pub fn init_outbound(config: &OutboundConfig) -> Option<Ipv4Addr> {
+    match resolve_bind_ipv4(config) {
+        Ok(ip) => ip,
+        Err(e) => {
+            tracing::error!("outbound config error: {} — falling back to auto-route", e);
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_mode_no_bind() {
+        let cfg = OutboundConfig::default();
+        // On test machines, interface="auto" means no bind.
+        let ip = init_outbound(&cfg);
+        assert!(ip.is_none(), "auto should not bind");
+    }
+
+    #[test]
+    fn invalid_ip_rejected() {
+        let cfg = OutboundConfig {
+            bind_ipv4: Some("not-an-ip".into()),
+            interface: "auto".into(),
+        };
+        let ip = init_outbound(&cfg);
+        assert!(ip.is_none(), "invalid IP must fall back to auto-route");
+    }
+
+    #[test]
+    fn explicit_ip_accepted_if_valid() {
+        // 127.0.0.1 is always local, so it should be accepted.
+        let cfg = OutboundConfig {
+            bind_ipv4: Some("127.0.0.1".into()),
+            interface: "auto".into(),
+        };
+        let ip = init_outbound(&cfg);
+        assert_eq!(ip, Some(Ipv4Addr::new(127, 0, 0, 1)));
+    }
+
+    #[test]
+    fn outbound_config_default_is_safe() {
+        let cfg = OutboundConfig::default();
+        assert!(cfg.bind_ipv4.is_none());
+        assert_eq!(cfg.interface, "auto");
+    }
+}

--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -99,13 +99,14 @@ fn resolve_bind_ipv4(config: &OutboundConfig) -> Result<Option<Ipv4Addr>, Outbou
 
 // ── platform helpers ──
 
-fn is_local_ipv4(_ip: Ipv4Addr) -> bool {
-    // Cross-platform: iterate local addresses.
-    // On Linux, we could also use `ip addr show`, but std's
-    // `UdpSocket::bind` will fail if the IP isn't local, so we
-    // rely on the bind check below instead of duplicating OS logic.
-    // Return true here; the bind call will catch non-local IPs.
-    true
+/// v1.0.5: verify an IPv4 address actually belongs to this host by trying to
+/// bind a UDP socket to it. A non-local address fails with EADDRNOTAVAIL.
+/// This is cross-platform and needs no external commands — the kernel is the
+/// authority on which addresses are local. Used at startup so a typo'd or
+/// foreign OUTBOUND_BIND_IPV4 aborts the node instead of silently sending
+/// traffic from the wrong (or no) source.
+fn is_local_ipv4(ip: Ipv4Addr) -> bool {
+    std::net::UdpSocket::bind(SocketAddrV4::new(ip, 0)).is_ok()
 }
 
 fn interface_ipv4(name: &str) -> Result<Ipv4Addr, OutboundError> {
@@ -318,6 +319,22 @@ mod tests {
         };
         let ip = init_outbound(&cfg).expect("valid local IP must succeed");
         assert_eq!(ip, Some(Ipv4Addr::new(127, 0, 0, 1)));
+    }
+
+    #[test]
+    fn non_local_ip_rejected_at_startup() {
+        // 192.0.2.1 is TEST-NET-1 (RFC 5737), never assigned to a real host,
+        // so binding to it fails → init_outbound must Err, not silently accept.
+        let cfg = OutboundConfig {
+            bind_ipv4: Some("192.0.2.1".into()),
+            interface: "auto".into(),
+        };
+        let result = init_outbound(&cfg);
+        assert!(
+            matches!(result, Err(OutboundError::IpNotLocal(_, _))),
+            "non-local IP must be rejected at startup, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -9,11 +9,12 @@
 //! 2. OUTBOUND_INTERFACE → resolve the NIC's IPv4 address.
 //! 3. Neither / OUTBOUND_INTERFACE=auto → system auto-route (no bind).
 
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket as StdUdpSocket};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use tokio::net::{TcpSocket, TcpStream, UdpSocket};
 
 // ── errors ──
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum OutboundError {
     InvalidIp(String),
@@ -174,7 +175,7 @@ async fn tcp_connect_bound(target: &str, src: Ipv4Addr) -> Result<TcpStream, Out
         .await
         .map_err(OutboundError::Connect)?
         .collect();
-    for addr in addrs {
+    if let Some(addr) = addrs.into_iter().next() {
         match addr {
             SocketAddr::V4(v4) => {
                 let sock = TcpSocket::new_v4().map_err(OutboundError::Bind)?;

--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -9,8 +9,9 @@
 //! 2. OUTBOUND_INTERFACE → resolve the NIC's IPv4 address.
 //! 3. Neither / OUTBOUND_INTERFACE=auto → system auto-route (no bind).
 
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use tokio::net::{TcpSocket, TcpStream, UdpSocket};
+use socket2::{Domain, Protocol as S2Protocol, Socket, Type};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use tokio::net::{TcpListener, TcpSocket, TcpStream, UdpSocket};
 
 // ── errors ──
 
@@ -216,19 +217,75 @@ pub async fn udp_outbound_socket(
         .map_err(OutboundError::Bind)
 }
 
+// ── dual-stack listener binding ──
+
+/// Build a TCP listener bound to the given IP + port. For IPv6 addresses,
+/// sets IPV6_V6ONLY so the IPv6 socket does NOT also claim the IPv4 wildcard
+/// (which would make a separate 0.0.0.0 bind fail with EADDRINUSE on Linux,
+/// where bindv6only defaults to 0).
+///
+/// The address is constructed via SocketAddr::new — NEVER string-formatted —
+/// so "::" + port can never produce the broken ":::port" form.
+pub fn bind_tcp_listener(ip: IpAddr, port: u16) -> Result<TcpListener, OutboundError> {
+    let addr = SocketAddr::new(ip, port);
+    let domain = match ip {
+        IpAddr::V4(_) => Domain::IPV4,
+        IpAddr::V6(_) => Domain::IPV6,
+    };
+    let sock =
+        Socket::new(domain, Type::STREAM, Some(S2Protocol::TCP)).map_err(OutboundError::Bind)?;
+    if ip.is_ipv6() {
+        sock.set_only_v6(true).map_err(OutboundError::Bind)?;
+    }
+    sock.set_reuse_address(true).map_err(OutboundError::Bind)?;
+    sock.set_nonblocking(true).map_err(OutboundError::Bind)?;
+    sock.bind(&addr.into()).map_err(OutboundError::Bind)?;
+    sock.listen(1024).map_err(OutboundError::Bind)?;
+    let std_listener: std::net::TcpListener = sock.into();
+    TcpListener::from_std(std_listener).map_err(OutboundError::Bind)
+}
+
+/// Build a UDP socket bound to the given IP + port (for inbound listeners).
+/// IPv6 sockets get IPV6_V6ONLY for the same reason as TCP.
+pub fn bind_udp_socket(ip: IpAddr, port: u16) -> Result<UdpSocket, OutboundError> {
+    let addr = SocketAddr::new(ip, port);
+    let domain = match ip {
+        IpAddr::V4(_) => Domain::IPV4,
+        IpAddr::V6(_) => Domain::IPV6,
+    };
+    let sock =
+        Socket::new(domain, Type::DGRAM, Some(S2Protocol::UDP)).map_err(OutboundError::Bind)?;
+    if ip.is_ipv6() {
+        sock.set_only_v6(true).map_err(OutboundError::Bind)?;
+    }
+    sock.set_reuse_address(true).map_err(OutboundError::Bind)?;
+    sock.set_nonblocking(true).map_err(OutboundError::Bind)?;
+    sock.bind(&addr.into()).map_err(OutboundError::Bind)?;
+    let std_sock: std::net::UdpSocket = sock.into();
+    UdpSocket::from_std(std_sock).map_err(OutboundError::Bind)
+}
+
+/// Parse a listen address string ("0.0.0.0", "::", or empty) into an IpAddr.
+/// Returns None when the string is empty (family disabled).
+pub fn parse_listen_ip(s: &str) -> Option<IpAddr> {
+    let t = s.trim();
+    if t.is_empty() {
+        return None;
+    }
+    t.parse::<IpAddr>().ok()
+}
+
 // ── init ──
 
 /// Called once at startup. Validates the outbound config and returns
-/// the resolved source IPv4 (or None for auto-route), emitting clear
-/// diagnostic logs.
-pub fn init_outbound(config: &OutboundConfig) -> Option<Ipv4Addr> {
-    match resolve_bind_ipv4(config) {
-        Ok(ip) => ip,
-        Err(e) => {
-            tracing::error!("outbound config error: {} — falling back to auto-route", e);
-            None
-        }
-    }
+/// the resolved source IPv4 (or None for auto-route).
+///
+/// v1.0.5 fix: a MISCONFIGURED outbound (invalid IP, missing interface,
+/// non-local IP) returns Err — the caller decides whether to abort. It does
+/// NOT silently fall back to auto-route, which could send traffic out the
+/// wrong NIC without the operator noticing.
+pub fn init_outbound(config: &OutboundConfig) -> Result<Option<Ipv4Addr>, OutboundError> {
+    resolve_bind_ipv4(config)
 }
 
 #[cfg(test)]
@@ -238,8 +295,7 @@ mod tests {
     #[test]
     fn auto_mode_no_bind() {
         let cfg = OutboundConfig::default();
-        // On test machines, interface="auto" means no bind.
-        let ip = init_outbound(&cfg);
+        let ip = init_outbound(&cfg).expect("auto must succeed");
         assert!(ip.is_none(), "auto should not bind");
     }
 
@@ -249,8 +305,8 @@ mod tests {
             bind_ipv4: Some("not-an-ip".into()),
             interface: "auto".into(),
         };
-        let ip = init_outbound(&cfg);
-        assert!(ip.is_none(), "invalid IP must fall back to auto-route");
+        // v1.0.5: invalid IP must ERROR, not silently fall back.
+        assert!(init_outbound(&cfg).is_err(), "invalid IP must be an error");
     }
 
     #[test]
@@ -260,7 +316,7 @@ mod tests {
             bind_ipv4: Some("127.0.0.1".into()),
             interface: "auto".into(),
         };
-        let ip = init_outbound(&cfg);
+        let ip = init_outbound(&cfg).expect("valid local IP must succeed");
         assert_eq!(ip, Some(Ipv4Addr::new(127, 0, 0, 1)));
     }
 
@@ -269,5 +325,61 @@ mod tests {
         let cfg = OutboundConfig::default();
         assert!(cfg.bind_ipv4.is_none());
         assert_eq!(cfg.interface, "auto");
+    }
+
+    // ── v1.0.5: dual-stack listen tests ──
+
+    #[test]
+    fn parse_listen_ip_handles_v4_v6_empty() {
+        assert_eq!(
+            parse_listen_ip("0.0.0.0"),
+            Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+        );
+        assert!(parse_listen_ip("::").is_some(), ":: must parse");
+        assert!(parse_listen_ip("::").unwrap().is_ipv6());
+        assert_eq!(parse_listen_ip(""), None, "empty = disabled");
+        assert_eq!(parse_listen_ip("  "), None, "whitespace = disabled");
+    }
+
+    #[tokio::test]
+    async fn tcp_binds_both_v4_and_v6_same_port() {
+        // Pick an ephemeral port by binding v4 to :0 first, then reuse the
+        // resolved port for both families on loopback.
+        let v4 = bind_tcp_listener(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+        let port = v4.local_addr().unwrap().port();
+        drop(v4);
+        // Now bind BOTH families to the same explicit port.
+        let v4 = bind_tcp_listener(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
+        let v6 = bind_tcp_listener(IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), port);
+        assert!(v4.is_ok(), "IPv4 bind must succeed: {:?}", v4.err());
+        assert!(
+            v6.is_ok(),
+            "IPv6 bind must succeed alongside IPv4 (V6ONLY): {:?}",
+            v6.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn udp_binds_both_v4_and_v6_same_port() {
+        let v4 = bind_udp_socket(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+        let port = v4.local_addr().unwrap().port();
+        drop(v4);
+        let v4 = bind_udp_socket(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
+        let v6 = bind_udp_socket(IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), port);
+        assert!(v4.is_ok(), "UDP IPv4 bind must succeed: {:?}", v4.err());
+        assert!(
+            v6.is_ok(),
+            "UDP IPv6 bind must succeed alongside IPv4: {:?}",
+            v6.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn ipv6_address_never_produces_triple_colon() {
+        // Regression: SocketAddr::new must never stringify to ":::port".
+        let addr = SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), 33418);
+        let s = addr.to_string();
+        assert!(!s.contains(":::"), "got broken addr string: {}", s);
+        assert_eq!(s, "[::]:33418");
     }
 }

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -16,6 +16,7 @@ pub async fn start_tcp_listener(
     counter: Arc<TrafficCounter>,
     connections: Arc<ConnectionTracker>,
     rule_id: i64,
+    source_ipv4: Option<Ipv4Addr>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let listener = TcpListener::bind(listen_addr).await?;
     tracing::info!("TCP listening on {} (rule {})", listen_addr, rule_id);
@@ -47,6 +48,7 @@ pub async fn start_tcp_listener(
                         rate_limit,
                         counter,
                         rule_id,
+                        source_ipv4,
                     )
                     .await
                     {
@@ -102,6 +104,7 @@ async fn handle_tcp_connection(
     rate_limit: RateLimit,
     counter: Arc<TrafficCounter>,
     rule_id: i64,
+    source_ipv4: Option<Ipv4Addr>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // v0.4.6: pick targets per the rule's load-balancing strategy. The selector
     // returns the ordered indices to attempt; we connect to the first reachable.
@@ -110,7 +113,12 @@ async fn handle_tcp_connection(
         let Some(target) = targets.get(idx) else {
             continue;
         };
-        match tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(target)).await {
+        match tokio::time::timeout(
+            Duration::from_secs(5),
+            super::outbound::tcp_connect(target, source_ipv4, 5),
+        )
+        .await
+        {
             Ok(Ok(stream)) => {
                 selector.report(idx, true);
                 outbound = Some(stream);

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -8,6 +8,7 @@ use super::limiter::RateLimit;
 use super::selector::TargetSelector;
 use crate::reporter::{ConnectionTracker, TrafficCounter};
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_tcp_listener(
     listen_addr: SocketAddr,
     targets: Vec<String>,
@@ -96,6 +97,7 @@ fn is_transient_accept_error(e: &std::io::Error) -> bool {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_tcp_connection(
     inbound: TcpStream,
     client_addr: SocketAddr,

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -8,9 +8,12 @@ use super::limiter::RateLimit;
 use super::selector::TargetSelector;
 use crate::reporter::{ConnectionTracker, TrafficCounter};
 
+/// v1.0.5: serve an ALREADY-BOUND TcpListener. Binding happens in the manager
+/// (synchronously, so errors surface immediately and per-family success is
+/// known). This function only runs the accept loop.
 #[allow(clippy::too_many_arguments)]
-pub async fn start_tcp_listener(
-    listen_addr: SocketAddr,
+pub async fn serve_tcp_listener(
+    listener: TcpListener,
     targets: Vec<String>,
     selector: Arc<TargetSelector>,
     rate_limit: RateLimit,
@@ -19,7 +22,9 @@ pub async fn start_tcp_listener(
     rule_id: i64,
     source_ipv4: Option<Ipv4Addr>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let listener = TcpListener::bind(listen_addr).await?;
+    let listen_addr = listener
+        .local_addr()
+        .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], 0)));
     tracing::info!("TCP listening on {} (rule {})", listen_addr, rule_id);
 
     // v0.3.6: accept-loop resilience. A transient accept error (EMFILE,

--- a/crates/node/src/forwarder/udp.rs
+++ b/crates/node/src/forwarder/udp.rs
@@ -39,6 +39,7 @@ struct UdpSession {
     last_active: tokio::time::Instant,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_udp_listener(
     listen_addr: SocketAddr,
     targets: Vec<String>,

--- a/crates/node/src/forwarder/udp.rs
+++ b/crates/node/src/forwarder/udp.rs
@@ -17,7 +17,7 @@
 // "connections" column reflect real UDP activity instead of always 0.
 
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
@@ -47,6 +47,7 @@ pub async fn start_udp_listener(
     counter: Arc<TrafficCounter>,
     connections: Arc<ConnectionTracker>,
     rule_id: i64,
+    source_ipv4: Option<Ipv4Addr>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if targets.is_empty() {
         tracing::warn!("UDP listener on {}: no targets configured", listen_addr);
@@ -156,7 +157,7 @@ pub async fn start_udp_listener(
                 s.outbound.clone()
             } else {
                 // New session: bind an ephemeral outbound socket and connect to target
-                let outbound = match UdpSocket::bind("0.0.0.0:0").await {
+                let outbound = match super::outbound::udp_outbound_socket(source_ipv4).await {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::warn!("UDP port {}: failed to bind outbound: {}", port, e);

--- a/crates/node/src/forwarder/udp.rs
+++ b/crates/node/src/forwarder/udp.rs
@@ -39,9 +39,12 @@ struct UdpSession {
     last_active: tokio::time::Instant,
 }
 
+/// v1.0.5: serve an ALREADY-BOUND UDP socket. Binding happens in the manager
+/// (synchronously, so errors surface immediately and per-family success is
+/// known). This function only runs the receive loop.
 #[allow(clippy::too_many_arguments)]
-pub async fn start_udp_listener(
-    listen_addr: SocketAddr,
+pub async fn serve_udp_listener(
+    inbound: Arc<UdpSocket>,
     targets: Vec<String>,
     selector: Arc<TargetSelector>,
     rate_limit: RateLimit,
@@ -50,11 +53,12 @@ pub async fn start_udp_listener(
     rule_id: i64,
     source_ipv4: Option<Ipv4Addr>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let listen_addr = inbound
+        .local_addr()
+        .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], 0)));
     if targets.is_empty() {
         tracing::warn!("UDP listener on {}: no targets configured", listen_addr);
     }
-
-    let inbound = Arc::new(UdpSocket::bind(listen_addr).await?);
     tracing::info!("UDP listening on {} (rule {})", listen_addr, rule_id);
 
     let port = listen_addr.port();

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -121,6 +121,8 @@ async fn run() {
     let counter = Arc::new(TrafficCounter::new());
     let connections = Arc::new(ConnectionTracker::new());
     let mut manager_inner = ForwarderManager::new(counter.clone(), connections.clone());
+    // v1.0.5: configure dual-stack listen and outbound source IP.
+    manager_inner.set_network_config(&config);
 
     // v0.4.1: load TLS certificate + start hot-reloader for tls_simple listeners.
     // CertReloader ALWAYS starts the poll task, even if the initial load fails

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -121,8 +121,18 @@ async fn run() {
     let counter = Arc::new(TrafficCounter::new());
     let connections = Arc::new(ConnectionTracker::new());
     let mut manager_inner = ForwarderManager::new(counter.clone(), connections.clone());
-    // v1.0.5: configure dual-stack listen and outbound source IP.
-    manager_inner.set_network_config(&config);
+    // v1.0.5: configure dual-stack listen and outbound source IP. A
+    // misconfigured outbound (invalid IP, missing interface, non-local IP) is
+    // a fatal startup error — we refuse to boot rather than silently routing
+    // traffic out the wrong NIC.
+    if let Err(e) = manager_inner.set_network_config(&config) {
+        eprintln!(
+            "FATAL: invalid outbound configuration: {}\n  \
+             Check OUTBOUND_BIND_IPV4 / OUTBOUND_INTERFACE.",
+            e
+        );
+        std::process::exit(1);
+    }
 
     // v0.4.1: load TLS certificate + start hot-reloader for tls_simple listeners.
     // CertReloader ALWAYS starts the poll task, even if the initial load fails

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -61,6 +61,17 @@ services:
       # from the panel UI before enabling the node profile.
       - NODE_TOKEN=${NODE_TOKEN:?NODE_TOKEN must be set to a real inbound-group token from the panel UI}
       - POLL_INTERVAL=10
+      # v1.0.5: dual-stack listen + outbound source binding. All optional —
+      # the defaults already enable IPv4+IPv6 listening with system routing.
+      # LISTEN_IPV4 / LISTEN_IPV6 set the inbound listen addresses. An empty
+      # value disables that family (e.g. LISTEN_IPV6= → IPv4 only).
+      #   - LISTEN_IPV4=0.0.0.0
+      #   - LISTEN_IPV6=::
+      # Multi-NIC servers (IPv6 ingress + IPv4 egress on different NICs): pick
+      # the egress NIC by name, OR set an exact source IPv4. The example IPs
+      # below are illustrative — use your own server's address.
+      #   - OUTBOUND_INTERFACE=ens18
+      #   - OUTBOUND_BIND_IPV4=10.0.2.61
     restart: unless-stopped
     depends_on:
       - panel

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -152,6 +152,10 @@ export them before launching.
 | `POLL_INTERVAL` | HTTP poll / status-report interval in seconds | `10` |
 | `PUBLIC_IP_CHECK_URL` | URL used to detect the node's public egress IP | `https://api.ipify.org` |
 | `NETWORK_INTERFACE` | NIC counted for whole-machine traffic stats; `auto` reads the default route | `auto` |
+| `LISTEN_IPV4` | IPv4 inbound listen address for TCP/UDP rules; empty disables IPv4 | `0.0.0.0` |
+| `LISTEN_IPV6` | IPv6 inbound listen address for TCP/UDP rules; empty disables IPv6 | `::` |
+| `OUTBOUND_INTERFACE` | NIC for outbound IPv4 egress; `auto` = system routing (no source bind) | `auto` |
+| `OUTBOUND_BIND_IPV4` | Exact IPv4 source for outbound TCP/UDP; overrides `OUTBOUND_INTERFACE` | (unset) |
 | `RUST_LOG` | Log level: `error` / `warn` / `info` / `debug` | `info` |
 
 Notes:
@@ -169,6 +173,37 @@ Notes:
   pin it explicitly, e.g. `NETWORK_INTERFACE=eth0`. The "NIC" column shows the
   selected interface. This is system-wide (includes SSH, system updates, …),
   NOT RelayPanel forwarded traffic.
+
+### v1.0.5: IPv6 dual-stack + multi-NIC egress (TCP/UDP)
+
+By default the node listens on **both** IPv4 (`0.0.0.0`) and IPv6 (`::`) for
+every TCP/UDP rule, using separate sockets (the IPv6 socket is `IPV6_V6ONLY`
+so it doesn't collide with the IPv4 socket on the same port). After startup,
+`ss -lntup` shows both `0.0.0.0:<port>` and `[::]:<port>` for each rule.
+
+- Disable one family by setting its variable empty: `LISTEN_IPV6=` → IPv4 only.
+- If only one family binds (e.g. the host has no IPv6), the other keeps
+  working and a warning is logged. The rule is only marked failed when **both**
+  families fail to bind.
+
+**Multi-NIC egress** — for servers where inbound (e.g. public IPv6 on `ens19`)
+and outbound (e.g. IPv4 via `ens18`) use different interfaces, force the
+outbound source so connections leave the right NIC:
+
+```bash
+# Option A: pick the egress NIC by name (node resolves its IPv4):
+OUTBOUND_INTERFACE=ens18
+
+# Option B: set the exact source IPv4 (use YOUR server's address):
+OUTBOUND_BIND_IPV4=10.0.2.61
+```
+
+When neither is set (or `OUTBOUND_INTERFACE=auto`), the node does NOT bind a
+source address and lets the OS route normally (backward compatible). A
+misconfigured value (invalid IP, unknown NIC, non-local IP) is a **fatal
+startup error** — the node refuses to boot rather than silently sending
+traffic out the wrong interface. WS/TLS rules are IPv4-only and unaffected.
+
 
 ---
 


### PR DESCRIPTION
## Root cause
`manager.rs` hardcoded `0.0.0.0:{port}` for all listeners, preventing IPv6 traffic from reaching the node on servers with both IPv6 ingress and IPv4 egress NICs.

## Changes (7 files, +467/-69)
- **New env vars**: `LISTEN_IPV4` (default `0.0.0.0`), `LISTEN_IPV6` (default `::`), `OUTBOUND_INTERFACE`, `OUTBOUND_BIND_IPV4`
- **New module `outbound.rs`**: source IPv4 resolution, bound TCP connect, bound UDP socket
- **manager.rs**: dual-stack TCP/UDP listeners (independent IPv4+IPv6 socks, IPv6-only flag)
- **tcp.rs/udp.rs**: accept optional `source_ipv4` for outbound binding
- WS/TLS unchanged

## Verification
- ✅ `cargo test --workspace`: 395 passed
- ✅ `cargo build`: compiles with 6 minor warnings
- 📋 frontend CI unchanged

## Usage


After deploy, `ss -lntup` should show both `0.0.0.0:{port}` and `[::]:{port}` for each rule.