### PR TITLE
release/v1.0.7: admin plan management + rule authz + UI polish

### DIFF
--- a/crates/panel/src/api/admin/rules.rs
+++ b/crates/panel/src/api/admin/rules.rs
@@ -128,6 +128,45 @@ pub async fn update_rule(
             }
         }
     }
+    // v1.0.7: resuming a rule (paused → false) is ALSO gated on authorization.
+    // A restricted user whose plan was removed has their rules auto-paused; they
+    // must not be able to re-enable a rule pointing at a now-unauthorized group
+    // by sending only {paused:false} — the device_group_in check above is
+    // skipped when that field is absent. Only needed when not switching groups
+    // in the same request (that path is already covered above).
+    if !user.admin && req.paused == Some(false) && req.device_group_in.is_none() {
+        let restricted = match state.db.is_user_restricted(user.user_id).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("update_rule: restriction lookup failed: {}", e);
+                return Json(err(500, "database error"));
+            }
+        };
+        if restricted {
+            match state.db.find_rule_by_id(id, &scope).await {
+                Ok(Some(rule)) => {
+                    let allowed = match state.db.authorized_device_group_ids(user.user_id).await {
+                        Ok(a) => a,
+                        Err(e) => {
+                            tracing::error!("update_rule: authz lookup failed: {}", e);
+                            return Json(err(500, "database error"));
+                        }
+                    };
+                    if !allowed.contains(&rule.device_group_in) {
+                        return Json(err(
+                            403,
+                            "cannot resume a rule on a device group you are not authorized for",
+                        ));
+                    }
+                }
+                Ok(None) => return Json(err(404, "Rule not found")),
+                Err(e) => {
+                    tracing::error!("update_rule: rule lookup failed: {}", e);
+                    return Json(err(500, "database error"));
+                }
+            }
+        }
+    }
     match crate::service::rules::update_rule(state.db.as_ref(), id, &scope, &req).await {
         Ok(()) => {
             state

--- a/crates/panel/src/api/admin/users.rs
+++ b/crates/panel/src/api/admin/users.rs
@@ -364,7 +364,7 @@ pub async fn get_user_device_groups(
     }))
 }
 
-// === v1.0.10: admin manages a user's plan ===
+// === v1.0.7: admin manages a user's plan ===
 
 /// POST /admin/users/{id}/buy-plan — admin assigns a plan to a user, charging
 /// the user's balance per the normal purchase rules (same atomic transaction as
@@ -500,25 +500,63 @@ pub async fn admin_set_user_plan(
     };
 
     match state.db.admin_set_user_plan(id, plan_id, expire).await {
-        Ok(0) => Json(err(404, "User not found (or is an admin)")),
-        Ok(_) => {
-            tracing::info!(
-                action = "admin_set_user_plan",
-                target_user_id = id,
-                actor_admin_id = _admin.user_id,
-                "admin edited user plan (clear={})",
-                req.clear
-            );
-            // Expiry feeds list_active_for_config — refresh node configs.
-            state
-                .node_connections
-                .broadcast_all(r#"{"type":"config_changed"}"#)
-                .await;
-            Json(ApiResponse::success(()))
-        }
+        Ok(0) => return Json(err(404, "User not found (or is an admin)")),
+        Ok(_) => {}
         Err(e) => {
             tracing::error!("admin_set_user_plan {}: db error: {}", id, e);
-            Json(err(500, "database error"))
+            return Json(err(500, "database error"));
         }
     }
+
+    // v1.0.7: removing the plan also REVOKES device-group authorization — the
+    // user returns to a bare account with no usable lines. Without this, the
+    // grants from the old plan (device-group auth is "only ever expands") would
+    // linger after the plan is gone and stack with the next purchase. Clear the
+    // all-groups flag + explicit assignments, then pause any rules that now
+    // reference an unauthorized group (data kept; resumes when re-authorized).
+    if req.clear {
+        if let Err(e) = state.db.set_user_all_device_groups(id, false).await {
+            tracing::error!(
+                "admin_set_user_plan {}: clear all_device_groups failed: {}",
+                id,
+                e
+            );
+            return Json(err(500, "database error"));
+        }
+        if let Err(e) = state.db.set_user_device_groups(id, &[]).await {
+            tracing::error!(
+                "admin_set_user_plan {}: clear device groups failed: {}",
+                id,
+                e
+            );
+            return Json(err(500, "database error"));
+        }
+        // Allowed set is now empty → pause ALL of the user's active rules.
+        match state.db.pause_rules_outside_groups(id, &[]).await {
+            Ok(n) if n > 0 => tracing::warn!(
+                "admin_set_user_plan {}: paused {} rule(s) after plan removal",
+                id,
+                n
+            ),
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("admin_set_user_plan {}: pause rules failed: {}", id, e);
+                return Json(err(500, "database error"));
+            }
+        }
+    }
+
+    tracing::info!(
+        action = "admin_set_user_plan",
+        target_user_id = id,
+        actor_admin_id = _admin.user_id,
+        "admin edited user plan (clear={})",
+        req.clear
+    );
+    // Expiry / authorization changes feed list_active_for_config — refresh nodes.
+    state
+        .node_connections
+        .broadcast_all(r#"{"type":"config_changed"}"#)
+        .await;
+    Json(ApiResponse::success(()))
 }

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -121,7 +121,7 @@ pub fn routes() -> Router<AppState> {
             "/admin/users/{id}/device-groups",
             axum::routing::get(admin::get_user_device_groups),
         )
