### PR TITLE
fix(rules): symmetric export array + attribute imported rules to target user

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -52,7 +52,9 @@ function listenHostFor(rule: ForwardRule, groups: DeviceGroup[]): string {
 }
 
 /** v1.0.4: simplified export format — only dest, listen_port, name.
- *  Enabled targets only. IPv6 wrapped as [addr]:port. */
+ *  Enabled targets only. IPv6 wrapped as [addr]:port.
+ *  v1.0.6: always emit a JSON array (even for a single rule) so the export
+ *  round-trips into the import box, which documents the `[{...}]` array form. */
 function buildExportJSON(rules: ForwardRule[]): string {
   const simplified = rules.map(r => {
     const targets = ruleTargets(r).filter(t => t.enabled);
@@ -63,7 +65,7 @@ function buildExportJSON(rules: ForwardRule[]): string {
     });
     return { dest, listen_port: r.listen_port, name: r.name };
   });
-  return JSON.stringify(rules.length === 1 ? simplified[0] : simplified, null, 2);
+  return JSON.stringify(simplified, null, 2);
 }
 
 /** Trigger a browser download of a text file. */
@@ -321,6 +323,9 @@ const IMPORT_DEFAULTS = {
           target_addr: first.host,
           target_port: first.port,
           targets,
+          // v1.0.6: attribute to the target user when an admin imports via the
+          // user-management entry (/rules?owner_uid=X); else owner = caller.
+          owner_uid: filterOwnerUid ?? undefined,
         });
         if (res.code === 0) results.push(`✅ ${entry.name}:${entry.listen_port}`);
         else results.push(`❌ ${entry.name}: ${res.message}`);


### PR DESCRIPTION
Two bugs in the rule import/export flow, reported on the 转发规则 / 用户管理 pages.

## 1. Export format not symmetric with import
Exporting a **single** rule produced a bare object:
```json
{ "dest": ["1.2.3.4:3287"], "listen_port": 31718, "name": "..." }
```
but the import box documents the array form `[{"dest":["ip:端口"],"listen_port":端口,"name":"名称"}]`. `buildExportJSON` now **always emits a JSON array**, so exported text pastes straight back into import.

## 2. Imported rules attributed to the admin, not the target user
When an admin imports rules from the user-management entry (`/rules?owner_uid=X`), `handleImport` never sent `owner_uid`, so the rules landed under the admin. The backend already honors `owner_uid` for admins (`service/rules.rs` `create_rule`), and the **manual** create path already passed it — only the **import** payload omitted it. Now forwards `filterOwnerUid` the same way.

## Verification
Frontend-only change in `Rules.tsx`. `typecheck` / `lint` / `build` pass; 102 frontend tests pass.

Per batch-release workflow: merge to main, no release yet (batched for the next tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)