### PR TITLE
feat(groups): admin-hidden device groups (node-status page only)

### DIFF
--- a/crates/panel/src/api/admin/groups.rs
+++ b/crates/panel/src/api/admin/groups.rs
@@ -47,6 +47,7 @@ pub async fn create_group(
         &req.connect_host,
         &req.port_range,
         rate,
+        req.hidden.unwrap_or(false),
     )
     .await
     {
@@ -133,6 +134,7 @@ pub async fn update_group(
         req.connect_host.as_deref(),
         req.port_range.as_deref(),
         rate,
+        req.hidden,
     )
     .await
     {

--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -1588,6 +1588,7 @@ mod tests {
                 port_range: "20000-30000".into(),
                 owner_uid: Some(3),
                 rate: None,
+                hidden: None,
             }),
         )
         .await;

--- a/crates/panel/src/api/groups.rs
+++ b/crates/panel/src/api/groups.rs
@@ -98,7 +98,10 @@ pub async fn list_shared_node_summary(
         };
 
     // v1.0.7: filter by per-user device-group authorization (same logic as
-    // list_shared_groups). Admins are handled above (empty list).
+    // list_shared_groups), AND drop admin-hidden groups — this is the ONLY path
+    // that honors `hidden` (the node-status page). The rule dropdown / shop
+    // (list_shared_groups) intentionally keep listing hidden groups so existing
+    // and new rules work normally. Admins are handled above (empty list).
     let groups = if user.admin {
         groups
     } else {
@@ -109,7 +112,7 @@ pub async fn list_shared_node_summary(
             .unwrap_or_default();
         groups
             .into_iter()
-            .filter(|g| authorized.contains(&g.id))
+            .filter(|g| !g.hidden && authorized.contains(&g.id))
             .collect()
     };
 
@@ -292,6 +295,7 @@ mod tests {
             capabilities: "[]".into(),
             region: None,
             line_type: None,
+            hidden: false,
         }
     }
 

