### PR TITLE
fix(deploy): start postgres on fresh interactive embedded-PostgreSQL install

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -201,6 +201,13 @@ else
                 ;;
             2)
                 info "Selected: PostgreSQL (embedded Docker)"
+                # v1.0.7 fix: set the SHELL var (not just .env) so this same run's
+                # pre-flight (2c) and profile decision (step 3) actually start the
+                # postgres container + add --profile postgres. Without this, a fresh
+                # interactive PG install wrote embedded-postgres to .env but left the
+                # shell var empty, so postgres never started and the panel crash-looped
+                # ("Panel did not become reachable") trying to resolve host `postgres`.
+                RELAYPANEL_DB_MODE=embedded-postgres
                 printf "  Database name [relaypanel]: "
                 read -r PG_DB
                 PG_DB="${PG_DB:-relaypanel}"


### PR DESCRIPTION
## Bug

全新安装时通过交互菜单选 **PostgreSQL(嵌入式)**,panel 启动后 crash-loop:

```
Failed to initialize PostgreSQL database: ... failed to lookup address information: Name or service not known
[FAIL] Panel did not become reachable in 60s.
```

## 根因

deploy.sh 全新安装的交互分支(选 PG)把 `RELAYPANEL_DB_MODE=embedded-postgres` **只写进 .env,没设成 shell 变量**。导致同一次运行里:

- 预启动(2c)`case "${RELAYPANEL_DB_MODE:-}"` 不匹配 → **postgres 容器没启动**
- profile 决策(step 3)`if [ ... = "embedded-postgres" ]` 不成立 → **没加 `--profile postgres`**

于是 postgres 容器从不启动,panel 解析不了服务名 `postgres` → 崩溃。`RELAYPANEL_DB_MODE=embedded-postgres ./deploy.sh` 不受影响(调用者设了 shell 变量),所以只有**交互选 PG 的全新安装**会中招。

## 修复

在交互 PG 分支补一行 `RELAYPANEL_DB_MODE=embedded-postgres`(设 shell 变量,不只是写 .env)。

## 影响 / 发版

install.sh 克隆 `main`,deploy.sh **不在 Docker 镜像里**——合进 main 即对所有新安装生效,**无需 bump 版本或重建镜像**。已在一台日本机实测复现 + 手动 `--profile postgres` 修复确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)