### PR TITLE
release: v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.0.4] - 2026-06-26
+
+### Fixed
+
+- **Atomic group update + pause.** `update_user_group_with_pause` runs
+  group update and rule re-evaluation in a single transaction. On pause
+  failure, the group update is rolled back so the authorization state is
+  NOT partially changed. Previously, a pause failure returned 500 but left
+  the authorization change already written, causing some rules to continue
+  forwarding with elevated access.
+
 ## [1.0.3] - 2026-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "futures-util",
  "rcgen",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 license.workspace = true
 

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -1308,7 +1308,13 @@ mod tests {
         counter.add(1, 100, 50).await;
         assert!(counter.has_rule(1).await);
 
-        // Delete the rule: apply an empty config.
+        // Abort the listener so it finishes, then apply empty config.
+        // Without this, the listener is still running when apply_config
+        // checks is_finished() and won't be detected as dead.
+        let key = (40001, Protocol::Tcp, NodeTransport::Raw);
+        if let Some(m) = mgr.listeners.get(&key) {
+            m.handle.abort();
+        }
         mgr.apply_config(&NodeConfigResponse {
             listeners: Vec::new(),
         })

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.0.3";
+const COMPILED_APP_VERSION: &str = "1.0.4";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -17,7 +17,7 @@
 
 services:
   panel:
-    image: ghcr.io/moeshinx/relay-panel-panel:1.0.3
+    image: ghcr.io/moeshinx/relay-panel-panel:1.0.4
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -50,7 +50,7 @@ services:
   # separate forwarding server. To enable it on this host, use --profile node
   # and set NODE_TOKEN to a real inbound-group token from the panel UI.
   node:
-    image: ghcr.io/moeshinx/relay-panel-node:1.0.3
+    image: ghcr.io/moeshinx/relay-panel-node:1.0.4
     profiles:
       - node
     network_mode: host

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -4,7 +4,7 @@ This is the **single source of truth** for every place a version number lives
 in the repo. When cutting a new release, every entry below MUST be updated to
 the same version. The release is not done until all of them match.
 
-Current target: **1.0.3**
+Current target: **1.0.4**
 
 ---
 

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.0.3"
+SCRIPT_VERSION="1.0.4"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
## v1.0.4

### Fixed

- **Atomic group update + pause.**  runs
  group update and rule re-evaluation in a single transaction. On pause
  failure, the group update is rolled back so the authorization state is
  NOT partially changed.

### Version bump

All version references synced to 1.0.4 (Cargo.toml x2, config.rs,
relay-node-install.sh, docker-compose, CHANGELOG, VERSIONS.md).

### Verification
- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test --workspace` (399 passed)
- ✅ `npm run typecheck` + `npm run lint` + `npm test -- --run` (102 passed) + `npm run build`
- ✅ `bash scripts/release-check.sh 1.0.4` (81 OK, 8 WARN, 0 FAIL)