-        // v1.0.10: admin manages a user's plan. POST buy-plan charges the user's
+        // v1.0.7: admin manages a user's plan. POST buy-plan charges the user's
         // balance and applies the plan (reuses the shop's buy_plan tx); PUT plan
         // edits the association + expiry without charging (remove / change expiry).
         .route(

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -3131,7 +3131,7 @@ async fn pg_migration_does_not_pause_cross_owner_shared_inbound_rules() {
     cleanup(&db).await;
 }
 
-// ── v1.0.10: admin directly edits a user's plan association + expiry ──
+// ── v1.0.7: admin directly edits a user's plan association + expiry ──
 
 #[tokio::test]
 async fn pg_admin_set_user_plan_clears_and_adjusts_expiry() {

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -159,7 +159,7 @@ pub trait UserRepository: Send + Sync {
         banned: Option<bool>,
         suspended: Option<bool>,
     ) -> Result<u64, DbError>;
-    /// v1.0.10: admin directly sets a user's plan association + expiry WITHOUT
+    /// v1.0.7: admin directly sets a user's plan association + expiry WITHOUT
     /// charging (the "edit user plan" panel uses this for removing a plan — both
     /// NULL — and for adjusting the expiry). Unconditionally writes both columns;
     /// the caller composes the pair (e.g. keep plan_id, change expiry). Skips

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -3095,7 +3095,7 @@ async fn expiry_does_not_revoke_granted_groups() {
     );
 }
 
-// ── v1.0.10: admin directly edits a user's plan association + expiry ──
+// ── v1.0.7: admin directly edits a user's plan association + expiry ──
 
 #[tokio::test]
 async fn admin_set_user_plan_clears_and_adjusts_expiry() {

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -916,14 +916,14 @@ pub struct BuyPlanRequest {
     pub plan_id: i64,
 }
 
-/// v1.0.10: admin assigns a plan to a user, charging the user's balance (same
+/// v1.0.7: admin assigns a plan to a user, charging the user's balance (same
 /// rules as a self-purchase). Hidden plans are allowed here.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AdminBuyPlanRequest {
     pub plan_id: i64,
 }
 
-/// v1.0.10: admin edits a user's plan association + expiry WITHOUT charging.
+/// v1.0.7: admin edits a user's plan association + expiry WITHOUT charging.
 /// `clear = true` removes the plan entirely (plan_id + plan_expire_at → NULL).
 /// `clear = false` keeps the user's current plan_id and sets the expiry, where
 /// `plan_expire_at = None` means "never expires".

--- a/frontend/src/components/nodes/NodeDesktopTable.tsx
+++ b/frontend/src/components/nodes/NodeDesktopTable.tsx
@@ -23,7 +23,7 @@ export function NodeDesktopTable({ rows, panelProtocol, currentVersion, t, openD
 
   const columns = [
     {
-      title: t('status'), key: 'status', width: 100, fixed: 'left' as const,
+      title: t('status'), key: 'status', width: 84, fixed: 'left' as const,
       render: (_: unknown, r: NodeDisplayRow) => {
         const v = r.config_protocol_version;
         if (v != null && panelProtocol > 0 && v !== panelProtocol) {
@@ -33,7 +33,7 @@ export function NodeDesktopTable({ rows, panelProtocol, currentVersion, t, openD
       },
     },
     {
-      title: t('network'), key: 'network', width: 220,
+      title: t('network'), key: 'network', width: 300,
       render: (_: unknown, r: NodeDisplayRow) => <NetworkCell row={r} t={t} />,
     },
     {
@@ -50,7 +50,7 @@ export function NodeDesktopTable({ rows, panelProtocol, currentVersion, t, openD
       render: (v: number) => <span className="rp-mono">{v || 0}</span>,
     },
     {
-      title: 'CPU', key: 'cpu', width: 100,
+      title: 'CPU', key: 'cpu', width: 84,
       render: (_: unknown, r: NodeDisplayRow) => <NodeResourceBar value={r.cpu} tooltip={`CPU: ${formatPercent(r.cpu)}`} />,
     },
     {

--- a/frontend/src/components/nodes/shared.tsx
+++ b/frontend/src/components/nodes/shared.tsx
@@ -16,7 +16,7 @@ export function NetworkCell({ row }: { row: NodeDisplayRow; t: Tfn }) {
   const line = (ip: string, code: string | null | undefined) => (
     <div key={ip} style={{ fontSize: 12, lineHeight: '18px', display: 'flex', alignItems: 'center', gap: 6 }}>
       <CountryFlag code={code} />
-      <span className="rp-mono">{ip}</span>
+      <span className="rp-mono" style={{ whiteSpace: 'nowrap' }}>{ip}</span>
     </div>
   );
   return (

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -155,7 +155,7 @@ export const enUS: Dict = {
   lbFailover: 'Failover',
   rateLimits: 'Rate Limits',
   rateLimitsHint: 'Per-rule cap shared across all connections (0 = unlimited). Each node enforces it independently.',
-  rateLimitsTooltip: 'Upload = client → target (data the user sends); Download = target → client (data the user receives). In Mbps; 0 means unlimited.',
+  rateLimitsTooltip: 'Upload = client → target (data the user sends); Download = target → client (data the user receives). In Mbps; 0 = unlimited.\n\n• Shared across all connections: this is a per-rule total bandwidth — every TCP connection / UDP session under this rule shares it, not a per-connection cap.\n• Enforced per node: when the rule is deployed to multiple nodes, each node runs at this cap independently, not merged across nodes. E.g. download = 100 with the rule on 3 nodes → each node can reach 100.',
   uploadLimit: 'Upload',
   downloadLimit: 'Download',
   transportProfile: 'Transport Template',
@@ -223,7 +223,7 @@ export const enUS: Dict = {
   editUser: 'Edit User',
   userUpdated: 'User updated',
   addUser: 'Add User',
-  // v1.0.10: admin edit-user-plan panel
+  // v1.0.7: admin edit-user-plan panel
   editUserPlan: 'Edit User Plan',
   currentPlan: 'Current plan',
   noPlan: 'No plan',
@@ -492,6 +492,11 @@ export const enUS: Dict = {
   batchExport: 'Batch Export',
   batchDeleteConfirm: 'Delete {count} selected rules? This cannot be undone.',
   batchDeleteSuccess: 'Deleted {count} rules',
+  batchResume: 'Batch Resume',
+  batchPause: 'Batch Pause',
+  batchResumeSuccess: 'Resumed {count} rules',
+  batchPauseSuccess: 'Paused {count} rules',
+  batchPartial: '{ok} succeeded, {fail} failed (unauthorized lines can\'t be resumed)',
   selectedCount: '{count} selected',
 
   // ── v1.0.8: plans + shop + suspension ──

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -154,7 +154,7 @@ export const zhCN = {
   lbFailover: '故障转移',
   rateLimits: '限速',
   rateLimitsHint: '规则级上限，所有连接共享（0 = 不限）。每台节点独立执行。',
-  rateLimitsTooltip: '上行 = 客户端 → 目标（用户上传）；下行 = 目标 → 客户端（用户下载）。单位 Mbps，0 表示不限速。',
+  rateLimitsTooltip: '上行 = 用户上传（客户端 → 目标）；下行 = 用户下载（目标 → 客户端）。单位 Mbps，0 = 不限速。\n\n• 所有连接共享：这是规则级总带宽，该规则下所有 TCP 连接 / UDP 会话共用，不是每条连接单独限速。\n• 每台节点独立执行：规则下发到多个节点时，每台节点各自按此上限运行，不跨节点合并。例如下行设 100，规则在 3 个节点上，每个节点都可跑到 100。',
   uploadLimit: '上行',
   downloadLimit: '下行',
   transportProfile: '传输模板',
@@ -222,7 +222,7 @@ export const zhCN = {
   editUser: '编辑用户',
   userUpdated: '用户已更新',
   addUser: '新增用户',
-  // v1.0.10: admin edit-user-plan panel
+  // v1.0.7: admin edit-user-plan panel
   editUserPlan: '编辑用户套餐',
   currentPlan: '当前套餐',
   noPlan: '无套餐',
@@ -491,6 +491,11 @@ export const zhCN = {
   batchExport: '批量导出',
   batchDeleteConfirm: '确定删除选中的 {count} 条规则？此操作不可撤销。',
   batchDeleteSuccess: '已删除 {count} 条规则',
+  batchResume: '批量启动',
+  batchPause: '批量暂停',
+  batchResumeSuccess: '已启动 {count} 条规则',
+  batchPauseSuccess: '已暂停 {count} 条规则',
+  batchPartial: '成功 {ok} 条，失败 {fail} 条（无权限的线路无法启动）',
   selectedCount: '已选 {count} 条',
 
   // ── v1.0.8: plans + shop + suspension ──

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -49,7 +49,10 @@ function payloadWithTargets<T extends Record<string, unknown>>(values: T & { tar
 /** v1.0.4: simplified export format — only dest, listen_port, name.
  *  Enabled targets only. IPv6 wrapped as [addr]:port.
  *  v1.0.6: always emit a JSON array (even for a single rule) so the export
- *  round-trips into the import box, which documents the `[{...}]` array form. */
+ *  round-trips into the import box, which documents the `[{...}]` array form.
+ *  v1.0.10: emit COMPACT single-line JSON (no pretty-printing) so the export is
+ *  exactly the one-line `[{"dest":[...],"listen_port":...,"name":"..."}]` shape
+ *  shown in the import hint — ready to copy-paste straight back in. */
 function buildExportJSON(rules: ForwardRule[]): string {
   const simplified = rules.map(r => {
     const targets = ruleTargets(r).filter(t => t.enabled);
@@ -60,7 +63,7 @@ function buildExportJSON(rules: ForwardRule[]): string {
     });
     return { dest, listen_port: r.listen_port, name: r.name };
   });
-  return JSON.stringify(simplified, null, 2);
+  return JSON.stringify(simplified);
 }
 
 /** Trigger a browser download of a text file. */
@@ -291,12 +294,6 @@ export default function Rules() {
     setCreateOpen(true);
   };
 
-  /** Export a single rule as JSON download. */
-  const handleExportOne = (r: ForwardRule) => {
-    downloadText(`rule-${r.name}-${r.id}.json`, buildExportJSON([r]));
-    message.success(t('exported'));
-  };
-
   /** Export all rules as JSON download. */
   const handleExportAll = () => {
     downloadText(`relaypanel-rules-${new Date().toISOString().slice(0, 10)}.json`, buildExportJSON(rules));
@@ -438,6 +435,30 @@ const IMPORT_DEFAULTS = {
     load();
   };
 
+  /** v1.0.7: batch pause/resume. Each rule goes through PUT /rules/{id}
+   *  {paused}. Resume can be rejected per-rule (403) when the rule points at a
+   *  device group the user is no longer authorized for, so we tally ok/fail
+   *  instead of assuming success. */
+  const handleBatchSetPaused = async (paused: boolean) => {
+    const ids = selectedRowKeys as number[];
+    if (ids.length === 0) return;
+    const results = await Promise.all(ids.map(async id => {
+      try {
+        const res = await api.put<unknown, ApiEnvelope<null>>(`/rules/${id}`, { paused });
+        return res.code === 0;
+      } catch { return false; }
+    }));
+    const ok = results.filter(Boolean).length;
+    const fail = results.length - ok;
+    if (fail === 0) {
+      message.success((paused ? t('batchPauseSuccess') : t('batchResumeSuccess')).replace('{count}', String(ok)));
+    } else {
+      message.warning(t('batchPartial').replace('{ok}', String(ok)).replace('{fail}', String(fail)));
+    }
+    setSelectedRowKeys([]);
+    load();
+  };
+
   /** v0.4.8: run a diagnosis for a rule. The panel fans the probe out to the
    *  rule's inbound-group nodes over WS and waits up to 8s for results. */
   const handleDiagnose = async (r: ForwardRule) => {
@@ -551,7 +572,6 @@ const IMPORT_DEFAULTS = {
           </Button>
           <Button size="small" type="text" icon={<EditOutlined />} onClick={() => handleEdit(r)}>{t('edit')}</Button>
           <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => handleCopy(r)}>{t('copy')}</Button>
-          <Button size="small" type="text" icon={<DownloadOutlined />} onClick={() => handleExportOne(r)}>{t('export')}</Button>
           {/* v0.4.9: diagnosis is TCP-only — disable for pure-UDP rules. */}
           <Button size="small" type="text" icon={<MedicineBoxOutlined />} disabled={r.protocol === 'udp'} onClick={() => handleDiagnose(r)} title={r.protocol === 'udp' ? t('diagnoseUdpUnsupported') : t('diagnose')}>{t('diagnose')}</Button>
           <Popconfirm title={t('deleteRuleConfirm')} onConfirm={() => handleDelete(r.id)}>
@@ -592,7 +612,10 @@ const IMPORT_DEFAULTS = {
 
   const hostForForm = (gid?: number) => {
     if (!gid) return '';
-    return groups.find(g => g.id === gid)?.connect_host ?? '';
+    // v1.0.10: a regular user doesn't own the admin device groups, so `groups`
+    // is empty for them — resolve the connect host from the merged groupInfo
+    // (which also folds in their authorized shared groups) instead.
+    return groupInfo.get(gid)?.connect_host ?? '';
   };
   const renderHostHint = (gid?: number) => {
     const host = hostForForm(gid);
@@ -686,6 +709,16 @@ const IMPORT_DEFAULTS = {
           {selectedRowKeys.length > 0 && (
             <Button icon={<DownloadOutlined />} onClick={handleExportSelected}>
               {t('batchExport')} ({selectedRowKeys.length})
+            </Button>
+          )}
+          {selectedRowKeys.length > 0 && (
+            <Button icon={<PlayCircleOutlined />} onClick={() => handleBatchSetPaused(false)}>
+              {t('batchResume')} ({selectedRowKeys.length})
+            </Button>
+          )}
+          {selectedRowKeys.length > 0 && (
+            <Button icon={<PauseCircleOutlined />} onClick={() => handleBatchSetPaused(true)}>
+              {t('batchPause')} ({selectedRowKeys.length})
             </Button>
           )}
           {selectedRowKeys.length > 0 && (
@@ -786,12 +819,12 @@ const IMPORT_DEFAULTS = {
                   }
                 />
                 <Form.Item
-                  label={<span>{t('rateLimits')} <Tooltip title={t('rateLimitsTooltip')}><QuestionCircleOutlined style={{ color: '#999' }} /></Tooltip></span>}
+                  label={<span>{t('rateLimits')} <Tooltip title={<span style={{ whiteSpace: 'pre-line' }}>{t('rateLimitsTooltip')}</span>} overlayStyle={{ maxWidth: 340 }}><QuestionCircleOutlined style={{ color: '#999' }} /></Tooltip></span>}
                   extra={t('rateLimitsHint')}
                 >
-                  <Space>
-                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: 200 }} placeholder="0" /></Form.Item>
-                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: 200 }} placeholder="0" /></Form.Item>
+                  <Space direction="vertical" style={{ width: '100%' }}>
+                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
+                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
               </>),
@@ -846,12 +879,12 @@ const IMPORT_DEFAULTS = {
                   }
                 />
                 <Form.Item
-                  label={<span>{t('rateLimits')} <Tooltip title={t('rateLimitsTooltip')}><QuestionCircleOutlined style={{ color: '#999' }} /></Tooltip></span>}
+                  label={<span>{t('rateLimits')} <Tooltip title={<span style={{ whiteSpace: 'pre-line' }}>{t('rateLimitsTooltip')}</span>} overlayStyle={{ maxWidth: 340 }}><QuestionCircleOutlined style={{ color: '#999' }} /></Tooltip></span>}
                   extra={t('rateLimitsHint')}
                 >
-                  <Space>
-                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: 200 }} placeholder="0" /></Form.Item>
-                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: 200 }} placeholder="0" /></Form.Item>
+                  <Space direction="vertical" style={{ width: '100%' }}>
+                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
+                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
               </>),

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -59,10 +59,9 @@ export default function Users() {
   const [resetting, setResetting] = useState<User | null>(null);
   // v1.0.7: inbound device groups available to assign to a user.
   const [deviceGroups, setDeviceGroups] = useState<DeviceGroup[]>([]);
-  // v1.0.10: admin "edit user plan" panel state. planEditing = the target row;
+  // v1.0.7: admin "edit user plan" panel state. planEditing = the target row;
   // plans = the catalog (for the assign dropdown); planChoice = the selected
   // plan to buy; planExpire = the expiry being edited (treated as UTC).
-  const [planEditing, setPlanEditing] = useState<User | null>(null);
   const [plans, setPlans] = useState<Plan[]>([]);
   const [planChoice, setPlanChoice] = useState<number | undefined>(undefined);
   const [planExpire, setPlanExpire] = useState<Dayjs | null>(null);
@@ -91,7 +90,7 @@ export default function Users() {
         const gRes = await api.get<unknown, ApiEnvelope<DeviceGroup[]>>('/groups');
         setDeviceGroups((gRes.data || []).filter(g => g.group_type === 'in'));
       } catch { setDeviceGroups([]); }
-      // v1.0.10: load the plan catalog for the "edit user plan" assign dropdown.
+      // v1.0.7: load the plan catalog for the "edit user plan" assign dropdown.
       try {
         const pRes = await api.get<unknown, ApiEnvelope<Plan[]>>('/admin/plans');
         setPlans(pRes.data || []);
@@ -103,37 +102,31 @@ export default function Users() {
   const planName = (id: number | null): string =>
     id == null ? t('noPlan') : (plans.find(p => p.id === id)?.name ?? `#${id}`);
 
-  const openPlan = (u: User) => {
-    setPlanEditing(u);
-    setPlanChoice(undefined);
-    // plan_expire_at is stored as a UTC 'YYYY-MM-DD HH:mm:ss' string; parse it
-    // as-is into the picker (we treat the displayed value as UTC end-to-end).
-    setPlanExpire(u.plan_expire_at ? dayjs(u.plan_expire_at) : null);
-  };
-
-  // Admin assigns a plan to the user, charging their balance (POST buy-plan).
+  // v1.0.10: plan management is embedded in the edit-user modal, so these act on
+  // the `editing` user. Admin assigns a plan, charging the user's balance.
   const handleBuyPlanForUser = async () => {
-    if (!planEditing || planChoice == null) return;
+    if (!editing || planChoice == null) return;
     setPlanBusy(true);
     try {
-      const res = await api.post<unknown, ApiEnvelope<null>>(`/admin/users/${planEditing.id}/buy-plan`, { plan_id: planChoice });
+      const res = await api.post<unknown, ApiEnvelope<null>>(`/admin/users/${editing.id}/buy-plan`, { plan_id: planChoice });
       if (res.code !== 0) { message.error(res.message); return; }
       message.success(t('planAssigned'));
-      setPlanEditing(null);
+      setEditing(null);
       load();
     } finally { setPlanBusy(false); }
   };
 
   // Edit the plan association/expiry without charging. clear=true removes the
-  // plan; otherwise keep plan_id and set the expiry (null = never expires).
+  // plan (and revokes device-group authorization on the backend); otherwise
+  // keep plan_id and set the expiry (null = never expires).
   const handleSetUserPlan = async (clear: boolean, expire: string | null) => {
-    if (!planEditing) return;
+    if (!editing) return;
     setPlanBusy(true);
     try {
-      const res = await api.put<unknown, ApiEnvelope<null>>(`/admin/users/${planEditing.id}/plan`, { clear, plan_expire_at: expire });
+      const res = await api.put<unknown, ApiEnvelope<null>>(`/admin/users/${editing.id}/plan`, { clear, plan_expire_at: expire });
       if (res.code !== 0) { message.error(res.message); return; }
       message.success(t('userUpdated'));
-      setPlanEditing(null);
+      setEditing(null);
       load();
     } finally { setPlanBusy(false); }
   };
@@ -149,6 +142,9 @@ export default function Users() {
 
   const openEdit = async (u: User) => {
     setEditing(u);
+    // v1.0.10: preload the embedded plan panel (assign choice + expiry picker).
+    setPlanChoice(undefined);
+    setPlanExpire(u.plan_expire_at ? dayjs(u.plan_expire_at) : null);
     form.setFieldsValue({
       // InputNumber with stringMode wants a string. Existing rows already have
       // a canonical TEXT-form value (e.g. "12.30"); pass it through unchanged.
@@ -346,17 +342,10 @@ export default function Users() {
       ),
     },
     {
-      title: t('action'), key: 'action', width: 250,
+      title: t('action'), key: 'action', width: 210,
       render: (_: unknown, u: User) => (
         <Space size="small">
           <Button icon={<EditOutlined />} size="small" type="text" onClick={() => openEdit(u)}>{t('edit')}</Button>
-          {/* v1.0.10: edit user plan (assign / change expiry / remove). Admins
-              can't hold a plan, so the entry is hidden for them. */}
-          {isAdmin && !u.admin && (
-            <Tooltip title={t('editUserPlan')}>
-              <Button icon={<ShoppingOutlined />} size="small" type="text" onClick={() => openPlan(u)} />
-            </Tooltip>
-          )}
           <Popconfirm title={t('resetTrafficConfirm')} onConfirm={() => handleResetTraffic(u.id)}>
             <Button icon={<UndoOutlined />} size="small" type="text">{t('resetTraffic')}</Button>
           </Popconfirm>
@@ -392,69 +381,6 @@ export default function Users() {
         </Space>
       </div>
       <Table dataSource={users} columns={columns} rowKey="id" loading={loading} pagination={{ pageSize: 20 }} />
-
-      {/* v1.0.10: edit-user-plan panel — assign a plan (charges balance),
-          adjust the expiry, or remove the plan. */}
-      <Modal
-        title={planEditing ? `${t('editUserPlan')}: ${planEditing.username}` : t('editUserPlan')}
-        open={!!planEditing}
-        onCancel={() => setPlanEditing(null)}
-        footer={null}
-        width={540}
-      >
-        {planEditing && (
-          <div>
-            <p style={{ marginTop: 0 }}>
-              <strong>{t('currentPlan')}:</strong> {planName(planEditing.plan_id)}
-              <span style={{ marginLeft: 16 }}>
-                <strong>{t('planExpiry')}:</strong> {planEditing.plan_expire_at || t('neverExpires')}
-              </span>
-            </p>
-
-            <Divider style={{ margin: '12px 0' }} />
-
-            <div style={{ marginBottom: 4 }}><strong>{t('assignPlan')}</strong></div>
-            <div style={{ color: '#999', fontSize: 12, marginBottom: 8 }}>{t('assignPlanHint')}</div>
-            <Space.Compact style={{ width: '100%' }}>
-              <Select
-                style={{ flex: 1 }}
-                placeholder={t('selectPlan')}
-                value={planChoice}
-                onChange={setPlanChoice}
-                options={plans.map(p => ({
-                  value: p.id,
-                  label: `${p.name} · ${p.price} · ${p.plan_type === 'time' ? `${p.duration_days}${t('days')}` : t('planTypeData')}`,
-                }))}
-              />
-              <Button type="primary" loading={planBusy} disabled={planChoice == null} onClick={handleBuyPlanForUser}>
-                {t('assignAndCharge')}
-              </Button>
-            </Space.Compact>
-
-            <Divider style={{ margin: '12px 0' }} />
-
-            <div style={{ marginBottom: 8 }}>
-              <strong>{t('editExpiry')}</strong>
-              <span style={{ color: '#999', fontSize: 12, marginLeft: 6 }}>(UTC)</span>
-            </div>
-            <Space wrap>
-              <DatePicker showTime value={planExpire} onChange={setPlanExpire} placeholder={t('neverExpires')} />
-              <Button loading={planBusy} onClick={() => handleSetUserPlan(false, planExpire ? planExpire.format('YYYY-MM-DD HH:mm:ss') : null)}>
-                {t('saveExpiry')}
-              </Button>
-              <Button loading={planBusy} onClick={() => { setPlanExpire(null); handleSetUserPlan(false, null); }}>
-                {t('setNeverExpires')}
-              </Button>
-            </Space>
-
-            <Divider style={{ margin: '12px 0' }} />
-
-            <Popconfirm title={t('removePlanConfirm')} onConfirm={() => handleSetUserPlan(true, null)}>
-              <Button danger loading={planBusy}>{t('removePlan')}</Button>
-            </Popconfirm>
-          </div>
-        )}
-      </Modal>
 
       <Modal
         title={editing ? `${t('editUser')}: ${editing.username}` : t('editUser')}
@@ -513,7 +439,7 @@ export default function Users() {
             label={t('maxRules')}
             rules={[{ type: 'number', min: 0, max: 100000, message: t('maxRulesRange') }]}
           >
-            <InputNumber min={0} max={100000} style={{ width: '100%' }} />
+            <InputNumber min={0} max={100000} style={{ width: 200 }} />
           </Form.Item>
           <Form.Item
             name="traffic_limit_gb"
@@ -557,6 +483,64 @@ export default function Users() {
             </>
           )}
         </Form>
+
+        {/* v1.0.10: plan management embedded in the edit-user modal (non-admin
+            only). Assign a plan (charges balance), adjust expiry, or remove the
+            plan. These act outside the form and refresh the list on success. */}
+        {editing && !editing.admin && (
+          <>
+            <Divider style={{ margin: '8px 0 16px' }} />
+            <div style={{ marginBottom: 8 }}>
+              <strong><ShoppingOutlined /> {t('editUserPlan')}</strong>
+            </div>
+            <p style={{ marginTop: 0 }}>
+              <strong>{t('currentPlan')}:</strong> {planName(editing.plan_id)}
+              <span style={{ marginLeft: 16 }}>
+                <strong>{t('planExpiry')}:</strong> {editing.plan_expire_at || t('neverExpires')}
+              </span>
+            </p>
+
+            <div style={{ marginBottom: 4 }}><strong>{t('assignPlan')}</strong></div>
+            <div style={{ color: '#999', fontSize: 12, marginBottom: 8 }}>{t('assignPlanHint')}</div>
+            <Space.Compact style={{ width: '100%' }}>
+              <Select
+                style={{ flex: 1 }}
+                placeholder={t('selectPlan')}
+                value={planChoice}
+                onChange={setPlanChoice}
+                options={plans.map(p => ({
+                  value: p.id,
+                  label: `${p.name} · ${p.price} · ${p.plan_type === 'time' ? `${p.duration_days}${t('days')}` : t('planTypeData')}`,
+                }))}
+              />
+              <Button type="primary" loading={planBusy} disabled={planChoice == null} onClick={handleBuyPlanForUser}>
+                {t('assignAndCharge')}
+              </Button>
+            </Space.Compact>
+
+            <Divider style={{ margin: '12px 0' }} />
+
+            <div style={{ marginBottom: 8 }}>
+              <strong>{t('editExpiry')}</strong>
+              <span style={{ color: '#999', fontSize: 12, marginLeft: 6 }}>(UTC)</span>
+            </div>
+            <Space wrap>
+              <DatePicker showTime value={planExpire} onChange={setPlanExpire} placeholder={t('neverExpires')} />
+              <Button loading={planBusy} onClick={() => handleSetUserPlan(false, planExpire ? planExpire.format('YYYY-MM-DD HH:mm:ss') : null)}>
+                {t('saveExpiry')}
+              </Button>
+              <Button loading={planBusy} onClick={() => { setPlanExpire(null); handleSetUserPlan(false, null); }}>
+                {t('setNeverExpires')}
+              </Button>
+            </Space>
+
+            <Divider style={{ margin: '12px 0' }} />
+
+            <Popconfirm title={t('removePlanConfirm')} onConfirm={() => handleSetUserPlan(true, null)}>
+              <Button danger loading={planBusy}>{t('removePlan')}</Button>
+            </Popconfirm>
+          </>
+        )}
       </Modal>
 
       <Modal


### PR DESCRIPTION
## 后端
- 管理员套餐管理:开通/扣费、改到期、删除套餐(`POST buy-plan` / `PUT plan`),新增 `admin_set_user_plan` repo 方法(SQLite + PG + parity 测试)
- **删除套餐联动收回设备组授权**(清 `all_device_groups` + `user_device_groups`)并暂停越权规则,避免残留授权在重新购买时叠加
- **启动规则授权校验**:受限用户无法用 `{paused:false}` 绕过授权重新启用越权规则

## 前端
- 套餐管理整合进「编辑用户」弹窗(开通/扣费、到期、删除);规则上限框宽度收窄
- 规则页批量启动/暂停;删除每行冗余的导出按钮;导出改紧凑单行 JSON(与导入提示一致)
- 限速输入框上下排列 + 上行/下行前缀 + tooltip 说明;普通用户入口分组连接地址从合并的共享组信息解析
- 节点状态表:IP 列加宽 + nowrap(IPv6 不换行),压缩状态/CPU,版本等列对齐

## 测试
- 后端 354 测试全过;前端 typecheck + lint 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)