### PR TITLE
fix(node): per-target TCP failure reasons + installer egress env examples

### DIFF
--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -1311,9 +1311,20 @@ mod tests {
         // Abort the listener so it finishes, then apply empty config.
         // Without this, the listener is still running when apply_config
         // checks is_finished() and won't be detected as dead.
+        //
+        // abort() only REQUESTS cancellation; the task isn't actually finished
+        // until the runtime polls it once more. On a busy CI runner the gap
+        // between abort() and the task settling made apply_config's
+        // is_finished() check race (it saw the task as still alive, skipped the
+        // dead-listener path, and the counter was never pruned → flaky FAIL).
+        // Spin on is_finished(), yielding so the runtime drives the cancelled
+        // task to completion, before applying the empty config.
         let key = (40001, Protocol::Tcp, NodeTransport::Raw);
         if let Some(m) = mgr.listeners.get(&key) {
             m.handle.abort();
+            while !m.handle.is_finished() {
+                tokio::task::yield_now().await;
+            }
         }
         mgr.apply_config(&NodeConfigResponse {
             listeners: Vec::new(),

--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -399,4 +399,82 @@ mod tests {
         assert!(!s.contains(":::"), "got broken addr string: {}", s);
         assert_eq!(s, "[::]:33418");
     }
+
+    // ── v1.0.5: outbound source-bind tests ──
+
+    #[tokio::test]
+    async fn tcp_connect_with_explicit_source_binds_and_connects() {
+        // #6: a TCP connection with an explicit source IPv4 must bind that
+        // source, then reach the target. Use loopback for both so the test is
+        // hermetic (127.0.0.1 is always local).
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let target = format!("127.0.0.1:{}", port);
+
+        let accept = tokio::spawn(async move { listener.accept().await.map(|(s, _)| s) });
+
+        let stream = tcp_connect(&target, Some(Ipv4Addr::LOCALHOST), 5)
+            .await
+            .expect("connect with source bind must succeed");
+        // The connection's local (source) address must be the bound 127.0.0.1.
+        assert_eq!(
+            stream.local_addr().unwrap().ip(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        );
+        assert!(accept.await.unwrap().is_ok(), "server must accept it");
+    }
+
+    #[tokio::test]
+    async fn tcp_connect_without_source_uses_auto_route() {
+        // #8: no source configured → system auto-route still connects.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let target = format!("127.0.0.1:{}", port);
+        let accept = tokio::spawn(async move { listener.accept().await.map(|(s, _)| s) });
+
+        let stream = tcp_connect(&target, None, 5)
+            .await
+            .expect("auto-route connect must succeed");
+        assert!(stream.peer_addr().unwrap().port() == port);
+        assert!(accept.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn udp_outbound_socket_binds_explicit_source() {
+        // #7: an explicit source IPv4 must produce a socket bound to {src}:0.
+        let sock = udp_outbound_socket(Some(Ipv4Addr::LOCALHOST))
+            .await
+            .expect("udp source bind must succeed");
+        let local = sock.local_addr().unwrap();
+        assert_eq!(local.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_ne!(local.port(), 0, "kernel must assign an ephemeral port");
+    }
+
+    #[tokio::test]
+    async fn udp_outbound_socket_auto_binds_wildcard() {
+        // #8: no source → bind 0.0.0.0:0 (system auto), backward compatible.
+        let sock = udp_outbound_socket(None)
+            .await
+            .expect("udp auto bind must succeed");
+        assert_eq!(
+            sock.local_addr().unwrap().ip(),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+        );
+    }
+
+    #[test]
+    fn nonexistent_interface_is_an_error() {
+        // #11: a typo'd / missing NIC must surface a clear error, never silently
+        // fall back to auto-route out the wrong interface.
+        let cfg = OutboundConfig {
+            bind_ipv4: None,
+            interface: "rp-no-such-nic-xyz".into(),
+        };
+        let result = init_outbound(&cfg);
+        assert!(
+            result.is_err(),
+            "missing interface must error, got {:?}",
+            result
+        );
+    }
 }

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -115,7 +115,13 @@ async fn handle_tcp_connection(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // v0.4.6: pick targets per the rule's load-balancing strategy. The selector
     // returns the ordered indices to attempt; we connect to the first reachable.
+    //
+    // v1.0.5: keep the REAL reason each target failed (DNS / timeout / no route /
+    // source-bind) instead of collapsing everything into "no target available".
+    // On a multi-NIC server a silent failure is impossible to diagnose, so we
+    // accumulate per-target reasons and log them together when nothing connects.
     let mut outbound = None;
+    let mut failures: Vec<String> = Vec::new();
     for idx in selector.order() {
         let Some(target) = targets.get(idx) else {
             continue;
@@ -131,9 +137,17 @@ async fn handle_tcp_connection(
                 outbound = Some(stream);
                 break;
             }
-            _ => {
+            Ok(Err(e)) => {
+                // tcp_connect already classifies the cause (InvalidIp / Connect /
+                // Bind). Preserve it verbatim so DNS vs. refused vs. source-bind
+                // failures are distinguishable in the log.
                 selector.report(idx, false);
-                continue;
+                failures.push(format!("{} -> {}", target, e));
+            }
+            Err(_) => {
+                // Outer timeout fired: the connect didn't finish within 5s.
+                selector.report(idx, false);
+                failures.push(format!("{} -> timed out after 5s", target));
             }
         }
     }
@@ -141,8 +155,18 @@ async fn handle_tcp_connection(
     let outbound = match outbound {
         Some(s) => s,
         None => {
-            tracing::warn!("TCP: no target available for {}", client_addr);
-            return Err("no target available".into());
+            let detail = if failures.is_empty() {
+                "no reachable target (all targets in circuit-break or empty)".to_string()
+            } else {
+                failures.join("; ")
+            };
+            tracing::warn!(
+                "TCP rule {}: no target available for client {} — {}",
+                rule_id,
+                client_addr,
+                detail
+            );
+            return Err(format!("no target available: {}", detail).into());
         }
     };
 

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -301,9 +301,11 @@ export PANEL_URL="__PANEL_URL__"
 export NODE_TOKEN="__NODE_TOKEN__"
 export POLL_INTERVAL="${POLL_INTERVAL:-10}"
 export RUST_LOG="${RUST_LOG:-info}"
-# v0.4.1: TLS Simple certificate paths. Sourced from relay-node.env if present
-# (written by the operator or a cert-management tool). If the file doesn't
-# exist, these stay unset and tls_simple listeners are disabled (Raw/WS work).
+# Optional config sourced from relay-node.env if present (written by the
+# installer with commented examples; edit it to set LISTEN_IPV4/LISTEN_IPV6,
+# OUTBOUND_INTERFACE/OUTBOUND_BIND_IPV4, or TLS_CERT_PATH/TLS_KEY_PATH). If the
+# file doesn't exist, all of these stay unset and the node uses its defaults
+# (dual-stack listen, system-routed egress, no TLS).
 # NOTE: path is hardcoded (/opt/relay-node) because this script runs with set -u
 # and INSTALL_DIR is not defined in the generated start.sh context.
 if [ -f "/opt/relay-node/relay-node.env" ]; then
@@ -334,15 +336,32 @@ chmod 700 "$CERTS_DIR"
 # one — the operator may have configured it).
 ENV_FILE="${INSTALL_DIR}/relay-node.env"
 if [ ! -f "$ENV_FILE" ]; then
-    info "Writing example TLS env file: $ENV_FILE (edit to enable TLS Simple)"
+    info "Writing example env file: $ENV_FILE (edit to tune listen / egress / TLS)"
     cat > "$ENV_FILE" <<'ENVEOF'
-# TLS Simple certificate configuration (v0.4.1).
+# relay-node optional environment. start.sh sources this file (set -a), so any
+# variable set here is exported to relay-node. All values below are commented:
+# the defaults already enable IPv4+IPv6 listening with system-routed egress.
+
+# ── v1.0.5: dual-stack inbound listen (TCP/UDP) ──
+# By default every rule listens on BOTH 0.0.0.0 and :: (separate sockets, the
+# IPv6 one is IPV6_V6ONLY). Set a family's variable EMPTY to disable it.
+#   LISTEN_IPV4=0.0.0.0      # empty → IPv4 disabled (IPv6-only node)
+#   LISTEN_IPV6=::           # empty → IPv6 disabled (IPv4-only node)
+
+# ── v1.0.5: IPv4 outbound egress for multi-NIC servers ──
+# When inbound (e.g. public IPv6 on ens19) and outbound (e.g. IPv4 via ens18)
+# use different interfaces, force the source so connections leave the right NIC.
+# Priority: OUTBOUND_BIND_IPV4 > OUTBOUND_INTERFACE > auto (system routing).
+# The example values below are ILLUSTRATIVE — use your own server's NIC/address.
+#   OUTBOUND_INTERFACE=ens18         # node resolves this NIC's IPv4 to bind
+#   OUTBOUND_BIND_IPV4=10.0.2.61     # or pin the exact source IPv4 (overrides above)
+
+# ── TLS Simple certificate configuration (v0.4.1) ──
 # Uncomment and set these to enable TLS Simple ingress on this node.
 # The cert must be PEM format (fullchain recommended); the key must be PEM
 # (PKCS#8, PKCS#1 RSA, or SEC1 EC). The key file MUST be chmod 600.
-#
-# TLS_CERT_PATH=/opt/relay-node/certs/fullchain.pem
-# TLS_KEY_PATH=/opt/relay-node/certs/privkey.pem
+#   TLS_CERT_PATH=/opt/relay-node/certs/fullchain.pem
+#   TLS_KEY_PATH=/opt/relay-node/certs/privkey.pem
 ENVEOF
     chmod 600 "$ENV_FILE"
 fi


### PR DESCRIPTION
## 背景

v1.0.5 的 IPv6 入口 + IPv4 出口 + 多网卡核心能力已经在 PR #19 落地（双栈监听、`OUTBOUND_BIND_IPV4`/`OUTBOUND_INTERFACE` 源地址绑定、`outbound.rs` 独立模块）。本 PR 补齐当时遗留的 3 个周边 gap，**不改 WS/TLS、不改默认行为**。

## 1. TCP 失败可观测性（根因诊断）

`handle_tcp_connection` 原先把每个 target 的失败都折叠成一句笼统的 `no target available`，丢掉了真实原因。多网卡服务器上出口有问题时根本无从判断是 DNS、超时、连接被拒还是源地址绑定失败。

现在每次尝试保留分类后的 `OutboundError`（或 `timed out after 5s`），最终日志/错误把所有 per-target 原因拼接输出：

```
TCP rule 17: no target available for client 1.2.3.4:55 — 38.246.227.59:41868 -> connect failed: Connection refused; 10.0.0.9:80 -> timed out after 5s
```

## 2. 安装脚本可发现性

`relay-node-install.sh` 生成的 `relay-node.env` 之前只有 TLS 注释。新的 `LISTEN_IPV4`/`LISTEN_IPV6` 和 `OUTBOUND_INTERFACE`/`OUTBOUND_BIND_IPV4` 虽然在 docker-compose 和 NODE.md 有文档，但安装时完全没提示。现在生成的 env 文件带上全部变量的注释示例（示例 IP 仅作说明，绝不作默认值），start.sh 的 source 注释也泛化了。

## 3. 测试补充

`outbound.rs` 新增 5 个测试：指定源 IPv4 的 TCP 连接、auto-route TCP 连接、指定源 UDP socket 绑定、wildcard UDP 绑定、不存在网卡报错。

## 验证

- `cargo fmt --check` ✅
- `cargo clippy -p relay-node --all-targets` ✅ 无警告
- `cargo test -p relay-node` ✅ 79 + 4 passed, 0 failed
- `bash -n scripts/relay-node-install.sh` ✅

## 不在本 PR 范围

WS/TLS 的 IPv6/出口能力（按需求要求暂不扩展）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)