### PR TITLE
feat(plans): purchase authorization REPLACE semantics + downgrade fix + i18n

### DIFF
--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -1301,8 +1301,24 @@ mod tests {
         let connections = Arc::new(ConnectionTracker::new());
         let mut mgr = ForwarderManager::new(counter.clone(), connections.clone());
 
+        // v1.0.8: use a port not shared with any other test in this file.
+        // `cargo test` runs #[tokio::test] fns in parallel by default, and this
+        // test previously hardcoded port 40001 — the SAME port used by
+        // `raw_tcp_and_udp_are_scheduled`, `tcp_udp_to_tcp_does_not_prune_
+        // surviving_rule_counter`, and `dead_listener_prunes_counter_when_
+        // rule_removed`. When two of those tests overlapped in time, one lost
+        // the OS-level bind race on 40001 for BOTH the v4 and v6 listener, hit
+        // the "no listener bound on port" branch, and never inserted a
+        // `self.listeners` entry at all. The `mgr.listeners.get(&key)` below
+        // then found nothing, silently skipping the abort/prune path entirely
+        // — so the manually-primed counter entry for rule 1 was never touched
+        // and the final assertion failed. This was the actual flake (not a
+        // timing issue with is_finished(), despite what an earlier fix here
+        // assumed) — confirmed by port collision, not the spin loop below.
+        // Fix: give each of the 4 tests its own port (40001/40003/40004/40005).
+        //
         // Apply a config with one rule.
-        mgr.apply_config(&one_rule(40001, Protocol::Tcp, NodeTransport::Raw))
+        mgr.apply_config(&one_rule(40003, Protocol::Tcp, NodeTransport::Raw))
             .await;
         // Simulate traffic: accumulate bytes for rule 1.
         counter.add(1, 100, 50).await;
@@ -1313,13 +1329,11 @@ mod tests {
         // checks is_finished() and won't be detected as dead.
         //
         // abort() only REQUESTS cancellation; the task isn't actually finished
-        // until the runtime polls it once more. On a busy CI runner the gap
-        // between abort() and the task settling made apply_config's
-        // is_finished() check race (it saw the task as still alive, skipped the
-        // dead-listener path, and the counter was never pruned → flaky FAIL).
-        // Spin on is_finished(), yielding so the runtime drives the cancelled
-        // task to completion, before applying the empty config.
-        let key = (40001, Protocol::Tcp, NodeTransport::Raw);
+        // until the runtime polls it once more. Spin on is_finished(), yielding
+        // so the runtime drives the cancelled task to completion, before
+        // applying the empty config. (This spin is still correct defensive
+        // practice even though it wasn't the source of the observed flake.)
+        let key = (40003, Protocol::Tcp, NodeTransport::Raw);
         if let Some(m) = mgr.listeners.get(&key) {
             m.handle.abort();
             while !m.handle.is_finished() {
@@ -1341,6 +1355,10 @@ mod tests {
     /// When a tcp_udp rule is changed to tcp-only (one listener removed), the
     /// remaining listener's counter must NOT be pruned — only the deleted
     /// listener is gone, but the rule itself still exists.
+    ///
+    /// v1.0.8: uses port 40004, dedicated to this test — see the port-collision
+    /// note in `deleted_rule_prunes_traffic_counter` above for why every test
+    /// in this file needs its own port.
     #[tokio::test]
     async fn tcp_udp_to_tcp_does_not_prune_surviving_rule_counter() {
         let counter = Arc::new(TrafficCounter::new());
@@ -1352,7 +1370,7 @@ mod tests {
             listeners: vec![
                 ListenerConfig {
                     rule_id: 1,
-                    port: 40001,
+                    port: 40004,
                     protocol: Protocol::Tcp,
                     node_transport: NodeTransport::Raw,
                     ws_path: None,
@@ -1363,7 +1381,7 @@ mod tests {
                 },
                 ListenerConfig {
                     rule_id: 1,
-                    port: 40001,
+                    port: 40004,
                     protocol: Protocol::Udp,
                     node_transport: NodeTransport::Raw,
                     ws_path: None,
@@ -1382,7 +1400,7 @@ mod tests {
         let tcp_cfg = NodeConfigResponse {
             listeners: vec![ListenerConfig {
                 rule_id: 1,
-                port: 40001,
+                port: 40004,
                 protocol: Protocol::Tcp,
                 node_transport: NodeTransport::Raw,
                 ws_path: None,
@@ -1403,6 +1421,9 @@ mod tests {
 
     /// A dead listener whose rule was also removed from the config must have
     /// its counter pruned, same as a normally-stopped listener.
+    ///
+    /// v1.0.8: uses port 40005, dedicated to this test — see the port-collision
+    /// note in `deleted_rule_prunes_traffic_counter` above.
     #[tokio::test]
     async fn dead_listener_prunes_counter_when_rule_removed() {
         let counter = Arc::new(TrafficCounter::new());
@@ -1410,12 +1431,12 @@ mod tests {
         let mut mgr = ForwarderManager::new(counter.clone(), connections.clone());
 
         // Apply config with rule 1.
-        mgr.apply_config(&one_rule(40001, Protocol::Tcp, NodeTransport::Raw))
+        mgr.apply_config(&one_rule(40005, Protocol::Tcp, NodeTransport::Raw))
             .await;
         counter.add(1, 50, 25).await;
 
         // Simulate a dead listener: abort its JoinHandle so is_finished() is true.
-        let key = (40001, Protocol::Tcp, NodeTransport::Raw);
+        let key = (40005, Protocol::Tcp, NodeTransport::Raw);
         if let Some(m) = mgr.listeners.get(&key) {
             m.handle.abort();
             // Briefly wait for the abort to propagate.

--- a/crates/panel/src/api/admin/groups.rs
+++ b/crates/panel/src/api/admin/groups.rs
@@ -35,7 +35,7 @@ pub async fn create_group(
     let rate = match req.rate {
         Some(r) => match validate_rate(r) {
             Some(v) => v,
-            None => return Json(err(400, "rate must be between 0.1 and 100")),
+            None => return Json(err(400, "倍率必须在 0.1 到 100 之间")),
         },
         None => RATE_DEFAULT,
     };
@@ -55,7 +55,7 @@ pub async fn create_group(
         Err(CreateGroupError::FetchFailed) => Json(err(500, "Failed to fetch created group")),
         Err(CreateGroupError::Database(e)) => {
             tracing::error!("create_group: db error: {}", e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -76,7 +76,7 @@ pub async fn rotate_group_token(
     Path(id): Path<i64>,
 ) -> Json<ApiResponse<RotatedToken>> {
     match crate::service::groups::rotate_group_token(state.db.as_ref(), id).await {
-        Ok(None) => Json(err(404, "Group not found")),
+        Ok(None) => Json(err(404, "分组不存在")),
         Ok(Some(new_token)) => {
             // v0.3.9: tear down every live WS connection for this group BEFORE
             // broadcasting. The old token just became invalid, but sockets that
@@ -107,7 +107,7 @@ pub async fn rotate_group_token(
                 id,
                 e
             );
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -122,7 +122,7 @@ pub async fn update_group(
     let rate = match req.rate {
         Some(r) => match validate_rate(r) {
             Some(v) => Some(v),
-            None => return Json(err(400, "rate must be between 0.1 and 100")),
+            None => return Json(err(400, "倍率必须在 0.1 到 100 之间")),
         },
         None => None,
     };
@@ -145,12 +145,12 @@ pub async fn update_group(
                 .await;
             Json(ApiResponse::success(()))
         }
-        Err(UpdateGroupError::NoFields) => Json(err(400, "No fields to update")),
+        Err(UpdateGroupError::NoFields) => Json(err(400, "无需要更新的字段")),
         // v0.3.6: 0 rows = group id didn't exist. 404 + no broadcast.
         Err(UpdateGroupError::NotFound) => Json(err(404, "Group not found")),
         Err(UpdateGroupError::Database(e)) => {
             tracing::error!("update_group {}: update_group_fields failed: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -161,7 +161,7 @@ pub async fn delete_group(
     Path(id): Path<i64>,
 ) -> Json<ApiResponse<()>> {
     match crate::service::groups::delete_group(state.db.as_ref(), id).await {
-        Ok(false) => Json(err(404, "Not found")),
+        Ok(false) => Json(err(404, "分组不存在")),
         Ok(true) => {
             tracing::warn!(
                 action = "delete_group",
@@ -191,7 +191,7 @@ pub async fn delete_group(
                 ));
             }
             tracing::error!("delete_group {}: delete_group failed: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }

--- a/crates/panel/src/api/admin/password.rs
+++ b/crates/panel/src/api/admin/password.rs
@@ -39,21 +39,21 @@ pub async fn reset_user_password(
         Ok(v) => v,
         Err(e) => {
             tracing::error!("reset_user_password {}: exists lookup failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if !exists {
-        return Json(err(404, "User not found"));
+        return Json(err(404, "用户不存在"));
     }
     let target_is_admin = match state.db.is_admin(id).await {
         Ok(v) => v,
         Err(e) => {
             tracing::error!("reset_user_password {}: is_admin lookup failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if target_is_admin && id != admin.user_id {
-        return Json(err(403, "Cannot reset another admin's password"));
+        return Json(err(403, "无法重置其他管理员的密码"));
     }
 
     let new_hash = match hash_password(&req.new_password) {
@@ -66,7 +66,7 @@ pub async fn reset_user_password(
         .admin_reset_password(id, &new_hash, req.must_change_password)
         .await
     {
-        Ok(0) => Json(err(404, "User not found")),
+        Ok(0) => Json(err(404, "用户不存在")),
         Ok(_) => {
             // Audit: actor + target + must_change flag. NEVER log the password
             // or its hash.
@@ -85,7 +85,7 @@ pub async fn reset_user_password(
                 id,
                 e
             );
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -104,11 +104,11 @@ pub async fn reset_user_traffic(
         Ok(v) => v,
         Err(e) => {
             tracing::error!("reset_user_traffic {}: exists lookup failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if !exists {
-        return Json(err(404, "User not found"));
+        return Json(err(404, "用户不存在"));
     }
 
     // Atomic: both updates in one transaction inside the repository. If either
@@ -126,7 +126,7 @@ pub async fn reset_user_traffic(
         }
         Err(e) => {
             tracing::error!("reset_user_traffic {}: reset_traffic failed: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -160,7 +160,7 @@ pub async fn get_me(user: AuthUser, State(state): State<AppState>) -> Json<ApiRe
         Ok(None) => {
             return Json(ApiResponse {
                 code: 404,
-                message: "User not found".into(),
+                message: "用户不存在".into(),
                 data: None,
             })
         }
@@ -168,7 +168,7 @@ pub async fn get_me(user: AuthUser, State(state): State<AppState>) -> Json<ApiRe
             tracing::error!("get_me {}: find_by_id failed: {}", user.user_id, e);
             return Json(ApiResponse {
                 code: 500,
-                message: "database error".into(),
+                message: "数据库错误".into(),
                 data: None,
             });
         }
@@ -196,7 +196,7 @@ pub async fn get_me(user: AuthUser, State(state): State<AppState>) -> Json<ApiRe
                 );
                 return Json(ApiResponse {
                     code: 500,
-                    message: "database error".into(),
+                    message: "数据库错误".into(),
                     data: None,
                 });
             }
@@ -243,14 +243,14 @@ pub async fn change_password(
     // Fetch the user's current password hash
     let current_hash = match state.db.find_password_by_id(user.user_id).await {
         Ok(Some(h)) => h,
-        Ok(None) => return Json(err(404, "User not found")),
+        Ok(None) => return Json(err(404, "用户不存在")),
         Err(e) => {
             tracing::error!(
                 "change_password {}: find_password_by_id failed: {}",
                 user.user_id,
                 e
             );
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
 
@@ -282,7 +282,7 @@ pub async fn change_password(
                 user.user_id,
                 e
             );
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }

--- a/crates/panel/src/api/admin/plans.rs
+++ b/crates/panel/src/api/admin/plans.rs
@@ -40,35 +40,35 @@ fn validate_plan_fields(
     if let Some(n) = name {
         let trimmed = n.trim();
         if name_required && trimmed.is_empty() {
-            return Err("name must not be empty".into());
+            return Err("名称不能为空".into());
         }
         if trimmed.len() > 100 {
-            return Err("name must be at most 100 characters".into());
+            return Err("名称不能超过100个字符".into());
         }
     }
     if let Some(mr) = max_rules {
         if !(0..=100_000).contains(&mr) {
-            return Err("max_rules must be between 0 and 100000".into());
+            return Err("max_rules 必须在 0 到 100000 之间".into());
         }
     }
     if let Some(t) = traffic {
         if t < 0 {
-            return Err("traffic must be non-negative".into());
+            return Err("流量必须为非负数".into());
         }
     }
     if let Some(pt) = plan_type {
         if pt != "data" && pt != "time" {
-            return Err("plan_type must be 'data' or 'time'".into());
+            return Err("套餐类型必须是 data 或 time".into());
         }
     }
     if let Some(dd) = duration_days {
         if dd < 0 {
-            return Err("duration_days must be non-negative".into());
+            return Err("时长天数必须为非负数".into());
         }
         // A time plan with duration_days=0 makes no sense; reject it at write
         // time so the shop never offers an instantly-expiring plan.
         if plan_type == Some("time") && dd == 0 {
-            return Err("duration_days must be > 0 for time plans".into());
+            return Err("限时套餐的时长天数必须大于 0".into());
         }
     }
     // price is a decimal string — canonicalize via the balance parser (same
@@ -155,7 +155,7 @@ pub async fn create_plan(
         Ok(id) => id,
         Err(e) => {
             tracing::error!("create_plan: db error: {}", e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
 
@@ -170,7 +170,7 @@ pub async fn create_plan(
         .await
     {
         tracing::error!("create_plan {}: set_plan_device_groups failed: {}", id, e);
-        return Json(err(500, "database error"));
+        return Json(err(500, "数据库错误"));
     }
 
     Json(ApiResponse::success(id))
@@ -194,7 +194,7 @@ pub async fn update_plan(
         && req.grant_all_groups.is_none()
         && req.device_group_ids.is_none()
     {
-        return Json(err(400, "No fields to update"));
+        return Json(err(400, "无需要更新的字段"));
     }
 
     // v1.0.8: when plan_type is being changed to 'time' in this same request,
@@ -222,18 +222,18 @@ pub async fn update_plan(
     // duration_days untouched (None) by reading the existing row.
     if let Some("time") = effective_plan_type {
         if req.duration_days == Some(0) {
-            return Json(err(400, "duration_days must be > 0 for time plans"));
+            return Json(err(400, "限时套餐的时长天数必须大于 0"));
         }
         if req.duration_days.is_none() {
             // Caller set plan_type=time without duration_days — verify the
             // existing row's duration_days is > 0 before flipping.
             match state.db.find_plan_by_id(id).await {
                 Ok(Some(p)) if p.duration_days > 0 => {}
-                Ok(Some(_)) => return Json(err(400, "duration_days must be > 0 for time plans")),
-                Ok(None) => return Json(err(404, "Plan not found")),
+                Ok(Some(_)) => return Json(err(400, "限时套餐的时长天数必须大于 0")),
+                Ok(None) => return Json(err(404, "套餐不存在")),
                 Err(e) => {
                     tracing::error!("update_plan {}: lookup failed: {}", id, e);
-                    return Json(err(500, "database error"));
+                    return Json(err(500, "数据库错误"));
                 }
             }
         }
@@ -273,21 +273,21 @@ pub async fn update_plan(
             )
             .await
         {
-            Ok(0) => return Json(err(404, "Plan not found")),
+            Ok(0) => return Json(err(404, "套餐不存在")),
             Ok(_) => {}
             Err(e) => {
                 tracing::error!("update_plan {}: db error: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
     } else {
         // Only a grant-set change: confirm the plan exists so we still 404.
         match state.db.find_plan_by_id(id).await {
             Ok(Some(_)) => {}
-            Ok(None) => return Json(err(404, "Plan not found")),
+            Ok(None) => return Json(err(404, "套餐不存在")),
             Err(e) => {
                 tracing::error!("update_plan {}: existence check failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
     }
@@ -297,7 +297,7 @@ pub async fn update_plan(
     if let Some(ref ids) = req.device_group_ids {
         if let Err(e) = state.db.set_plan_device_groups(id, ids).await {
             tracing::error!("update_plan {}: set_plan_device_groups failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     }
 
@@ -319,7 +319,7 @@ pub async fn delete_plan(
         Ok(n) => n,
         Err(e) => {
             tracing::error!("delete_plan {}: count_users_on_plan failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if in_use > 0 {
@@ -330,11 +330,11 @@ pub async fn delete_plan(
     }
 
     match state.db.delete_plan(id).await {
-        Ok(0) => Json(err(404, "Plan not found")),
+        Ok(0) => Json(err(404, "套餐不存在")),
         Ok(_) => Json(ApiResponse::success(())),
         Err(e) => {
             tracing::error!("delete_plan {}: db error: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }

--- a/crates/panel/src/api/admin/profiles.rs
+++ b/crates/panel/src/api/admin/profiles.rs
@@ -74,14 +74,14 @@ pub async fn create_tunnel_profile(
                 .await;
             Json(ApiResponse::success(p))
         }
-        Err(CreateProfileError::EmptyName) => Json(err(400, "name must not be empty")),
+        Err(CreateProfileError::EmptyName) => Json(err(400, "名称不能为空")),
         Err(CreateProfileError::InvalidTransport) => {
-            Json(err(400, "transport must be one of: ws, tls_simple"))
+            Json(err(400, "传输协议必须是以下之一: ws, tls_simple"))
         }
-        Err(CreateProfileError::FetchFailed) => Json(err(500, "Failed to fetch created profile")),
+        Err(CreateProfileError::FetchFailed) => Json(err(500, "获取创建的模板失败")),
         Err(CreateProfileError::Database(e)) => {
             tracing::error!("create_tunnel_profile: db error: {}", e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -111,12 +111,10 @@ pub async fn update_tunnel_profile(
                 .await;
             Json(ApiResponse::success(()))
         }
-        Err(UpdateProfileError::NotFound) => Json(err(404, "Profile not found")),
-        Err(UpdateProfileError::BuiltinReadOnly) => {
-            Json(err(400, "Builtin profiles cannot be edited"))
-        }
+        Err(UpdateProfileError::NotFound) => Json(err(404, "模板不存在")),
+        Err(UpdateProfileError::BuiltinReadOnly) => Json(err(400, "内置模板不可编辑")),
         Err(UpdateProfileError::InvalidTransport) => {
-            Json(err(400, "transport must be one of: ws, tls_simple"))
+            Json(err(400, "传输协议必须是以下之一: ws, tls_simple"))
         }
         // v0.4.8 fix: a transport change must stay compatible with every rule
         // already bound to this profile — surface a concrete count + protocol so
@@ -130,10 +128,10 @@ pub async fn update_tunnel_profile(
                 ),
             ))
         }
-        Err(UpdateProfileError::NoFields) => Json(err(400, "No fields to update")),
+        Err(UpdateProfileError::NoFields) => Json(err(400, "无需要更新的字段")),
         Err(UpdateProfileError::Database(e)) => {
             tracing::error!("update_tunnel_profile {}: db error: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -156,10 +154,8 @@ pub async fn delete_tunnel_profile(
                 .await;
             Json(ApiResponse::success(()))
         }
-        Err(DeleteProfileError::NotFound) => Json(err(404, "Profile not found")),
-        Err(DeleteProfileError::BuiltinReadOnly) => {
-            Json(err(400, "Builtin profiles cannot be deleted"))
-        }
+        Err(DeleteProfileError::NotFound) => Json(err(404, "模板不存在")),
+        Err(DeleteProfileError::BuiltinReadOnly) => Json(err(400, "内置模板不可删除")),
         // HTTP 200 + body code (same convention as other err() returns) so the
         // frontend's res.code path surfaces the message.
         Err(DeleteProfileError::InUse(usage)) => {
@@ -167,7 +163,7 @@ pub async fn delete_tunnel_profile(
         }
         Err(DeleteProfileError::Database(e)) => {
             tracing::error!("delete_tunnel_profile {}: db error: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }

--- a/crates/panel/src/api/admin/rules.rs
+++ b/crates/panel/src/api/admin/rules.rs
@@ -49,7 +49,7 @@ pub async fn create_rule(
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("create_rule: restriction lookup failed: {}", e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
         if restricted {
@@ -57,14 +57,11 @@ pub async fn create_rule(
                 Ok(a) => a,
                 Err(e) => {
                     tracing::error!("create_rule: authz lookup failed: {}", e);
-                    return Json(err(500, "database error"));
+                    return Json(err(500, "数据库错误"));
                 }
             };
             if !allowed.contains(&req.device_group_in) {
-                return Json(err(
-                    403,
-                    "device_group_in is not in your allowed device groups",
-                ));
+                return Json(err(403, "device_group_in 不在您允许的分组列表中"));
             }
         }
     }
@@ -81,14 +78,11 @@ pub async fn create_rule(
         Err(CreateRuleError::BadRequest(msg)) => Json(err(400, msg)),
         Err(CreateRuleError::PortConflict(port)) => Json(err(
             409,
-            format!(
-                "listen_port {} is already in use on this inbound group",
-                port
-            ),
+            format!("监听端口 {} 在此入口分组上已被占用", port),
         )),
         Err(CreateRuleError::Database(e)) => {
             tracing::error!("create_rule: service failed: {}", e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -108,7 +102,7 @@ pub async fn update_rule(
                 Ok(r) => r,
                 Err(e) => {
                     tracing::error!("update_rule: restriction lookup failed: {}", e);
-                    return Json(err(500, "database error"));
+                    return Json(err(500, "数据库错误"));
                 }
             };
             if restricted {
@@ -116,7 +110,7 @@ pub async fn update_rule(
                     Ok(a) => a,
                     Err(e) => {
                         tracing::error!("update_rule: authz lookup failed: {}", e);
-                        return Json(err(500, "database error"));
+                        return Json(err(500, "数据库错误"));
                     }
                 };
                 if !allowed.contains(&dgi) {
@@ -139,7 +133,7 @@ pub async fn update_rule(
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("update_rule: restriction lookup failed: {}", e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
         if restricted {
@@ -149,7 +143,7 @@ pub async fn update_rule(
                         Ok(a) => a,
                         Err(e) => {
                             tracing::error!("update_rule: authz lookup failed: {}", e);
-                            return Json(err(500, "database error"));
+                            return Json(err(500, "数据库错误"));
                         }
                     };
                     if !allowed.contains(&rule.device_group_in) {
@@ -159,10 +153,10 @@ pub async fn update_rule(
                         ));
                     }
                 }
-                Ok(None) => return Json(err(404, "Rule not found")),
+                Ok(None) => return Json(err(404, "规则不存在")),
                 Err(e) => {
                     tracing::error!("update_rule: rule lookup failed: {}", e);
-                    return Json(err(500, "database error"));
+                    return Json(err(500, "数据库错误"));
                 }
             }
         }
@@ -176,15 +170,12 @@ pub async fn update_rule(
             Json(ApiResponse::success(()))
         }
         Err(UpdateRuleError::BadRequest(msg)) => Json(err(400, msg)),
-        Err(UpdateRuleError::NotFound) => Json(err(404, "Rule not found")),
-        Err(UpdateRuleError::PortConflict) => Json(err(
-            409,
-            "listen_port is already in use on this inbound group",
-        )),
+        Err(UpdateRuleError::NotFound) => Json(err(404, "规则不存在")),
+        Err(UpdateRuleError::PortConflict) => Json(err(409, "监听端口在此入口分组上已被占用")),
         Err(UpdateRuleError::Internal(msg)) => Json(err(500, msg)),
         Err(UpdateRuleError::Database(e)) => {
             tracing::error!("update_rule {}: service failed: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -201,7 +192,7 @@ pub async fn delete_rule(
     match crate::service::groups::delete_rule(state.db.as_ref(), id, &scope).await {
         // v0.3.6: nothing existed at that id. Return 404 and do NOT broadcast
         // config_changed — a no-op delete shouldn't trigger a node re-fetch.
-        Ok(false) => Json(err(404, "Not found")),
+        Ok(false) => Json(err(404, "规则不存在")),
         Ok(true) => {
             tracing::warn!(
                 action = "delete_rule",
@@ -218,7 +209,7 @@ pub async fn delete_rule(
         }
         Err(e) => {
             tracing::error!("delete_rule {}: delete_rule failed: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }

--- a/crates/panel/src/api/admin/settings.rs
+++ b/crates/panel/src/api/admin/settings.rs
@@ -17,7 +17,7 @@ pub async fn get_registration_settings(
             Ok(s) => s,
             Err(e) => {
                 tracing::error!("get_registration_settings: db error: {}", e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
     Json(ApiResponse::success(settings))
@@ -41,25 +41,23 @@ pub async fn update_registration_settings(
         Ok(settings) => Json(ApiResponse::success(settings)),
         Err(e) => {
             let (code, msg): (i32, String) = match e {
-                RegistrationSettingsError::DefaultPlanMissing => {
-                    (400, "default plan does not exist".into())
-                }
+                RegistrationSettingsError::DefaultPlanMissing => (400, "默认套餐不存在".into()),
                 RegistrationSettingsError::AllowedPlansEmpty => {
-                    (400, "allowed_plan_ids must not be empty".into())
+                    (400, "允许注册的套餐列表不能为空".into())
                 }
                 RegistrationSettingsError::DefaultPlanNotInAllowed => {
-                    (400, "default_plan_id must be in allowed_plan_ids".into())
+                    (400, "默认套餐必须在允许注册的套餐列表中".into())
                 }
                 RegistrationSettingsError::AllowedPlanNotFound(id) => {
                     tracing::error!(
                         "update_registration_settings: allowed plan {} does not exist",
                         id
                     );
-                    (400, format!("plan {} does not exist", id))
+                    (400, format!("套餐 {} 不存在", id))
                 }
                 RegistrationSettingsError::Database(e) => {
                     tracing::error!("update_registration_settings: db error: {}", e);
-                    (500, "database error".into())
+                    (500, "数据库错误".into())
                 }
             };
             Json(err(code, msg))

--- a/crates/panel/src/api/admin/shop.rs
+++ b/crates/panel/src/api/admin/shop.rs
@@ -66,20 +66,20 @@ pub async fn buy_plan(
     // Hidden plans are not self-purchasable even if the caller knows the id.
     let plan = match state.db.find_plan_by_id(req.plan_id).await {
         Ok(Some(p)) => p,
-        Ok(None) => return Json(err(404, "Plan not found")),
+        Ok(None) => return Json(err(404, "套餐不存在")),
         Err(e) => {
             tracing::error!("buy_plan {}: plan lookup failed: {}", req.plan_id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if plan.hidden {
         // Don't reveal existence — same 404 as a missing plan.
-        return Json(err(404, "Plan not found"));
+        return Json(err(404, "套餐不存在"));
     }
     // A time plan must have a positive duration (the CRUD layer enforces this
     // too, but a pre-existing bad row shouldn't crash the purchase).
     if plan.plan_type == "time" && plan.duration_days <= 0 {
-        return Json(err(400, "This plan has no valid duration"));
+        return Json(err(400, "该套餐无有效时长"));
     }
 
     // Decimal money: compare + deduct in integer cents (no floats). price is
@@ -93,7 +93,7 @@ pub async fn buy_plan(
                 plan.id,
                 plan.price
             );
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
 
@@ -119,9 +119,28 @@ pub async fn buy_plan(
                     plan.id,
                     e
                 );
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
+    };
+
+    // v1.0.8: compute the new authorized set that will drive pause_rules_outside
+    // _groups inside buy_plan. grant_all_groups → all inbound groups (nothing
+    // paused), else the plan's own groups.
+    let new_authorized_group_ids: Vec<i64> = if plan.grant_all_groups {
+        match state.db.list_all_inbound_group_ids().await {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::error!(
+                    "buy_plan {}: list_all_inbound_group_ids failed: {}",
+                    plan.id,
+                    e
+                );
+                return Json(err(500, "数据库错误"));
+            }
+        }
+    } else {
+        device_group_ids.clone()
     };
 
     match state
@@ -137,6 +156,7 @@ pub async fn buy_plan(
             plan.reset_traffic,
             plan.grant_all_groups,
             &device_group_ids,
+            &new_authorized_group_ids,
         )
         .await
     {
@@ -153,7 +173,7 @@ pub async fn buy_plan(
         Err(BuyPlanError::InsufficientBalance) => Json(err(400, "余额不足")),
         Err(BuyPlanError::Database(e)) => {
             tracing::error!("buy_plan {}: db error: {}", plan.id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -167,7 +187,7 @@ pub async fn list_my_orders(
         Ok(o) => o,
         Err(e) => {
             tracing::error!("list_my_orders {}: db error: {}", user.user_id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     Json(ApiResponse::success(orders))

--- a/crates/panel/src/api/admin/users.rs
+++ b/crates/panel/src/api/admin/users.rs
@@ -56,13 +56,13 @@ pub async fn create_user(
             "Username must be 1-64 chars, ASCII letters/digits/underscore only",
         )),
         Err(CreateUserError::Password(PasswordValidationError::TooShort)) => {
-            Json(err(400, "Password must be at least 8 characters"))
+            Json(err(400, "密码至少8个字符"))
         }
         Err(CreateUserError::Password(PasswordValidationError::TooLong)) => {
-            Json(err(400, "Password must be at most 72 bytes"))
+            Json(err(400, "密码最多72字节"))
         }
         Err(CreateUserError::Hash(e)) => Json(err(500, format!("Failed to hash password: {}", e))),
-        Err(CreateUserError::DuplicateUsername) => Json(err(409, "Username already exists")),
+        Err(CreateUserError::DuplicateUsername) => Json(err(409, "用户名已存在")),
         Err(CreateUserError::DefaultPlanMissing) => {
             tracing::error!("create_user: default plan 1 is missing; no user created");
             Json(err(
@@ -72,7 +72,7 @@ pub async fn create_user(
         }
         Err(CreateUserError::Database(e)) => {
             tracing::error!("create_user: insert failed for {:?}: {}", req.username, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -89,7 +89,7 @@ pub async fn delete_user(
         Ok(v) => v,
         Err(e) => {
             tracing::error!("delete_user {}: is_admin lookup failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     // Also need to confirm the row exists (is_admin returns false for both
@@ -98,14 +98,11 @@ pub async fn delete_user(
         Ok(v) => v,
         Err(e) => {
             tracing::error!("delete_user {}: exists lookup failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if !exists || is_admin {
-        return Json(err(
-            404,
-            "User not found (or is an admin and cannot be deleted)",
-        ));
+        return Json(err(404, "用户不存在（或为管理员，无法删除）"));
     }
 
     // Atomic cascade delete: removes the user's rules, tunnel_profiles and
@@ -113,10 +110,7 @@ pub async fn delete_user(
     // admin guard baked in. Returns 0 (and rolls back) if the target is an admin
     // or no longer exists — so we never leave a half-deleted account.
     match state.db.delete_user_cascade(id).await {
-        Ok(0) => Json(err(
-            404,
-            "User not found (or is an admin and cannot be deleted)",
-        )),
+        Ok(0) => Json(err(404, "用户不存在（或为管理员，无法删除）")),
         Ok(_) => {
             tracing::warn!(
                 action = "delete_user",
@@ -128,7 +122,7 @@ pub async fn delete_user(
         }
         Err(e) => {
             tracing::error!("delete_user {}: cascade delete failed: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -154,18 +148,18 @@ pub async fn update_user(
         && req.all_device_groups.is_none()
         && req.device_group_ids.is_none()
     {
-        return Json(err(400, "No fields to update"));
+        return Json(err(400, "无需要更新的字段"));
     }
 
     // Clamp numeric inputs to sane ranges (prevent overflow / absurd values).
     if let Some(mr) = req.max_rules {
         if !(0..=100_000).contains(&mr) {
-            return Json(err(400, "max_rules must be between 0 and 100000"));
+            return Json(err(400, "max_rules 必须在 0 到 100000 之间"));
         }
     }
     if let Some(tl) = req.traffic_limit {
         if tl < 0 {
-            return Json(err(400, "traffic_limit must be non-negative"));
+            return Json(err(400, "流量限制必须为非负数"));
         }
     }
 
@@ -189,11 +183,11 @@ pub async fn update_user(
             Ok(v) => v,
             Err(e) => {
                 tracing::error!("update_user {}: is_admin lookup failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
         if is_admin {
-            return Json(err(400, "Cannot ban an admin user"));
+            return Json(err(400, "无法封禁管理员用户"));
         }
     }
 
@@ -203,11 +197,11 @@ pub async fn update_user(
             Ok(v) => v,
             Err(e) => {
                 tracing::error!("update_user {}: is_admin lookup failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
         if is_admin {
-            return Json(err(400, "Cannot suspend an admin user"));
+            return Json(err(400, "无法暂停管理员用户"));
         }
     }
 
@@ -233,7 +227,7 @@ pub async fn update_user(
             )
             .await
         {
-            Ok(0) => return Json(err(404, "User not found")),
+            Ok(0) => return Json(err(404, "用户不存在")),
             Ok(_) => {
                 if let Some(banned) = req.banned {
                     tracing::warn!(
@@ -258,7 +252,7 @@ pub async fn update_user(
             }
             Err(e) => {
                 tracing::error!("update_user {}: update_user_fields failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
     }
@@ -277,13 +271,13 @@ pub async fn update_user(
                 id,
                 e
             );
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     }
     if let Some(ref ids) = req.device_group_ids {
         if let Err(e) = state.db.set_user_device_groups(id, ids).await {
             tracing::error!("update_user {}: set_user_device_groups failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     }
     if authz_changed {
@@ -292,7 +286,7 @@ pub async fn update_user(
             Ok(a) => a,
             Err(e) => {
                 tracing::error!("update_user {}: authz lookup for pause failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
         match state.db.pause_rules_outside_groups(id, &allowed).await {
@@ -310,7 +304,7 @@ pub async fn update_user(
                     id,
                     e
                 );
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
     }
@@ -345,17 +339,17 @@ pub async fn get_user_device_groups(
     let all_device_groups =
         match crate::db::repo::UserRepository::find_by_id(state.db.as_ref(), id).await {
             Ok(Some(u)) => u.all_device_groups,
-            Ok(None) => return Json(err(404, "User not found")),
+            Ok(None) => return Json(err(404, "用户不存在")),
             Err(e) => {
                 tracing::error!("get_user_device_groups {}: find_by_id failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         };
     let device_group_ids = match state.db.list_user_device_groups(id).await {
         Ok(ids) => ids,
         Err(e) => {
             tracing::error!("get_user_device_groups {}: list failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     Json(ApiResponse::success(UserDeviceGroups {
@@ -379,25 +373,25 @@ pub async fn admin_buy_plan_for_user(
 ) -> Json<ApiResponse<()>> {
     // Target must exist and be a non-admin.
     match crate::db::repo::UserRepository::find_by_id(state.db.as_ref(), id).await {
-        Ok(Some(u)) if u.admin => return Json(err(400, "Cannot assign a plan to an admin user")),
+        Ok(Some(u)) if u.admin => return Json(err(400, "无法给管理员用户分配套餐")),
         Ok(Some(_)) => {}
-        Ok(None) => return Json(err(404, "User not found")),
+        Ok(None) => return Json(err(404, "用户不存在")),
         Err(e) => {
             tracing::error!("admin_buy_plan_for_user {}: find_by_id failed: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     }
 
     let plan = match state.db.find_plan_by_id(req.plan_id).await {
         Ok(Some(p)) => p,
-        Ok(None) => return Json(err(404, "Plan not found")),
+        Ok(None) => return Json(err(404, "套餐不存在")),
         Err(e) => {
             tracing::error!("admin_buy_plan_for_user: plan lookup failed: {}", e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
     if plan.plan_type == "time" && plan.duration_days <= 0 {
-        return Json(err(400, "This plan has no valid duration"));
+        return Json(err(400, "该套餐无有效时长"));
     }
 
     let price_cents = match relay_shared::money::balance_to_cents(&plan.price) {
@@ -408,7 +402,7 @@ pub async fn admin_buy_plan_for_user(
                 plan.id,
                 plan.price
             );
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     };
 
@@ -428,9 +422,26 @@ pub async fn admin_buy_plan_for_user(
                     "admin_buy_plan_for_user: list_plan_device_groups failed: {}",
                     e
                 );
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
+    };
+
+    // v1.0.8: compute the new authorized set (mirrors shop.rs buy_plan).
+    let new_authorized_group_ids: Vec<i64> = if plan.grant_all_groups {
+        match state.db.list_all_inbound_group_ids().await {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::error!(
+                    "admin_buy_plan_for_user {}: list_all_inbound_group_ids failed: {}",
+                    id,
+                    e
+                );
+                return Json(err(500, "数据库错误"));
+            }
+        }
+    } else {
+        device_group_ids.clone()
     };
 
     match state
@@ -446,6 +457,7 @@ pub async fn admin_buy_plan_for_user(
             plan.reset_traffic,
             plan.grant_all_groups,
             &device_group_ids,
+            &new_authorized_group_ids,
         )
         .await
     {
@@ -466,7 +478,7 @@ pub async fn admin_buy_plan_for_user(
         Err(BuyPlanError::InsufficientBalance) => Json(err(400, "余额不足")),
         Err(BuyPlanError::Database(e)) => {
             tracing::error!("admin_buy_plan_for_user {}: db error: {}", id, e);
-            Json(err(500, "database error"))
+            Json(err(500, "数据库错误"))
         }
     }
 }
@@ -489,22 +501,22 @@ pub async fn admin_set_user_plan(
         (None, None)
     } else {
         match crate::db::repo::UserRepository::find_by_id(state.db.as_ref(), id).await {
-            Ok(Some(u)) if u.admin => return Json(err(400, "Cannot edit an admin user's plan")),
+            Ok(Some(u)) if u.admin => return Json(err(400, "无法修改管理员用户的套餐")),
             Ok(Some(u)) => (u.plan_id, req.plan_expire_at.clone()),
-            Ok(None) => return Json(err(404, "User not found")),
+            Ok(None) => return Json(err(404, "用户不存在")),
             Err(e) => {
                 tracing::error!("admin_set_user_plan {}: find_by_id failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
     };
 
     match state.db.admin_set_user_plan(id, plan_id, expire).await {
-        Ok(0) => return Json(err(404, "User not found (or is an admin)")),
+        Ok(0) => return Json(err(404, "用户不存在（或为管理员）")),
         Ok(_) => {}
         Err(e) => {
             tracing::error!("admin_set_user_plan {}: db error: {}", id, e);
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
     }
 
@@ -521,7 +533,7 @@ pub async fn admin_set_user_plan(
                 id,
                 e
             );
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
         if let Err(e) = state.db.set_user_device_groups(id, &[]).await {
             tracing::error!(
@@ -529,7 +541,7 @@ pub async fn admin_set_user_plan(
                 id,
                 e
             );
-            return Json(err(500, "database error"));
+            return Json(err(500, "数据库错误"));
         }
         // Allowed set is now empty → pause ALL of the user's active rules.
         match state.db.pause_rules_outside_groups(id, &[]).await {
@@ -541,7 +553,7 @@ pub async fn admin_set_user_plan(
             Ok(_) => {}
             Err(e) => {
                 tracing::error!("admin_set_user_plan {}: pause rules failed: {}", id, e);
-                return Json(err(500, "database error"));
+                return Json(err(500, "数据库错误"));
             }
         }
     }

--- a/crates/panel/src/db/pg_repo/groups.rs
+++ b/crates/panel/src/db/pg_repo/groups.rs
@@ -272,4 +272,12 @@ impl GroupRepository for PgRepository {
             .await?;
         Ok(result.rows_affected())
     }
+
+    async fn list_all_inbound_group_ids(&self) -> Result<Vec<i64>, DbError> {
+        let rows: Vec<(i64,)> =
+            sqlx::query_as("SELECT id FROM device_groups WHERE group_type = 'in' ORDER BY id")
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
 }

--- a/crates/panel/src/db/pg_repo/settings.rs
+++ b/crates/panel/src/db/pg_repo/settings.rs
@@ -308,8 +308,13 @@ impl PlanRepository for PgRepository {
         .await?;
 
         // v1.0.8: grant device-group authorization in the SAME tx (mirrors the
-        // SQLite impl). Purchase REPLACES the user's authorization — old grants
-        // are cleared so rules bound to groups no longer in the plan are paused.
+        // SQLite impl). Purchase REPLACES the user's authorization — BOTH
+        // dimensions are reset so exactly the new plan's grant remains:
+        //   - grant_all_groups → set all_device_groups=TRUE AND clear explicit
+        //     user_device_groups rows.
+        //   - else → clear all_device_groups=FALSE AND replace user_device_groups.
+        //     Resetting the flag is the fix for the grant-all → per-group
+        //     downgrade case (without it the user stayed unrestricted).
         if grant_all_groups {
             sqlx::query(
                 "UPDATE users SET all_device_groups = TRUE WHERE id = $1 AND admin = FALSE",
@@ -317,8 +322,19 @@ impl PlanRepository for PgRepository {
             .bind(user_id)
             .execute(&mut *tx)
             .await?;
+            sqlx::query("DELETE FROM user_device_groups WHERE user_id = $1")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
         } else {
-            // REPLACE semantics: clear old assignments, then insert the plan's.
+            // REPLACE semantics: reset the all-groups flag, clear old explicit
+            // assignments, then insert the plan's.
+            sqlx::query(
+                "UPDATE users SET all_device_groups = FALSE WHERE id = $1 AND admin = FALSE",
+            )
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
             sqlx::query("DELETE FROM user_device_groups WHERE user_id = $1")
                 .bind(user_id)
                 .execute(&mut *tx)

--- a/crates/panel/src/db/pg_repo/settings.rs
+++ b/crates/panel/src/db/pg_repo/settings.rs
@@ -210,6 +210,9 @@ impl PlanRepository for PgRepository {
         reset_traffic: bool,
         grant_all_groups: bool,
         device_group_ids: &[i64],
+        // v1.0.8: the NEW authorized group set AFTER purchase. Used inside the
+        // transaction to pause rules outside this set (replacement semantics).
+        new_authorized_group_ids: &[i64],
     ) -> Result<(), BuyPlanError> {
         let mut tx = self.pool.begin().await?;
 
@@ -304,10 +307,9 @@ impl PlanRepository for PgRepository {
         .execute(&mut *tx)
         .await?;
 
-        // v1.0.9: grant device-group authorization in the SAME tx (mirrors the
-        // SQLite impl). grant_all_groups → set all_device_groups (admins left
-        // alone). Else APPEND the plan's groups via ON CONFLICT DO NOTHING —
-        // dedupes, never removes. Expiry does NOT revoke these.
+        // v1.0.8: grant device-group authorization in the SAME tx (mirrors the
+        // SQLite impl). Purchase REPLACES the user's authorization — old grants
+        // are cleared so rules bound to groups no longer in the plan are paused.
         if grant_all_groups {
             sqlx::query(
                 "UPDATE users SET all_device_groups = TRUE WHERE id = $1 AND admin = FALSE",
@@ -316,16 +318,56 @@ impl PlanRepository for PgRepository {
             .execute(&mut *tx)
             .await?;
         } else {
+            // REPLACE semantics: clear old assignments, then insert the plan's.
+            sqlx::query("DELETE FROM user_device_groups WHERE user_id = $1")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
             for dg_id in device_group_ids {
                 sqlx::query(
-                    "INSERT INTO user_device_groups (user_id, device_group_id) \
-                     VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                    "INSERT INTO user_device_groups (user_id, device_group_id) VALUES ($1, $2)",
                 )
                 .bind(user_id)
                 .bind(dg_id)
                 .execute(&mut *tx)
                 .await?;
             }
+        }
+
+        // Pause rules outside the new authorization (same logic as SQLite).
+        // Inline the pause logic inside the transaction (using &mut *tx) to
+        // avoid acquiring a separate pool connection while the transaction is
+        // still open — that would risk a pool-exhaustion deadlock.
+        let n = if new_authorized_group_ids.is_empty() {
+            let r = sqlx::query(
+                "UPDATE forward_rules SET paused = TRUE WHERE uid = $1 AND paused = FALSE",
+            )
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+            r.rows_affected()
+        } else {
+            let placeholders = (1..=new_authorized_group_ids.len())
+                .map(|i| format!("${}", i + 1))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "UPDATE forward_rules SET paused = TRUE \
+                 WHERE uid = $1 AND paused = FALSE AND device_group_in NOT IN ({})",
+                placeholders
+            );
+            let mut q = sqlx::query(&sql).bind(user_id);
+            for gid in new_authorized_group_ids {
+                q = q.bind(gid);
+            }
+            let r = q.execute(&mut *tx).await?;
+            r.rows_affected()
+        };
+        if n > 0 {
+            tracing::warn!(
+                "buy_plan: user {} purchased plan {}, {} rule(s) paused due to authorization change",
+                user_id, plan_id, n
+            );
         }
 
         tx.commit().await?;

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -3188,6 +3188,58 @@ async fn pg_buy_plan_grant_all_sets_flag() {
     cleanup(&db).await;
 }
 
+/// v1.0.8 regression (PG): downgrading from a grant-all plan to a per-group
+/// plan must RESET all_device_groups back to FALSE. Mirrors the SQLite test.
+#[tokio::test]
+async fn pg_buy_plan_grant_all_then_per_group_resets_all_flag() {
+    let Some(db) = repo("buy_grant_all_downgrade").await else {
+        return;
+    };
+    let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 52, alice).await;
+
+    // 1) Buy a grant-all plan → all_device_groups = TRUE.
+    db.buy_plan(alice, pid, "all", 100, 1000, 10, 0, false, true, &[], &[])
+        .await
+        .unwrap();
+    let all: (bool,) = sqlx::query_as("SELECT all_device_groups FROM users WHERE id = $1")
+        .bind(alice)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(all.0, "grant-all purchase must set the flag (PG)");
+
+    // 2) Downgrade to a per-group plan granting only {52}.
+    db.buy_plan(
+        alice,
+        pid,
+        "ltd",
+        100,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[52],
+        &[52],
+    )
+    .await
+    .unwrap();
+
+    let all: (bool,) = sqlx::query_as("SELECT all_device_groups FROM users WHERE id = $1")
+        .bind(alice)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(
+        !all.0,
+        "downgrade to a per-group plan must reset all_device_groups to FALSE (PG)"
+    );
+    assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![52]);
+    cleanup(&db).await;
+}
+
 /// v1.0.8: REPLACE semantics — buying a second (different) plan replaces the
 /// first plan's authorization rather than stacking it. Mirrors the SQLite
 /// test.

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -2769,9 +2769,21 @@ async fn pg_buy_plan_stacks_traffic_and_charges_balance() {
         .await
         .unwrap();
 
-    db.buy_plan(alice, pid, "p1", 3000, 1_000_000, 10, 0, false, false, &[])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        3000,
+        1_000_000,
+        10,
+        0,
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    .unwrap();
 
     let (balance, traffic_limit, max_rules, plan_id): (String, i64, i32, Option<i64>) =
         sqlx::query_as(
@@ -2808,9 +2820,21 @@ async fn pg_buy_plan_reset_traffic_zeros_usage() {
         .await
         .unwrap();
 
-    db.buy_plan(alice, pid, "p1", 1000, 1_000_000, 10, 0, true, false, &[])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        1000,
+        1_000_000,
+        10,
+        0,
+        true,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    .unwrap();
 
     let used: (i64,) = sqlx::query_as("SELECT traffic_used FROM users WHERE id = $1")
         .bind(alice)
@@ -2834,7 +2858,19 @@ async fn pg_buy_plan_insufficient_balance_is_rejected_and_rolls_back() {
         .unwrap();
 
     let err = db
-        .buy_plan(alice, pid, "p1", 3000, 1_000_000, 10, 0, false, false, &[])
+        .buy_plan(
+            alice,
+            pid,
+            "p1",
+            3000,
+            1_000_000,
+            10,
+            0,
+            false,
+            false,
+            &[],
+            &[],
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, BuyPlanError::InsufficientBalance));
@@ -2862,7 +2898,7 @@ async fn pg_buy_plan_time_plan_sets_future_expiry() {
     };
     let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 0, "5.00", 30, false).await;
 
-    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[])
+    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[], &[])
         .await
         .unwrap();
 
@@ -2897,7 +2933,7 @@ async fn pg_buy_plan_renewal_stacks_expiry_from_current_end() {
         .await
         .unwrap();
 
-    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[])
+    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[], &[])
         .await
         .unwrap();
 
@@ -3027,8 +3063,11 @@ async fn pg_plan_device_groups_round_trip_and_replace() {
     cleanup(&db).await;
 }
 
+/// v1.0.8: purchase REPLACES authorization, so a group the user already had
+/// that ALSO appears in the new plan's grant set must end up exactly once
+/// (mirrors the SQLite test).
 #[tokio::test]
-async fn pg_buy_plan_appends_device_groups_dedup_without_removing_existing() {
+async fn pg_buy_plan_new_authorized_set_has_no_duplicate_groups() {
     let Some(db) = repo("buy_dg_dedup").await else {
         return;
     };
@@ -3038,9 +3077,21 @@ async fn pg_buy_plan_appends_device_groups_dedup_without_removing_existing() {
     db.set_user_device_groups(alice, &[50]).await.unwrap();
     db.set_plan_device_groups(pid, &[50, 51]).await.unwrap();
 
-    db.buy_plan(alice, pid, "p1", 500, 1000, 10, 0, false, false, &[50, 51])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50, 51],
+        &[50, 51],
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         db.list_user_device_groups(alice).await.unwrap(),
@@ -3055,6 +3106,65 @@ async fn pg_buy_plan_appends_device_groups_dedup_without_removing_existing() {
     cleanup(&db).await;
 }
 
+/// v1.0.8: purchase REPLACES authorization — old groups are cleared. If the
+/// user previously had groups not in the new plan, those are removed and
+/// rules bound to them are paused. Mirrors the SQLite test.
+#[tokio::test]
+async fn pg_buy_plan_replaces_authorization_clears_old_groups() {
+    let Some(db) = repo("buy_replaces_auth").await else {
+        return;
+    };
+    let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 51, alice).await;
+    seed_device_group(&db, 52, alice).await;
+    // Alice previously had groups 50 and 51.
+    db.set_user_device_groups(alice, &[50, 51]).await.unwrap();
+    // Plan grants only group 52.
+    db.set_plan_device_groups(pid, &[52]).await.unwrap();
+
+    // Create a rule bound to group 50 (will be paused after purchase).
+    sqlx::query(
+        "INSERT INTO forward_rules \
+         (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+         VALUES (100, 'r100', $1, 20000, 50, '127.0.0.1', 80, FALSE)",
+    )
+    .bind(alice)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    // v1.0.8: new_authorized = {52} (the plan's grants).
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[52],
+        &[52],
+    )
+    .await
+    .unwrap();
+
+    // Result: {52} — old groups 50, 51 are cleared.
+    assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![52]);
+    // The rule bound to group 50 is now paused.
+    let paused: (bool,) = sqlx::query_as("SELECT paused FROM forward_rules WHERE id = 100")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(
+        paused.0,
+        "rule bound to removed group should be paused (PG)"
+    );
+    cleanup(&db).await;
+}
+
 #[tokio::test]
 async fn pg_buy_plan_grant_all_sets_flag() {
     let Some(db) = repo("buy_grant_all").await else {
@@ -3062,7 +3172,7 @@ async fn pg_buy_plan_grant_all_sets_flag() {
     };
     let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
 
-    db.buy_plan(alice, pid, "p1", 500, 1000, 10, 0, false, true, &[])
+    db.buy_plan(alice, pid, "p1", 500, 1000, 10, 0, false, true, &[], &[])
         .await
         .unwrap();
 
@@ -3078,8 +3188,11 @@ async fn pg_buy_plan_grant_all_sets_flag() {
     cleanup(&db).await;
 }
 
+/// v1.0.8: REPLACE semantics — buying a second (different) plan replaces the
+/// first plan's authorization rather than stacking it. Mirrors the SQLite
+/// test.
 #[tokio::test]
-async fn pg_multi_plan_grants_stack() {
+async fn pg_second_plan_purchase_replaces_first_plan_groups() {
     let Some(db) = repo("multi_plan_stack").await else {
         return;
     };
@@ -3093,17 +3206,38 @@ async fn pg_multi_plan_grants_stack() {
     db.set_plan_device_groups(pid_a, &[50]).await.unwrap();
     db.set_plan_device_groups(pid_b, &[51]).await.unwrap();
 
-    db.buy_plan(alice, pid_a, "pA", 500, 1000, 10, 0, false, false, &[50])
-        .await
-        .unwrap();
-    db.buy_plan(alice, pid_b, "pB", 500, 1000, 10, 0, false, false, &[51])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+    db.buy_plan(
+        alice,
+        pid_b,
+        "pB",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[51],
+        &[51],
+    )
+    .await
+    .unwrap();
 
-    assert_eq!(
-        db.list_user_device_groups(alice).await.unwrap(),
-        vec![50, 51]
-    );
+    assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![51]);
     cleanup(&db).await;
 }
 
@@ -3134,7 +3268,7 @@ async fn pg_expiry_does_not_revoke_granted_groups() {
     seed_device_group(&db, 50, alice).await;
     db.set_plan_device_groups(pid, &[50]).await.unwrap();
 
-    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[50])
+    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[50], &[50])
         .await
         .unwrap();
     assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![50]);

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -687,9 +687,11 @@ pub trait PlanRepository: Send + Sync {
     ///   - reset traffic_used to 0 when `reset_traffic`
     ///   - plan_expire_at = max(now, current expiry) + duration_days (NULL when duration_days=0)
     ///   - insert an orders row (snapshots plan_name + price)
-    ///   - v1.0.9: grant device groups in the SAME tx — when `grant_all_groups`
-    ///     set all_device_groups=1; else append the plan's `device_group_ids`
-    ///     to user_device_groups (deduped, never removing existing grants).
+    ///   - v1.0.9: grant device groups in the SAME tx. v1.0.8: purchase REPLACES
+    ///     authorization — when `grant_all_groups` set all_device_groups=1 (and
+    ///     clear explicit rows); else reset all_device_groups=0 and replace
+    ///     user_device_groups with the plan's `device_group_ids`. Rules bound to
+    ///     groups outside `new_authorized_group_ids` are paused in the same tx.
     /// All on the same tx handle so a concurrent purchase can't double-spend.
     /// `price_cents` / `traffic_to_add` / `plan_max_rules` / `duration_days` are
     /// resolved by the caller from the plan row (and re-checked hidden=0 there),

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -418,6 +418,11 @@ pub trait GroupRepository: Send + Sync {
     async fn count_rules_by_group(&self, id: i64) -> Result<i64, DbError>;
     async fn delete_group(&self, id: i64, scope: &ResourceScope) -> Result<u64, DbError>;
     async fn delete_groups_by_uid(&self, uid: i64) -> Result<u64, DbError>;
+    /// v1.0.8: list all inbound device groups (group_type = 'in'). Used by the
+    /// purchase flow to compute the authorized set when grant_all_groups=true
+    /// — in that mode the user gains access to every inbound group, so rules
+    /// bound to inbound groups are NOT paused.
+    async fn list_all_inbound_group_ids(&self) -> Result<Vec<i64>, DbError>;
 }
 
 // ── v1.0.7: per-user device-group authorization ──
@@ -702,6 +707,11 @@ pub trait PlanRepository: Send + Sync {
         reset_traffic: bool,
         grant_all_groups: bool,
         device_group_ids: &[i64],
+        // v1.0.8: the NEW authorized group set AFTER purchase. Used inside the
+        // transaction to pause rules outside this set (replacement semantics).
+        // Computed by the caller: all inbound groups if grant_all_groups, else
+        // device_group_ids (the plan's grants).
+        new_authorized_group_ids: &[i64],
     ) -> Result<(), BuyPlanError>;
 }
 

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -61,7 +61,9 @@ CREATE TABLE IF NOT EXISTS plans (
     description TEXT NOT NULL DEFAULT '',
     -- v1.0.9: when 1, buying this plan sets the user's all_device_groups flag
     -- (access to EVERY inbound group). When 0, buying grants only the groups
-    -- in plan_device_groups (appended to the user's existing authorizations).
+    -- in plan_device_groups. v1.0.8: purchase REPLACES the user's authorization
+    -- (the plan's grant becomes the user's entire authorized set — old grants
+    -- are cleared), not appended.
     grant_all_groups INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -199,8 +201,9 @@ CREATE TABLE IF NOT EXISTS orders (
 CREATE INDEX IF NOT EXISTS idx_orders_user_id ON orders(user_id);
 
 -- v1.0.9: plan ↔ device_group grant map. Buying a plan (with grant_all_groups=0)
--- appends these groups to the user's user_device_groups. FK cascade so deleting
--- a plan or device_group cleans up the mapping rows.
+-- REPLACES the user's user_device_groups with these groups (v1.0.8: purchase is
+-- replace, not append — the plan's grant becomes the user's whole authorized
+-- set). FK cascade so deleting a plan or device_group cleans up the mapping rows.
 CREATE TABLE IF NOT EXISTS plan_device_groups (
     plan_id INTEGER NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
     device_group_id INTEGER NOT NULL REFERENCES device_groups(id) ON DELETE CASCADE,

--- a/crates/panel/src/db/sqlite_repo/groups.rs
+++ b/crates/panel/src/db/sqlite_repo/groups.rs
@@ -267,4 +267,12 @@ impl GroupRepository for SqliteRepository {
             .await?;
         Ok(result.rows_affected())
     }
+
+    async fn list_all_inbound_group_ids(&self) -> Result<Vec<i64>, DbError> {
+        let rows: Vec<(i64,)> =
+            sqlx::query_as("SELECT id FROM device_groups WHERE group_type = 'in' ORDER BY id")
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
 }

--- a/crates/panel/src/db/sqlite_repo/settings.rs
+++ b/crates/panel/src/db/sqlite_repo/settings.rs
@@ -305,16 +305,32 @@ impl PlanRepository for SqliteRepository {
             .await?;
 
         // v1.0.8: grant device-group authorization in the SAME tx. Purchase
-        // REPLACES the user's authorization — old grants are cleared so rules
-        // bound to groups no longer in the plan are paused (the caller computes
-        // new_authorized_group_ids to drive the pause).
+        // REPLACES the user's authorization — BOTH dimensions are reset so the
+        // user is left with EXACTLY the new plan's grant, nothing lingering:
+        //   - grant_all_groups → set all_device_groups=1 AND clear the explicit
+        //     user_device_groups rows (redundant under the flag; clearing them
+        //     avoids stale grants resurfacing if the user later downgrades).
+        //   - else → clear all_device_groups=0 AND replace user_device_groups
+        //     with the plan's set. Resetting the flag is the fix for the
+        //     grant-all → per-group downgrade case: without it the user kept
+        //     all_device_groups=1 and stayed effectively unrestricted.
+        // The caller's new_authorized_group_ids drives the rule-pause below.
         if grant_all_groups {
             sqlx::query("UPDATE users SET all_device_groups = 1 WHERE id = ? AND admin = 0")
                 .bind(user_id)
                 .execute(&mut *tx)
                 .await?;
+            sqlx::query("DELETE FROM user_device_groups WHERE user_id = ?")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
         } else {
-            // REPLACE semantics: clear old assignments, then insert the plan's.
+            // REPLACE semantics: reset the all-groups flag, clear old explicit
+            // assignments, then insert the plan's.
+            sqlx::query("UPDATE users SET all_device_groups = 0 WHERE id = ? AND admin = 0")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
             sqlx::query("DELETE FROM user_device_groups WHERE user_id = ?")
                 .bind(user_id)
                 .execute(&mut *tx)

--- a/crates/panel/src/db/sqlite_repo/settings.rs
+++ b/crates/panel/src/db/sqlite_repo/settings.rs
@@ -199,6 +199,11 @@ impl PlanRepository for SqliteRepository {
         reset_traffic: bool,
         grant_all_groups: bool,
         device_group_ids: &[i64],
+        // v1.0.8: the NEW authorized group set AFTER purchase. Used inside the
+        // transaction to pause rules outside this set (replacement semantics).
+        // Computed by the caller: all inbound groups if grant_all_groups, else
+        // device_group_ids (the plan's grants).
+        new_authorized_group_ids: &[i64],
     ) -> Result<(), BuyPlanError> {
         let mut tx = self.pool.begin().await?;
 
@@ -299,22 +304,24 @@ impl PlanRepository for SqliteRepository {
             .execute(&mut *tx)
             .await?;
 
-        // v1.0.9: grant device-group authorization in the SAME tx. Two modes:
-        //   - grant_all_groups → set the user's all_device_groups flag (access
-        //     to EVERY inbound group). Admins are left alone (always all-allowed).
-        //   - else → APPEND the plan's device groups to user_device_groups.
-        //     INSERT OR IGNORE dedupes against existing grants and never removes
-        //     any (purchases only ever expand a user's access). Expiry does NOT
-        //     revoke these — that's the spec's "到期不撤授权".
+        // v1.0.8: grant device-group authorization in the SAME tx. Purchase
+        // REPLACES the user's authorization — old grants are cleared so rules
+        // bound to groups no longer in the plan are paused (the caller computes
+        // new_authorized_group_ids to drive the pause).
         if grant_all_groups {
             sqlx::query("UPDATE users SET all_device_groups = 1 WHERE id = ? AND admin = 0")
                 .bind(user_id)
                 .execute(&mut *tx)
                 .await?;
         } else {
+            // REPLACE semantics: clear old assignments, then insert the plan's.
+            sqlx::query("DELETE FROM user_device_groups WHERE user_id = ?")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
             for dg_id in device_group_ids {
                 sqlx::query(
-                    "INSERT OR IGNORE INTO user_device_groups (user_id, device_group_id) \
+                    "INSERT INTO user_device_groups (user_id, device_group_id) \
                      VALUES (?, ?)",
                 )
                 .bind(user_id)
@@ -322,6 +329,41 @@ impl PlanRepository for SqliteRepository {
                 .execute(&mut *tx)
                 .await?;
             }
+        }
+
+        // Pause rules outside the new authorization. This is the key change from
+        // the old append-only behavior: a new purchase can revoke access to
+        // groups the user previously had, and those rules stop forwarding.
+        // When grant_all_groups=true, new_authorized = all inbound groups, so
+        // no rules are paused (the user still has full access).
+        // Inline the pause logic inside the transaction (using &mut *tx) to
+        // avoid acquiring a separate pool connection while the transaction is
+        // still open — that would risk a pool-exhaustion deadlock.
+        let n = if new_authorized_group_ids.is_empty() {
+            let r = sqlx::query("UPDATE forward_rules SET paused = 1 WHERE uid = ? AND paused = 0")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
+            r.rows_affected()
+        } else {
+            let placeholders = vec!["?"; new_authorized_group_ids.len()].join(", ");
+            let sql = format!(
+                "UPDATE forward_rules SET paused = 1 \
+                 WHERE uid = ? AND paused = 0 AND device_group_in NOT IN ({})",
+                placeholders
+            );
+            let mut q = sqlx::query(&sql).bind(user_id);
+            for gid in new_authorized_group_ids {
+                q = q.bind(gid);
+            }
+            let r = q.execute(&mut *tx).await?;
+            r.rows_affected()
+        };
+        if n > 0 {
+            tracing::warn!(
+                "buy_plan: user {} purchased plan {}, {} rule(s) paused due to authorization change",
+                user_id, plan_id, n
+            );
         }
 
         tx.commit().await?;

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -3150,6 +3150,58 @@ async fn buy_plan_replaces_authorization_clears_old_groups() {
     assert!(paused.0, "rule bound to removed group should be paused");
 }
 
+/// v1.0.8 regression: downgrading from a grant-all plan to a per-group plan
+/// must RESET all_device_groups back to 0. Without the reset the user stays
+/// effectively unrestricted (all_device_groups=1 overrides the explicit set),
+/// so the "replace to only the new plan's lines" never takes effect.
+#[tokio::test]
+async fn buy_plan_grant_all_then_per_group_resets_all_flag() {
+    let db = repo().await;
+    let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 52, alice).await;
+
+    // 1) Buy a grant-all plan → all_device_groups = 1.
+    db.buy_plan(alice, pid, "all", 100, 1000, 10, 0, false, true, &[], &[])
+        .await
+        .unwrap();
+    let all: (bool,) = sqlx::query_as("SELECT all_device_groups FROM users WHERE id = ?")
+        .bind(alice)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(all.0, "grant-all purchase must set the flag");
+
+    // 2) Downgrade to a per-group plan granting only {52}.
+    db.buy_plan(
+        alice,
+        pid,
+        "ltd",
+        100,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[52],
+        &[52],
+    )
+    .await
+    .unwrap();
+
+    // The flag must be cleared, and the authorized set is exactly {52}.
+    let all: (bool,) = sqlx::query_as("SELECT all_device_groups FROM users WHERE id = ?")
+        .bind(alice)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(
+        !all.0,
+        "downgrade to a per-group plan must reset all_device_groups to 0"
+    );
+    assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![52]);
+}
+
 #[tokio::test]
 async fn buy_plan_grant_all_sets_flag() {
     let db = repo().await;

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -2763,9 +2763,21 @@ async fn buy_plan_stacks_traffic_and_charges_balance() {
         .await
         .unwrap();
 
-    db.buy_plan(alice, pid, "p1", 3000, 1_000_000, 10, 0, false, false, &[])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        3000,
+        1_000_000,
+        10,
+        0,
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    .unwrap();
 
     let (balance, traffic_limit, max_rules, plan_id): (String, i64, i32, Option<i64>) =
         sqlx::query_as("SELECT balance, traffic_limit, max_rules, plan_id FROM users WHERE id = ?")
@@ -2798,9 +2810,21 @@ async fn buy_plan_reset_traffic_zeros_usage() {
         .await
         .unwrap();
 
-    db.buy_plan(alice, pid, "p1", 1000, 1_000_000, 10, 0, true, false, &[])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        1000,
+        1_000_000,
+        10,
+        0,
+        true,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    .unwrap();
 
     let used: (i64,) = sqlx::query_as("SELECT traffic_used FROM users WHERE id = ?")
         .bind(alice)
@@ -2823,7 +2847,19 @@ async fn buy_plan_insufficient_balance_is_rejected_and_rolls_back() {
         .unwrap();
 
     let err = db
-        .buy_plan(alice, pid, "p1", 3000, 1_000_000, 10, 0, false, false, &[])
+        .buy_plan(
+            alice,
+            pid,
+            "p1",
+            3000,
+            1_000_000,
+            10,
+            0,
+            false,
+            false,
+            &[],
+            &[],
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, BuyPlanError::InsufficientBalance));
@@ -2848,7 +2884,7 @@ async fn buy_plan_time_plan_sets_future_expiry() {
     // after now and within 31 days — avoids a flaky exact-timestamp assert).
     let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 0, "5.00", 30, false).await;
 
-    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[])
+    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[], &[])
         .await
         .unwrap();
 
@@ -2880,7 +2916,7 @@ async fn buy_plan_renewal_stacks_expiry_from_current_end() {
         .await
         .unwrap();
 
-    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[])
+    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[], &[])
         .await
         .unwrap();
 
@@ -3015,22 +3051,40 @@ async fn plan_device_groups_round_trip_and_replace() {
     assert_eq!(db.list_plan_device_groups(pid).await.unwrap(), vec![50, 51]);
 }
 
+/// v1.0.8: purchase REPLACES authorization, so a group the user already had
+/// that ALSO appears in the new plan's grant set must end up exactly once
+/// (the replace is a clean delete-then-insert of the new set, not a
+/// dedup-on-append) — no duplicate row, no unique-constraint error.
 #[tokio::test]
-async fn buy_plan_appends_device_groups_dedup_without_removing_existing() {
+async fn buy_plan_new_authorized_set_has_no_duplicate_groups() {
     let db = repo().await;
     let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
     seed_device_group(&db, 50, alice).await;
     seed_device_group(&db, 51, alice).await;
-    // Alice already has group 50 from a prior grant.
+    // Alice already has group 50 from a prior purchase.
     db.set_user_device_groups(alice, &[50]).await.unwrap();
-    // Plan grants 50 (dup) + 51 (new).
+    // Plan grants 50 (overlaps the existing grant) + 51 (new).
     db.set_plan_device_groups(pid, &[50, 51]).await.unwrap();
 
-    db.buy_plan(alice, pid, "p1", 500, 1000, 10, 0, false, false, &[50, 51])
-        .await
-        .unwrap();
+    // v1.0.8: new_authorized = {50, 51} (the plan's grants).
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50, 51],
+        &[50, 51],
+    )
+    .await
+    .unwrap();
 
-    // Result: {50, 51} — 50 not duplicated, the pre-existing 50 kept.
+    // Result: exactly {50, 51} — the overlapping id 50 appears once, not
+    // duplicated by the replace's delete-then-insert.
     assert_eq!(
         db.list_user_device_groups(alice).await.unwrap(),
         vec![50, 51]
@@ -3044,13 +3098,67 @@ async fn buy_plan_appends_device_groups_dedup_without_removing_existing() {
     assert!(!all.0);
 }
 
+/// v1.0.8: purchase REPLACES authorization — old groups are cleared.
+/// If the user previously had groups not in the new plan, those are removed
+/// and rules bound to them are paused.
+#[tokio::test]
+async fn buy_plan_replaces_authorization_clears_old_groups() {
+    let db = repo().await;
+    let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 51, alice).await;
+    seed_device_group(&db, 52, alice).await;
+    // Alice previously had groups 50 and 51.
+    db.set_user_device_groups(alice, &[50, 51]).await.unwrap();
+    // Plan grants only group 52.
+    db.set_plan_device_groups(pid, &[52]).await.unwrap();
+
+    // Create a rule bound to group 50 (will be paused after purchase).
+    sqlx::query(
+        "INSERT INTO forward_rules (id, name, uid, listen_port, device_group_in, \
+         target_addr, target_port, paused) VALUES (100, 'r100', ?, 20000, 50, '127.0.0.1', 80, 0)",
+    )
+    .bind(alice)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    // v1.0.8: new_authorized = {52} (the plan's grants).
+    db.buy_plan(
+        alice,
+        pid,
+        "p1",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[52],
+        &[52],
+    )
+    .await
+    .unwrap();
+
+    // Result: {52} — old groups 50, 51 are cleared.
+    assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![52]);
+    // The rule bound to group 50 is now paused.
+    let paused: (bool,) = sqlx::query_as("SELECT paused FROM forward_rules WHERE id = 100")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(paused.0, "rule bound to removed group should be paused");
+}
+
 #[tokio::test]
 async fn buy_plan_grant_all_sets_flag() {
     let db = repo().await;
     let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
 
     // grant_all_groups=true → set all_device_groups, ignore the explicit list.
-    db.buy_plan(alice, pid, "p1", 500, 1000, 10, 0, false, true, &[])
+    // new_authorized = all inbound groups (in this test, the only inbound group
+    // is the one created by seed_buyer_and_plan).
+    db.buy_plan(alice, pid, "p1", 500, 1000, 10, 0, false, true, &[], &[])
         .await
         .unwrap();
 
@@ -3065,8 +3173,11 @@ async fn buy_plan_grant_all_sets_flag() {
     );
 }
 
+/// v1.0.8: REPLACE semantics — buying a second (different) plan replaces the
+/// first plan's authorization rather than stacking it. After both purchases
+/// the user is left with ONLY plan B's groups.
 #[tokio::test]
-async fn multi_plan_grants_stack() {
+async fn second_plan_purchase_replaces_first_plan_groups() {
     let db = repo().await;
     let (alice, pid_a) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
     seed_device_group(&db, 50, alice).await;
@@ -3079,18 +3190,40 @@ async fn multi_plan_grants_stack() {
     db.set_plan_device_groups(pid_a, &[50]).await.unwrap();
     db.set_plan_device_groups(pid_b, &[51]).await.unwrap();
 
-    db.buy_plan(alice, pid_a, "pA", 500, 1000, 10, 0, false, false, &[50])
-        .await
-        .unwrap();
-    db.buy_plan(alice, pid_b, "pB", 500, 1000, 10, 0, false, false, &[51])
-        .await
-        .unwrap();
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+    db.buy_plan(
+        alice,
+        pid_b,
+        "pB",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[51],
+        &[51],
+    )
+    .await
+    .unwrap();
 
-    // Buying two plans stacks their grants.
-    assert_eq!(
-        db.list_user_device_groups(alice).await.unwrap(),
-        vec![50, 51]
-    );
+    // User now has only the groups from plan B — plan A's grant was replaced,
+    // not stacked.
+    assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![51]);
 }
 
 #[tokio::test]
@@ -3122,7 +3255,7 @@ async fn expiry_does_not_revoke_granted_groups() {
     db.set_plan_device_groups(pid, &[50]).await.unwrap();
 
     // Buy a 30-day time plan that grants group 50.
-    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[50])
+    db.buy_plan(alice, pid, "p1", 500, 0, 10, 30, false, false, &[50], &[50])
         .await
         .unwrap();
     assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![50]);


### PR DESCRIPTION
## 概述

套餐购买的设备分组授权语义从「只增不减」改为 **REPLACE**,并修掉降级时的授权残留 bug,附带后端错误提示中文化 + 一个 flaky 测试修复。

## 改动

### 1. 购买授权 REPLACE 语义(§5)
- 买套餐时用套餐的授权集合**替换**用户原有授权(不再追加):`grant_all_groups` → 置 `all_device_groups`;否则清空并写入套餐的分组。
- 失权分组上的规则在**同一事务内自动暂停**(调用方计算 `new_authorized_group_ids` 驱动)。
- 新增 `list_all_inbound_group_ids`;`buy_plan` 签名加 `new_authorized_group_ids`;shop.rs / admin users.rs 两个购买入口都计算新授权集。

### 2. 🔴 降级授权残留 bug 修复
- 之前限定套餐分支只改 `user_device_groups`,没复位 `all_device_groups`。用户「全通套餐 → 限定套餐」降级后仍 `all_device_groups=1`、实际不受限,"只留新套餐线路"失效。
- 双库限定分支补 `all_device_groups=0`,全通分支清冗余显式行——两分支都是干净 REPLACE。
- 回归测试 `buy_plan_grant_all_then_per_group_resets_all_flag`(sqlite+pg)。

### 3. flaky 测试修复
- `forwarder::manager` 里 4 个测试硬编码同一端口 40001,并行跑时抢端口导致 `deleted_rule_prunes_traffic_counter` 偶发 FAIL(已两次卡 CI)。改为各用独立端口(40001/40003/40004/40005),连跑无 flake。

### 4. 后端错误提示中文化
- admin API(groups/password/plans/profiles/rules/settings/shop/users)错误消息英文→中文。

## 验证
- `cargo test --workspace`:360(panel)+ 79(node)+ 其余全过,3 轮无 flake
- clippy(workspace all-targets)干净、fmt 干净、repo-test-parity OK(86 sqlite / 85 pg)

## 注意
REPLACE 语义与已发布 v1.0.7 文档中「授权只增不减 / 到期不撤授权」相反 —— 下次发版时 CHANGELOG/README/网站需同步更新。本 PR 不含版本号 bump(按攒批流程,发版时统一处理)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)