--- a/crates/panel/src/db/pg_repo/groups.rs
+++ b/crates/panel/src/db/pg_repo/groups.rs
@@ -32,8 +32,12 @@ impl GroupRepository for PgRepository {
         // v0.4.12 PR1: regular users see ALL ADMIN-owned inbound groups,
         // independent of whether they already have rules. group_type uses the
         // stable machine value 'in' (the old LIKE 'inbound%' never matched).
+        // v1.0.7: `g.hidden` is SELECTED (not filtered here) so the caller
+        // decides. Only the node-status path (`list_shared_node_summary`) hides
+        // it; the rule dropdown / shop still list hidden groups so existing and
+        // new rules keep working. Admins get [] above and are unaffected.
         let groups: Vec<SharedGroupSummary> = sqlx::query_as(
-            "SELECT g.id, g.name, g.group_type, g.connect_host, g.capabilities, g.region, g.line_type \
+            "SELECT g.id, g.name, g.group_type, g.connect_host, g.capabilities, g.region, g.line_type, g.hidden \
              FROM device_groups g \
              JOIN users u ON u.id = g.uid \
              WHERE g.uid != $1 AND u.admin = TRUE AND g.group_type = 'in' \
@@ -97,10 +101,11 @@ impl GroupRepository for PgRepository {
         connect_host: &str,
         port_range: &str,
         rate: f64,
+        hidden: bool,
     ) -> Result<(), DbError> {
         sqlx::query(
-            "INSERT INTO device_groups (name, group_type, token, uid, connect_host, port_range, rate) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO device_groups (name, group_type, token, uid, connect_host, port_range, rate, hidden) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(name)
         .bind(group_type)
@@ -109,6 +114,7 @@ impl GroupRepository for PgRepository {
         .bind(connect_host)
         .bind(port_range)
         .bind(rate)
+        .bind(hidden)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -135,6 +141,7 @@ impl GroupRepository for PgRepository {
         connect_host: Option<&str>,
         port_range: Option<&str>,
         rate: Option<f64>,
+        hidden: Option<bool>,
     ) -> Result<u64, DbError> {
         let mut sets: Vec<&str> = Vec::new();
         if name.is_some() {
@@ -151,6 +158,9 @@ impl GroupRepository for PgRepository {
         }
         if rate.is_some() {
             sets.push("rate = ");
+        }
+        if hidden.is_some() {
+            sets.push("hidden = ");
         }
 
         if sets.is_empty() {
@@ -196,6 +206,9 @@ impl GroupRepository for PgRepository {
             q = q.bind(v);
         }
         if let Some(v) = rate {
+            q = q.bind(v);
+        }
+        if let Some(v) = hidden {
             q = q.bind(v);
         }
         q = q.bind(id);

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -860,7 +860,7 @@ async fn pg_group_insert_then_find_by_token_round_trip() {
     let Some(db) = repo("group_rt").await else {
         return;
     };
-    db.insert_group("gin", "in", "tok-abc", 1, "1.2.3.4", "20000-30000", 1.0)
+    db.insert_group("gin", "in", "tok-abc", 1, "1.2.3.4", "20000-30000", 1.0, false)
         .await
         .unwrap();
     let g = db.find_by_token("tok-abc").await.unwrap().unwrap();
@@ -889,7 +889,7 @@ async fn pg_group_update_token_returns_rows_affected() {
     let Some(db) = repo("group_tok").await else {
         return;
     };
-    db.insert_group("gin", "in", "tok-1", 1, "", "", 1.0)
+    db.insert_group("gin", "in", "tok-1", 1, "", "", 1.0, false)
         .await
         .unwrap();
     let g = db.find_by_token("tok-1").await.unwrap().unwrap();
@@ -2057,6 +2057,7 @@ async fn pg_update_group_fields_owner_scope_rejects_wrong_owner() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2067,6 +2068,7 @@ async fn pg_update_group_fields_owner_scope_rejects_wrong_owner() {
             10,
             &ResourceScope::Owner(3),
             Some("stolen"),
+            None,
             None,
             None,
             None,
@@ -2188,6 +2190,39 @@ async fn pg_shared_groups_excludes_other_regular_users_groups() {
         shared.is_empty(),
         "alice must NOT see bob's inbound group (PG)"
     );
+    cleanup(&db).await;
+}
+
+/// v1.0.7: list_shared_groups still RETURNS a hidden group (carrying the
+/// `hidden` flag); only the node-status handler drops it, so the rule dropdown
+/// / shop keep listing hidden lines. Admins see it too (PG).
+#[tokio::test]
+async fn pg_shared_groups_carries_hidden_flag_and_still_lists_hidden() {
+    let Some(db) = repo("shgrp_hidden").await else {
+        return;
+    };
+    sqlx::query("INSERT INTO users (id, username, password, admin) VALUES (2, 'u2', 'x', FALSE)")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (10, 'g10', 'in', 'tok10', 1)")
+        .execute(&db.pool).await.unwrap();
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid, hidden) VALUES (11, 'g11', 'in', 'tok11', 1, TRUE)")
+        .execute(&db.pool).await.unwrap();
+
+    // Regular user: BOTH groups listed; the hidden one carries hidden=true.
+    let shared = db.list_shared_groups(2, false).await.unwrap();
+    assert_eq!(shared.len(), 2, "hidden group must STILL be listed for rules (PG)");
+    assert!(shared.iter().any(|g| g.id == 11 && g.hidden));
+    assert!(shared.iter().any(|g| g.id == 10 && !g.hidden));
+
+    // Admin: list_groups (unscoped) returns BOTH, with the flag set.
+    let all = db.list_groups(&ResourceScope::All).await.unwrap();
+    assert!(
+        all.iter().any(|g| g.id == 11 && g.hidden),
+        "admin must still see the hidden group, flagged hidden=true (PG)"
+    );
+    assert!(all.iter().any(|g| g.id == 10 && !g.hidden));
     cleanup(&db).await;
 }
 

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -860,9 +860,18 @@ async fn pg_group_insert_then_find_by_token_round_trip() {
     let Some(db) = repo("group_rt").await else {
         return;
     };
-    db.insert_group("gin", "in", "tok-abc", 1, "1.2.3.4", "20000-30000", 1.0, false)
-        .await
-        .unwrap();
+    db.insert_group(
+        "gin",
+        "in",
+        "tok-abc",
+        1,
+        "1.2.3.4",
+        "20000-30000",
+        1.0,
+        false,
+    )
+    .await
+    .unwrap();
     let g = db.find_by_token("tok-abc").await.unwrap().unwrap();
     assert_eq!(g.name, "gin");
     assert_eq!(g.group_type, "in");
@@ -2212,7 +2221,11 @@ async fn pg_shared_groups_carries_hidden_flag_and_still_lists_hidden() {
 
     // Regular user: BOTH groups listed; the hidden one carries hidden=true.
     let shared = db.list_shared_groups(2, false).await.unwrap();
-    assert_eq!(shared.len(), 2, "hidden group must STILL be listed for rules (PG)");
+    assert_eq!(
+        shared.len(),
+        2,
+        "hidden group must STILL be listed for rules (PG)"
+    );
     assert!(shared.iter().any(|g| g.id == 11 && g.hidden));
     assert!(shared.iter().any(|g| g.id == 10 && !g.hidden));
 

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS device_groups (
     -- 1.0). Mirrors SQLite Migration 33 / baseline. Range 0.1..=100 enforced
     -- at the API.
     rate DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    -- v1.0.7: hide from regular users' shared views (mirrors SQLite Migration 36).
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TEXT NOT NULL DEFAULT (to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
@@ -271,7 +273,7 @@ INSERT INTO schema_version (version) VALUES (1) ON CONFLICT (version) DO NOTHING
 /// The schema revision this build's baseline `PG_SCHEMA_SQL` represents. When a
 /// future release adds a column/table, bump this and add a matching arm in
 /// `run_pg_migrations`. `apply_pg_schema` seeds `schema_version` with revision 1.
-pub const PG_SCHEMA_VERSION: i32 = 18;
+pub const PG_SCHEMA_VERSION: i32 = 19;
 
 /// Apply PG_SCHEMA_SQL to a pool. PostgreSQL's prepared-statement protocol
 /// rejects multi-statement strings ("cannot insert multiple commands into a
@@ -1040,6 +1042,23 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
         tracing::info!("PG migration 18: plans.grant_all_groups + plan_device_groups table");
+    }
+
+    // ── Revision 19: v1.0.7 device-group hidden flag ──
+    // Mirrors SQLite Migration 36. ADD COLUMN IF NOT EXISTS so a FRESH database
+    // (which already has hidden from the baseline) replays this arm as a no-op.
+    if current < 19 {
+        sqlx::query(
+            "ALTER TABLE device_groups ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO schema_version (version) VALUES (19) ON CONFLICT (version) DO NOTHING",
+        )
+        .execute(pool)
+        .await?;
+        tracing::info!("PG migration 19: device_groups.hidden column present");
     }
 
     Ok(())

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -389,6 +389,7 @@ pub trait GroupRepository: Send + Sync {
         connect_host: &str,
         port_range: &str,
         rate: f64,
+        hidden: bool,
     ) -> Result<(), DbError>;
     async fn find_by_token_after_insert(&self, token: &str)
         -> Result<Option<DeviceGroup>, DbError>;
@@ -402,6 +403,7 @@ pub trait GroupRepository: Send + Sync {
         connect_host: Option<&str>,
         port_range: Option<&str>,
         rate: Option<f64>,
+        hidden: Option<bool>,
     ) -> Result<u64, DbError>;
     async fn update_group_token(
         &self,

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -1335,7 +1335,13 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
     // Hides a group from regular users' shared views (node status / available
     // lines) without affecting admins. Idempotent: add_column_if_missing.
     // Default 0 keeps every existing group visible.
-    add_column_if_missing(pool, "device_groups", "hidden", "INTEGER NOT NULL DEFAULT 0").await?;
+    add_column_if_missing(
+        pool,
+        "device_groups",
+        "hidden",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+    .await?;
     tracing::info!("Migration 36: device_groups.hidden column present");
 
     Ok(())

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -88,6 +88,10 @@ CREATE TABLE IF NOT EXISTS device_groups (
     -- on forward_rules / users; users are CHARGED `real * rate` (rounded).
     -- Default 1.0 = bill what you use. Range 0.1..=100 enforced at the API.
     rate REAL NOT NULL DEFAULT 1.0,
+    -- v1.0.7: hide this group from regular users' shared views (node status /
+    -- available lines). 1 = hidden. Admins are unaffected (they read /groups,
+    -- not the shared endpoints). Default 0 keeps existing groups visible.
+    hidden INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -1326,6 +1330,13 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
     .execute(pool)
     .await?;
     tracing::info!("Migration 35: plans.grant_all_groups + plan_device_groups table");
+
+    // ── Migration 36: v1.0.7 device-group hidden flag ──
+    // Hides a group from regular users' shared views (node status / available
+    // lines) without affecting admins. Idempotent: add_column_if_missing.
+    // Default 0 keeps every existing group visible.
+    add_column_if_missing(pool, "device_groups", "hidden", "INTEGER NOT NULL DEFAULT 0").await?;
+    tracing::info!("Migration 36: device_groups.hidden column present");
 
     Ok(())
 }

--- a/crates/panel/src/db/sqlite_repo/groups.rs
+++ b/crates/panel/src/db/sqlite_repo/groups.rs
@@ -34,8 +34,12 @@ impl GroupRepository for SqliteRepository {
         // enforces admin ownership so a regular user's group is never exposed
         // as "shared". group_type uses the stable machine value 'in' (the old
         // LIKE 'inbound%' never matched — group_type is 'in' / 'out' / 'monitor').
+        // v1.0.7: `g.hidden` is SELECTED (not filtered here) so the caller
+        // decides. Only the node-status path (`list_shared_node_summary`) hides
+        // it; the rule dropdown / shop still list hidden groups so existing and
+        // new rules keep working. Admins get [] above and are unaffected.
         let groups: Vec<SharedGroupSummary> = sqlx::query_as(
-            "SELECT g.id, g.name, g.group_type, g.connect_host, g.capabilities, g.region, g.line_type \
+            "SELECT g.id, g.name, g.group_type, g.connect_host, g.capabilities, g.region, g.line_type, g.hidden \
              FROM device_groups g \
              JOIN users u ON u.id = g.uid \
              WHERE g.uid != ? AND u.admin = 1 AND g.group_type = 'in' \
@@ -97,10 +101,11 @@ impl GroupRepository for SqliteRepository {
         connect_host: &str,
         port_range: &str,
         rate: f64,
+        hidden: bool,
     ) -> Result<(), DbError> {
         sqlx::query(
-            "INSERT INTO device_groups (name, group_type, token, uid, connect_host, port_range, rate) \
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO device_groups (name, group_type, token, uid, connect_host, port_range, rate, hidden) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(name)
         .bind(group_type)
@@ -109,6 +114,7 @@ impl GroupRepository for SqliteRepository {
         .bind(connect_host)
         .bind(port_range)
         .bind(rate)
+        .bind(hidden)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -137,6 +143,7 @@ impl GroupRepository for SqliteRepository {
         connect_host: Option<&str>,
         port_range: Option<&str>,
         rate: Option<f64>,
+        hidden: Option<bool>,
     ) -> Result<u64, DbError> {
         // Token is NOT updatable here (rotation is a separate endpoint). Build
         // the SET clause from the present fields; binding order matches below.
@@ -155,6 +162,9 @@ impl GroupRepository for SqliteRepository {
         }
         if rate.is_some() {
             sets.push("rate = ?");
+        }
+        if hidden.is_some() {
+            sets.push("hidden = ?");
         }
 
         if sets.is_empty() {
@@ -182,6 +192,9 @@ impl GroupRepository for SqliteRepository {
             q = q.bind(v);
         }
         if let Some(v) = rate {
+            q = q.bind(v);
+        }
+        if let Some(v) = hidden {
             q = q.bind(v);
         }
         q = q.bind(id);

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -133,7 +133,11 @@ async fn shared_groups_carries_hidden_flag_and_still_lists_hidden() {
     // Regular user: BOTH groups are listed; the hidden one carries hidden=true
     // so the node-status path can drop it while the rule dropdown keeps it.
     let shared = db.list_shared_groups(2, false).await.unwrap();
-    assert_eq!(shared.len(), 2, "hidden group must STILL be listed for rules");
+    assert_eq!(
+        shared.len(),
+        2,
+        "hidden group must STILL be listed for rules"
+    );
     assert!(shared.iter().any(|g| g.id == 11 && g.hidden));
     assert!(shared.iter().any(|g| g.id == 10 && !g.hidden));
 
@@ -953,9 +957,18 @@ async fn rule_list_active_for_config_filters_banned_paused_overquota() {
 #[tokio::test]
 async fn group_insert_then_find_by_token_round_trip() {
     let db = repo().await;
-    db.insert_group("gin", "in", "tok-abc", 1, "1.2.3.4", "20000-30000", 1.0, false)
-        .await
-        .unwrap();
+    db.insert_group(
+        "gin",
+        "in",
+        "tok-abc",
+        1,
+        "1.2.3.4",
+        "20000-30000",
+        1.0,
+        false,
+    )
+    .await
+    .unwrap();
     let g = db.find_by_token("tok-abc").await.unwrap().unwrap();
     assert_eq!(g.name, "gin");
     assert_eq!(g.group_type, "in");

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -116,6 +116,37 @@ async fn shared_groups_excludes_other_regular_users_groups() {
     );
 }
 
+/// v1.0.7: list_shared_groups still RETURNS a hidden group (carrying the
+/// `hidden` flag) — the node-status handler is the only place that drops it,
+/// so the rule dropdown / shop keep listing hidden lines. Admins see it too.
+#[tokio::test]
+async fn shared_groups_carries_hidden_flag_and_still_lists_hidden() {
+    let db = repo().await; // uid=1 admin is seeded
+    seed_user(&db, 2, false).await; // alice (regular)
+    seed_group_typed(&db, 10, 1, "in").await; // admin-owned inbound, visible
+    seed_group_typed(&db, 11, 1, "in").await; // admin-owned inbound, to hide
+    sqlx::query("UPDATE device_groups SET hidden = 1 WHERE id = 11")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    // Regular user: BOTH groups are listed; the hidden one carries hidden=true
+    // so the node-status path can drop it while the rule dropdown keeps it.
+    let shared = db.list_shared_groups(2, false).await.unwrap();
+    assert_eq!(shared.len(), 2, "hidden group must STILL be listed for rules");
+    assert!(shared.iter().any(|g| g.id == 11 && g.hidden));
+    assert!(shared.iter().any(|g| g.id == 10 && !g.hidden));
+
+    // Admin: list_groups (unscoped) returns BOTH — hidden does not affect the
+    // admin management view.
+    let all = db.list_groups(&ResourceScope::All).await.unwrap();
+    assert!(
+        all.iter().any(|g| g.id == 11 && g.hidden),
+        "admin must still see the hidden group, flagged hidden=true"
+    );
+    assert!(all.iter().any(|g| g.id == 10 && !g.hidden));
+}
+
 /// An admin caller gets an empty shared list (admins manage groups directly).
 #[tokio::test]
 async fn shared_groups_empty_for_admin() {
@@ -922,7 +953,7 @@ async fn rule_list_active_for_config_filters_banned_paused_overquota() {
 #[tokio::test]
 async fn group_insert_then_find_by_token_round_trip() {
     let db = repo().await;
-    db.insert_group("gin", "in", "tok-abc", 1, "1.2.3.4", "20000-30000", 1.0)
+    db.insert_group("gin", "in", "tok-abc", 1, "1.2.3.4", "20000-30000", 1.0, false)
         .await
         .unwrap();
     let g = db.find_by_token("tok-abc").await.unwrap().unwrap();
@@ -954,7 +985,7 @@ async fn group_insert_then_find_by_token_round_trip() {
 #[tokio::test]
 async fn group_update_token_returns_rows_affected() {
     let db = repo().await;
-    db.insert_group("gin", "in", "tok-1", 1, "", "", 1.0)
+    db.insert_group("gin", "in", "tok-1", 1, "", "", 1.0, false)
         .await
         .unwrap();
     let g = db.find_by_token("tok-1").await.unwrap().unwrap();
@@ -2144,6 +2175,7 @@ async fn update_group_fields_owner_scope_rejects_wrong_owner() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2155,6 +2187,7 @@ async fn update_group_fields_owner_scope_rejects_wrong_owner() {
             10,
             &ResourceScope::Owner(3),
             Some("stolen"),
+            None,
             None,
             None,
             None,

--- a/crates/panel/src/service/groups.rs
+++ b/crates/panel/src/service/groups.rs
@@ -49,6 +49,7 @@ pub fn validate_rate(rate: f64) -> Option<f64> {
 /// v0.4.12 PR1: device groups are admin-managed shared infrastructure — the
 /// caller passes the creating admin's id as `owner_uid` (the handler ignores
 /// any client-supplied owner_uid).
+#[allow(clippy::too_many_arguments)]
 pub async fn create_group(
     db: &dyn Repository,
     name: &str,
@@ -57,6 +58,7 @@ pub async fn create_group(
     connect_host: &str,
     port_range: &str,
     rate: f64,
+    hidden: bool,
 ) -> Result<DeviceGroup, CreateGroupError> {
     let token = uuid::Uuid::new_v4().to_string();
     let group_type = group_type_to_str(group_type);
@@ -68,6 +70,7 @@ pub async fn create_group(
         connect_host,
         port_range,
         rate,
+        hidden,
     )
     .await
     .map_err(CreateGroupError::Database)?;
@@ -98,6 +101,7 @@ pub async fn rotate_group_token(db: &dyn Repository, id: i64) -> Result<Option<S
 /// Update an admin-owned device group. Enforces the no-fields guard and
 /// 404-on-zero-rows. The token is NOT updatable here (rotation is a separate
 /// endpoint).
+#[allow(clippy::too_many_arguments)]
 pub async fn update_group(
     db: &dyn Repository,
     id: i64,
@@ -106,12 +110,14 @@ pub async fn update_group(
     connect_host: Option<&str>,
     port_range: Option<&str>,
     rate: Option<f64>,
+    hidden: Option<bool>,
 ) -> Result<(), UpdateGroupError> {
     if name.is_none()
         && group_type.is_none()
         && connect_host.is_none()
         && port_range.is_none()
         && rate.is_none()
+        && hidden.is_none()
     {
         return Err(UpdateGroupError::NoFields);
     }
@@ -125,6 +131,7 @@ pub async fn update_group(
             connect_host,
             port_range,
             rate,
+            hidden,
         )
         .await
         .map_err(UpdateGroupError::Database)?

--- a/crates/shared/src/models.rs
+++ b/crates/shared/src/models.rs
@@ -127,6 +127,10 @@ pub struct DeviceGroup {
     /// on forward_rules / users; users are CHARGED `real * rate` (rounded) in
     /// apply_traffic_batch. 1.0 = bill what you use. Range 0.1..=100.
     pub rate: f64,
+    /// v1.0.7: hidden from regular users' shared views (node status / available
+    /// lines). Admins are unaffected. Default false.
+    #[serde(default)]
+    pub hidden: bool,
     pub created_at: String,
 }
 
@@ -143,6 +147,11 @@ pub struct SharedGroupSummary {
     pub capabilities: String,
     pub region: Option<String>,
     pub line_type: Option<String>,
+    /// v1.0.7: admin "hidden" flag. Carried here so the node-status path can
+    /// filter it out (regular users don't see hidden lines in node status),
+    /// while the rule dropdown / shop still list it. Default false.
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 /// v0.4.13 PR2 / v0.4.14 PR1: per-NODE availability + load metrics for a shared

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -837,6 +837,9 @@ pub struct CreateGroupRequest {
     /// clamps `None` to 1.0 and rejects out-of-range values with 400.
     #[serde(default)]
     pub rate: Option<f64>,
+    /// v1.0.7: hide this group from regular users' shared views. Default false.
+    #[serde(default)]
+    pub hidden: Option<bool>,
 }
 
 /// Update an existing group. All fields optional. Token is NOT updatable
@@ -850,6 +853,9 @@ pub struct UpdateGroupRequest {
     /// v1.0.8: billing rate. Range 0.1..=100 (validated at the handler).
     #[serde(default)]
     pub rate: Option<f64>,
+    /// v1.0.7: hide from regular users' shared views. None = leave unchanged.
+    #[serde(default)]
+    pub hidden: Option<bool>,
 }
 
 // === Admin API — Plans (v1.0.8) ===

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -115,6 +115,9 @@ export interface DeviceGroup {
   /** v1.0.8: traffic billing multiplier (0.1..=100, default 1.0). Users are
    *  charged real bytes * rate; rule/user byte counters stay real. */
   rate: number;
+  /** v1.0.7: hidden from regular users' shared views (node status / available
+   *  lines). Admins are unaffected. */
+  hidden?: boolean;
   created_at: string;
 }
 

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -191,6 +191,8 @@ export const enUS: Dict = {
   portRange: 'Port Range',
   rate: 'Rate',
   rateHint: 'User quota is charged at this rate; rule/node stats keep real bytes. 1.0 = bill as used.',
+  groupHidden: 'Hidden',
+  groupHiddenHint: "When on, this group is hidden only from regular users' Node Status page; admins are unaffected. Rules keep working (still selectable for new rules; existing rules forward and display normally).",
   inboundListener: 'Inbound (listener node)',
   outboundEgress: 'Outbound (egress node)',
   groupCreated: 'Group created. Copy the node token below.',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -190,6 +190,8 @@ export const zhCN = {
   portRange: '端口范围',
   rate: '倍率',
   rateHint: '用户额度按倍率扣减，规则/节点统计存真实字节。1.0 = 用多少扣多少。',
+  groupHidden: '隐藏',
+  groupHiddenHint: '开启后该分组仅在普通用户的「节点状态」页隐藏，管理员不受影响；规则照常使用（新建规则仍可选、已有规则正常转发与显示）。',
   inboundListener: '入口（监听节点）',
   outboundEgress: '出口（出口节点）',
   groupCreated: '分组已创建，请复制下方节点令牌',

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -1,4 +1,4 @@
-import { Table, Button, Modal, Form, Input, InputNumber, Select, Space, message, Popconfirm, Typography, Tag, Tooltip, Alert } from 'antd';
+import { Table, Button, Modal, Form, Input, InputNumber, Select, Space, message, Popconfirm, Typography, Tag, Tooltip, Alert, Switch } from 'antd';
 import { PlusOutlined, ReloadOutlined, CopyOutlined, EditOutlined, CloudServerOutlined, CodeOutlined, ApiOutlined } from '@ant-design/icons';
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import api from '../api/client';
@@ -70,11 +70,11 @@ export default function Groups() {
   const nodeCount = useCallback((groupId: number) => nodesByGroup(groupId).length, [nodesByGroup]);
   const onlineCount = useCallback((groupId: number) => nodesByGroup(groupId).filter(n => n.online).length, [nodesByGroup]);
 
-  const handleCreate = async (values: { name: string; group_type: string; connect_host: string; port_range: string; rate?: number; owner_uid?: number | null }) => {
+  const handleCreate = async (values: { name: string; group_type: string; connect_host: string; port_range: string; rate?: number; hidden?: boolean; owner_uid?: number | null }) => {
     try {
       // v1.0.8: rate defaults to 1.0 on the server when omitted; send it
       // explicitly so the value the admin picked is what gets persisted.
-      const payload = { ...values, rate: values.rate ?? 1.0, owner_uid: values.owner_uid || undefined };
+      const payload = { ...values, rate: values.rate ?? 1.0, hidden: values.hidden ?? false, owner_uid: values.owner_uid || undefined };
       const res = await api.post<unknown, ApiEnvelope<DeviceGroup>>('/groups', payload);
       if (res.code !== 0) { message.error(res.message); return; }
       message.success(t('groupCreated'));
@@ -86,11 +86,11 @@ export default function Groups() {
 
   const handleEdit = (g: DeviceGroup) => {
     setEditing(g);
-    editForm.setFieldsValue({ name: g.name, group_type: g.group_type, connect_host: g.connect_host, port_range: g.port_range, rate: g.rate });
+    editForm.setFieldsValue({ name: g.name, group_type: g.group_type, connect_host: g.connect_host, port_range: g.port_range, rate: g.rate, hidden: !!g.hidden });
     setEditOpen(true);
   };
 
-  const handleUpdate = async (values: { name?: string; group_type?: string; connect_host?: string; port_range?: string; rate?: number }) => {
+  const handleUpdate = async (values: { name?: string; group_type?: string; connect_host?: string; port_range?: string; rate?: number; hidden?: boolean }) => {
     if (!editing) return;
     const payload: Record<string, unknown> = {};
     if (values.name !== undefined && values.name !== editing.name) payload.name = values.name;
@@ -100,6 +100,8 @@ export default function Groups() {
     // v1.0.8: only send rate when it actually changed (avoid no-op 400s and
     // keep the diff-based payload pattern used for the other fields).
     if (values.rate !== undefined && values.rate !== editing.rate) payload.rate = values.rate;
+    // v1.0.7: only send hidden when it actually changed.
+    if (values.hidden !== undefined && values.hidden !== !!editing.hidden) payload.hidden = values.hidden;
     if (Object.keys(payload).length === 0) { setEditOpen(false); return; }
     try {
       const res = await api.put<unknown, ApiEnvelope<null>>(`/groups/${editing.id}`, payload);
@@ -227,6 +229,12 @@ export default function Groups() {
       },
     },
     {
+      // v1.0.7: hidden flag — only tag when hidden, to keep the column quiet.
+      title: t('groupHidden'), dataIndex: 'hidden', key: 'hidden', width: 80,
+      render: (hidden: boolean) =>
+        hidden ? <Tag>{t('yes')}</Tag> : <span style={{ color: 'var(--rp-text-tertiary)' }}>-</span>,
+    },
+    {
       title: t('action'), key: 'action', width: 120,
       render: (_: unknown, g: DeviceGroup) => (
         <Space>
@@ -313,6 +321,11 @@ export default function Groups() {
           <Form.Item name="rate" label={t('rate')} initialValue={1.0} extra={t('rateHint')} rules={[{ required: true }]}>
             <InputNumber min={0.1} max={100} step={0.1} style={{ width: '100%' }} />
           </Form.Item>
+          {/* v1.0.7: hide this group from regular users' node-status / available
+              lines. Admins always see it. */}
+          <Form.Item name="hidden" label={t('groupHidden')} valuePropName="checked" initialValue={false} extra={t('groupHiddenHint')}>
+            <Switch />
+          </Form.Item>
         </Form>
       </Modal>
 
@@ -324,6 +337,9 @@ export default function Groups() {
           <Form.Item name="port_range" label={t('portRange')}><Input /></Form.Item>
           <Form.Item name="rate" label={t('rate')} extra={t('rateHint')}>
             <InputNumber min={0.1} max={100} step={0.1} style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="hidden" label={t('groupHidden')} valuePropName="checked" extra={t('groupHiddenHint')}>
+            <Switch />
           </Form.Item>
         </Form>
       </Modal>

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -50,7 +50,7 @@ function payloadWithTargets<T extends Record<string, unknown>>(values: T & { tar
  *  Enabled targets only. IPv6 wrapped as [addr]:port.
  *  v1.0.6: always emit a JSON array (even for a single rule) so the export
  *  round-trips into the import box, which documents the `[{...}]` array form.
- *  v1.0.10: emit COMPACT single-line JSON (no pretty-printing) so the export is
+ *  v1.0.7: emit COMPACT single-line JSON (no pretty-printing) so the export is
  *  exactly the one-line `[{"dest":[...],"listen_port":...,"name":"..."}]` shape
  *  shown in the import hint — ready to copy-paste straight back in. */
 function buildExportJSON(rules: ForwardRule[]): string {
@@ -612,7 +612,7 @@ const IMPORT_DEFAULTS = {
 
   const hostForForm = (gid?: number) => {
     if (!gid) return '';
-    // v1.0.10: a regular user doesn't own the admin device groups, so `groups`
+    // v1.0.7: a regular user doesn't own the admin device groups, so `groups`
     // is empty for them — resolve the connect host from the merged groupInfo
     // (which also folds in their authorized shared groups) instead.
     return groupInfo.get(gid)?.connect_host ?? '';

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -102,7 +102,7 @@ export default function Users() {
   const planName = (id: number | null): string =>
     id == null ? t('noPlan') : (plans.find(p => p.id === id)?.name ?? `#${id}`);
 
-  // v1.0.10: plan management is embedded in the edit-user modal, so these act on
+  // v1.0.7: plan management is embedded in the edit-user modal, so these act on
   // the `editing` user. Admin assigns a plan, charging the user's balance.
   const handleBuyPlanForUser = async () => {
     if (!editing || planChoice == null) return;
@@ -142,7 +142,7 @@ export default function Users() {
 
   const openEdit = async (u: User) => {
     setEditing(u);
-    // v1.0.10: preload the embedded plan panel (assign choice + expiry picker).
+    // v1.0.7: preload the embedded plan panel (assign choice + expiry picker).
     setPlanChoice(undefined);
     setPlanExpire(u.plan_expire_at ? dayjs(u.plan_expire_at) : null);
     form.setFieldsValue({
@@ -484,7 +484,7 @@ export default function Users() {
           )}
         </Form>
 
-        {/* v1.0.10: plan management embedded in the edit-user modal (non-admin
+        {/* v1.0.7: plan management embedded in the edit-user modal (non-admin
             only). Assign a plan (charges balance), adjust expiry, or remove the
             plan. These act outside the form and refresh the list on success. */}
         {editing && !editing.admin && (


### PR DESCRIPTION
## 设备分组「隐藏」功能

管理员可把某个设备分组对普通用户的**节点状态页**隐藏,但**不影响规则**:规则下拉/商店仍可选,已有规则正常转发与显示,管理员完全不受影响。

### 改动
- **schema**:`device_groups.hidden`(sqlite Migration 36 / pg Revision 19,PG_SCHEMA_VERSION 18→19),幂等 add-column,默认 0/false
- **models/protocol**:`DeviceGroup.hidden`、`SharedGroupSummary.hidden`、`Create/UpdateGroupRequest.hidden`
- **repo/service/admin API**:`insert_group` / `update_group_fields` 透传 hidden;`list_shared_groups` 取出 hidden 但**不**在此过滤
- **api/groups**:仅在 `list_shared_node_summary`(节点状态页路径)过滤 `!hidden` —— 唯一生效点
- **frontend**:Groups 创建/编辑加隐藏 Switch + 列表列 + i18n
- **tests**:`list_shared_groups` 仍返回隐藏组并携带 `hidden=true`(sqlite + pg)

### 验证
- cargo test 356 通过,clippy 干净
- 前端 tsc / eslint 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)