### PR TITLE
release: v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.0.6] - 2026-06-29
+
+### Fixed
+
+- **Rule export always returns a JSON array.** Single-rule exports previously
+  emitted a bare object `{…}` instead of a one-element array `[{…}]`, making
+  the exported JSON incompatible with the import box (which expects the array
+  form `[{"dest":[…],"listen_port":…,"name":"…"}]`). Export now always wraps
+  the result in an array, so copy-paste round-trips work regardless of the
+  number of rules selected.
+- **Imported rules were attributed to the admin instead of the target user.**
+  When an admin opened a user's rule list via `/rules?owner_uid=X` and used
+  the bulk-import feature, the created rules were owned by the admin account.
+  The `owner_uid` parameter is now forwarded in the import POST request,
+  matching the behaviour of the manual "add rule" form.
+
+---
+
 ## [1.0.5] - 2026-06-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "futures-util",
  "rcgen",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.0.5";
+const COMPILED_APP_VERSION: &str = "1.0.6";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -17,7 +17,7 @@
 
 services:
   panel:
-    image: ghcr.io/moeshinx/relay-panel-panel:1.0.5
+    image: ghcr.io/moeshinx/relay-panel-panel:1.0.6
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -50,7 +50,7 @@ services:
   # separate forwarding server. To enable it on this host, use --profile node
   # and set NODE_TOKEN to a real inbound-group token from the panel UI.
   node:
-    image: ghcr.io/moeshinx/relay-panel-node:1.0.5
+    image: ghcr.io/moeshinx/relay-panel-node:1.0.6
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.0.5"
+SCRIPT_VERSION="1.0.6"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

- Fix rule export always returning an array (was {} for single rule, now always [{...}])
- Fix imported rules attributed to admin instead of target user when admin uses /rules?owner_uid=X

## Changes

- CHANGELOG.md - added [1.0.6] section
- crates/node/Cargo.toml + crates/panel/Cargo.toml - bumped to 1.0.6
- crates/panel/src/config.rs - COMPILED_APP_VERSION = "1.0.6"
- scripts/relay-node-install.sh - SCRIPT_VERSION="1.0.6"
- docker-compose.release.yaml - both image tags -> 1.0.6
- Cargo.lock - updated

## Pre-flight

scripts/release-check.sh 1.0.6 -> 81 OK, 0 FAIL
cargo test --workspace -> all pass
npm run typecheck && npm run lint -> clean

Generated with Claude Code