### PR TITLE
feat(plans): auto-resume on re-authorization + account available lines

### DIFF
--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -84,6 +84,16 @@ pub struct UserSelf {
     /// v1.0.8: admin suspension (login allowed; forwarding gated).
     #[serde(default)]
     pub suspended: bool,
+    /// v1.0.8: true when this user is unrestricted (admin, or
+    /// all_device_groups=1) — every inbound line is usable. When false,
+    /// `available_groups` lists the specific lines they're authorized for.
+    #[serde(default)]
+    pub all_groups: bool,
+    /// v1.0.8: names of the device groups (lines) this user can currently use.
+    /// Empty when `all_groups` is true (nothing to enumerate) or when the user
+    /// has no authorization at all.
+    #[serde(default)]
+    pub available_groups: Vec<String>,
 }
 
 /// Build an error ApiResponse. Accepts `&str` or `String` (or anything else

--- a/crates/panel/src/api/admin/password.rs
+++ b/crates/panel/src/api/admin/password.rs
@@ -202,6 +202,58 @@ pub async fn get_me(user: AuthUser, State(state): State<AppState>) -> Json<ApiRe
             }
         };
 
+    // v1.0.8: resolve which lines this user can use, for the account page's
+    // "可用线路" row. Admins and all_device_groups users are unrestricted
+    // (all_groups=true, nothing to enumerate); everyone else gets the names of
+    // their explicitly authorized groups.
+    let (all_groups, available_groups) = if u.admin {
+        (true, Vec::new())
+    } else {
+        match state.db.is_user_restricted(user.user_id).await {
+            Ok(false) => (true, Vec::new()),
+            Ok(true) => {
+                let ids = match state.db.authorized_device_group_ids(user.user_id).await {
+                    Ok(ids) => ids,
+                    Err(e) => {
+                        tracing::error!(
+                            "get_me {}: authorized_device_group_ids failed: {}",
+                            user.user_id,
+                            e
+                        );
+                        return Json(ApiResponse {
+                            code: 500,
+                            message: "数据库错误".into(),
+                            data: None,
+                        });
+                    }
+                };
+                match state.db.list_group_names_by_ids(&ids).await {
+                    Ok(names) => (false, names),
+                    Err(e) => {
+                        tracing::error!(
+                            "get_me {}: list_group_names_by_ids failed: {}",
+                            user.user_id,
+                            e
+                        );
+                        return Json(ApiResponse {
+                            code: 500,
+                            message: "数据库错误".into(),
+                            data: None,
+                        });
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("get_me {}: is_user_restricted failed: {}", user.user_id, e);
+                return Json(ApiResponse {
+                    code: 500,
+                    message: "数据库错误".into(),
+                    data: None,
+                });
+            }
+        }
+    };
+
     Json(ApiResponse::success(UserSelf {
         id: u.id,
         username: u.username,
@@ -217,6 +269,8 @@ pub async fn get_me(user: AuthUser, State(state): State<AppState>) -> Json<ApiRe
         must_change_password: u.must_change_password,
         plan_expire_at: u.plan_expire_at,
         suspended: u.suspended,
+        all_groups,
+        available_groups,
     }))
 }
 

--- a/crates/panel/src/api/admin/rules.rs
+++ b/crates/panel/src/api/admin/rules.rs
@@ -147,10 +147,7 @@ pub async fn update_rule(
                         }
                     };
                     if !allowed.contains(&rule.device_group_in) {
-                        return Json(err(
-                            403,
-                            "cannot resume a rule on a device group you are not authorized for",
-                        ));
+                        return Json(err(403, "无法启动未被授权设备分组下的规则"));
                     }
                 }
                 Ok(None) => return Json(err(404, "规则不存在")),

--- a/crates/panel/src/db/pg_repo/groups.rs
+++ b/crates/panel/src/db/pg_repo/groups.rs
@@ -280,4 +280,24 @@ impl GroupRepository for PgRepository {
                 .await?;
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
+
+    async fn list_group_names_by_ids(&self, ids: &[i64]) -> Result<Vec<String>, DbError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = (1..=ids.len())
+            .map(|i| format!("${}", i))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT name FROM device_groups WHERE id IN ({}) ORDER BY name",
+            placeholders
+        );
+        let mut q = sqlx::query_as(&sql);
+        for id in ids {
+            q = q.bind(id);
+        }
+        let rows: Vec<(String,)> = q.fetch_all(&self.pool).await?;
+        Ok(rows.into_iter().map(|(name,)| name).collect())
+    }
 }

--- a/crates/panel/src/db/pg_repo/rules.rs
+++ b/crates/panel/src/db/pg_repo/rules.rs
@@ -458,6 +458,11 @@ impl RuleRepository for PgRepository {
         }
         if paused.is_some() {
             sets.push("paused = ");
+            // v1.0.8: an explicit paused write is always a human action (the
+            // on/off switch, batch pause/resume) — clear auto_paused so a later
+            // buy_plan re-authorization doesn't treat this rule as something IT
+            // needs to reconcile.
+            sets.push("auto_paused = ");
         }
 
         if sets.is_empty() {
@@ -528,6 +533,7 @@ impl RuleRepository for PgRepository {
         }
         if let Some(v) = paused {
             q = q.bind(v);
+            q = q.bind(false); // auto_paused reset
         }
         q = q.bind(id);
         if let Some(uid) = scope.owner_id() {

--- a/crates/panel/src/db/pg_repo/settings.rs
+++ b/crates/panel/src/db/pg_repo/settings.rs
@@ -354,9 +354,12 @@ impl PlanRepository for PgRepository {
         // Inline the pause logic inside the transaction (using &mut *tx) to
         // avoid acquiring a separate pool connection while the transaction is
         // still open — that would risk a pool-exhaustion deadlock.
+        // v1.0.8: auto_paused=TRUE marks these as SYSTEM pauses (see the resume
+        // step below and the column doc on forward_rules.auto_paused).
         let n = if new_authorized_group_ids.is_empty() {
             let r = sqlx::query(
-                "UPDATE forward_rules SET paused = TRUE WHERE uid = $1 AND paused = FALSE",
+                "UPDATE forward_rules SET paused = TRUE, auto_paused = TRUE \
+                 WHERE uid = $1 AND paused = FALSE",
             )
             .bind(user_id)
             .execute(&mut *tx)
@@ -368,7 +371,7 @@ impl PlanRepository for PgRepository {
                 .collect::<Vec<_>>()
                 .join(", ");
             let sql = format!(
-                "UPDATE forward_rules SET paused = TRUE \
+                "UPDATE forward_rules SET paused = TRUE, auto_paused = TRUE \
                  WHERE uid = $1 AND paused = FALSE AND device_group_in NOT IN ({})",
                 placeholders
             );
@@ -384,6 +387,36 @@ impl PlanRepository for PgRepository {
                 "buy_plan: user {} purchased plan {}, {} rule(s) paused due to authorization change",
                 user_id, plan_id, n
             );
+        }
+
+        // v1.0.8: symmetric auto-resume — a rule this system previously paused
+        // (auto_paused=TRUE) whose group is back in the new authorized set gets
+        // un-paused here. A rule the user paused THEMSELVES (auto_paused=FALSE,
+        // e.g. via the on/off switch) is deliberately left alone even if its
+        // group is authorized again — buying a plan must never silently revive
+        // a rule the user turned off on purpose.
+        if !new_authorized_group_ids.is_empty() {
+            let placeholders = (1..=new_authorized_group_ids.len())
+                .map(|i| format!("${}", i + 1))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "UPDATE forward_rules SET paused = FALSE, auto_paused = FALSE \
+                 WHERE uid = $1 AND paused = TRUE AND auto_paused = TRUE \
+                 AND device_group_in IN ({})",
+                placeholders
+            );
+            let mut q = sqlx::query(&sql).bind(user_id);
+            for gid in new_authorized_group_ids {
+                q = q.bind(gid);
+            }
+            let resumed = q.execute(&mut *tx).await?.rows_affected();
+            if resumed > 0 {
+                tracing::info!(
+                    "buy_plan: user {} purchased plan {}, {} previously auto-paused rule(s) resumed",
+                    user_id, plan_id, resumed
+                );
+            }
         }
 
         tx.commit().await?;

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -3240,6 +3240,216 @@ async fn pg_buy_plan_grant_all_then_per_group_resets_all_flag() {
     cleanup(&db).await;
 }
 
+/// v1.0.8: re-buying a plan that re-grants a group must auto-resume a rule
+/// this system previously auto-paused on that group. Mirrors the SQLite test.
+#[tokio::test]
+async fn pg_buy_plan_resumes_auto_paused_rules_when_group_reauthorized() {
+    let Some(db) = repo("buy_plan_resume").await else {
+        return;
+    };
+    let (alice, pid_a) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 51, alice).await;
+    let pid_b = db
+        .insert_plan("pB", 10, 1000, "5.00", "data", 0, false, false, "", false)
+        .await
+        .unwrap();
+    db.set_plan_device_groups(pid_a, &[50]).await.unwrap();
+    db.set_plan_device_groups(pid_b, &[51]).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO forward_rules \
+         (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+         VALUES (200, 'r200', $1, 20000, 50, '127.0.0.1', 80, FALSE)",
+    )
+    .bind(alice)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+
+    db.buy_plan(
+        alice,
+        pid_b,
+        "pB",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[51],
+        &[51],
+    )
+    .await
+    .unwrap();
+    let (paused, auto_paused): (bool, bool) =
+        sqlx::query_as("SELECT paused, auto_paused FROM forward_rules WHERE id = 200")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(
+        paused && auto_paused,
+        "buy_plan must auto-pause rule 200 (PG)"
+    );
+
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+    let (paused, auto_paused): (bool, bool) =
+        sqlx::query_as("SELECT paused, auto_paused FROM forward_rules WHERE id = 200")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(
+        !paused && !auto_paused,
+        "re-authorizing group 50 must auto-resume the rule buy_plan itself paused (PG)"
+    );
+    cleanup(&db).await;
+}
+
+/// v1.0.8: a rule the user paused THEMSELVES (auto_paused cleared) must NOT be
+/// silently revived by a later purchase. Mirrors the SQLite test.
+#[tokio::test]
+async fn pg_buy_plan_does_not_resume_manually_paused_rules() {
+    let Some(db) = repo("buy_plan_no_resume").await else {
+        return;
+    };
+    let (alice, pid_a) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 51, alice).await;
+    let pid_b = db
+        .insert_plan("pB", 10, 1000, "5.00", "data", 0, false, false, "", false)
+        .await
+        .unwrap();
+    db.set_plan_device_groups(pid_a, &[50]).await.unwrap();
+    db.set_plan_device_groups(pid_b, &[51]).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO forward_rules \
+         (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+         VALUES (201, 'r201', $1, 20001, 50, '127.0.0.1', 80, FALSE)",
+    )
+    .bind(alice)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+
+    db.buy_plan(
+        alice,
+        pid_b,
+        "pB",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[51],
+        &[51],
+    )
+    .await
+    .unwrap();
+
+    // Human re-confirms the pause via the on/off switch — clears auto_paused.
+    let scope = crate::db::repo::ResourceScope::All;
+    db.update_rule_fields(
+        201,
+        &scope,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(true),
+    )
+    .await
+    .unwrap();
+    let (_, auto_paused): (bool, bool) =
+        sqlx::query_as("SELECT paused, auto_paused FROM forward_rules WHERE id = 201")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(
+        !auto_paused,
+        "an explicit paused write must clear auto_paused (PG)"
+    );
+
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+    let (paused,): (bool,) = sqlx::query_as("SELECT paused FROM forward_rules WHERE id = 201")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(
+        paused,
+        "a manually-paused rule must NOT be auto-resumed by a later purchase (PG)"
+    );
+    cleanup(&db).await;
+}
+
 /// v1.0.8: REPLACE semantics — buying a second (different) plan replaces the
 /// first plan's authorization rather than stacking it. Mirrors the SQLite
 /// test.

--- a/crates/panel/src/db/pg_repo/user_groups.rs
+++ b/crates/panel/src/db/pg_repo/user_groups.rs
@@ -89,9 +89,13 @@ impl DeviceGroupAuthRepository for PgRepository {
         allowed_group_ids: &[i64],
     ) -> Result<u64, DbError> {
         // Empty allowed list → pause ALL of the user's currently-active rules.
+        // v1.0.8: auto_paused=TRUE marks this as a SYSTEM pause (vs. a human
+        // using the on/off switch), so a later re-authorization can safely
+        // auto-resume it.
         if allowed_group_ids.is_empty() {
             let r = sqlx::query(
-                "UPDATE forward_rules SET paused = TRUE WHERE uid = $1 AND paused = FALSE",
+                "UPDATE forward_rules SET paused = TRUE, auto_paused = TRUE \
+                 WHERE uid = $1 AND paused = FALSE",
             )
             .bind(user_id)
             .execute(&self.pool)
@@ -104,7 +108,7 @@ impl DeviceGroupAuthRepository for PgRepository {
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
-            "UPDATE forward_rules SET paused = TRUE \
+            "UPDATE forward_rules SET paused = TRUE, auto_paused = TRUE \
              WHERE uid = $1 AND paused = FALSE AND device_group_in NOT IN ({})",
             placeholders
         );

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -113,6 +113,11 @@ CREATE TABLE IF NOT EXISTS forward_rules (
     name TEXT NOT NULL,
     uid BIGINT NOT NULL REFERENCES users(id),
     paused BOOLEAN NOT NULL DEFAULT FALSE,
+    -- v1.0.8: 1 = system-auto-paused (buy_plan / plan removal revoking
+    -- authorization), 0 = human-paused or never paused. Mirrors SQLite
+    -- Migration 37. Lets a later re-authorization safely auto-resume only the
+    -- rules IT paused.
+    auto_paused BOOLEAN NOT NULL DEFAULT FALSE,
     listen_port INTEGER NOT NULL,
     protocol TEXT NOT NULL DEFAULT 'tcp',
     public_transport TEXT NOT NULL DEFAULT 'raw',
@@ -273,7 +278,7 @@ INSERT INTO schema_version (version) VALUES (1) ON CONFLICT (version) DO NOTHING
 /// The schema revision this build's baseline `PG_SCHEMA_SQL` represents. When a
 /// future release adds a column/table, bump this and add a matching arm in
 /// `run_pg_migrations`. `apply_pg_schema` seeds `schema_version` with revision 1.
-pub const PG_SCHEMA_VERSION: i32 = 19;
+pub const PG_SCHEMA_VERSION: i32 = 20;
 
 /// Apply PG_SCHEMA_SQL to a pool. PostgreSQL's prepared-statement protocol
 /// rejects multi-statement strings ("cannot insert multiple commands into a
@@ -1059,6 +1064,23 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
         tracing::info!("PG migration 19: device_groups.hidden column present");
+    }
+
+    // ── Revision 20: v1.0.8 forward_rules.auto_paused ──
+    // Mirrors SQLite Migration 37. ADD COLUMN IF NOT EXISTS so a FRESH database
+    // (which already has auto_paused from the baseline) replays this as a no-op.
+    if current < 20 {
+        sqlx::query(
+            "ALTER TABLE forward_rules ADD COLUMN IF NOT EXISTS auto_paused BOOLEAN NOT NULL DEFAULT FALSE",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO schema_version (version) VALUES (20) ON CONFLICT (version) DO NOTHING",
+        )
+        .execute(pool)
+        .await?;
+        tracing::info!("PG migration 20: forward_rules.auto_paused column present");
     }
 
     Ok(())

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -423,6 +423,13 @@ pub trait GroupRepository: Send + Sync {
     /// — in that mode the user gains access to every inbound group, so rules
     /// bound to inbound groups are NOT paused.
     async fn list_all_inbound_group_ids(&self) -> Result<Vec<i64>, DbError>;
+    /// v1.0.8: resolve device-group NAMES for the given ids, for display (e.g.
+    /// the account page's "可用线路" and the shop's plan-grant hint). Unlike
+    /// `list_shared_groups`, this is NOT filtered by ownership/authorization —
+    /// callers already know the ids are safe to show to the caller (their own
+    /// authorized set, or a plan's grant set). Order is not guaranteed; callers
+    /// that need it presented in `ids` order should sort client-side.
+    async fn list_group_names_by_ids(&self, ids: &[i64]) -> Result<Vec<String>, DbError>;
 }
 
 // ── v1.0.7: per-user device-group authorization ──

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -124,6 +124,15 @@ CREATE TABLE IF NOT EXISTS forward_rules (
     -- then max_rules / uid are effectively advisory, not enforced per-user.
     uid INTEGER NOT NULL REFERENCES users(id),
     paused INTEGER NOT NULL DEFAULT 0,
+    -- v1.0.8: 1 = this rule was paused BY THE SYSTEM (buy_plan / plan removal
+    -- revoking device-group authorization), 0 = paused by an explicit human
+    -- action (the on/off switch, batch pause/resume) or never paused. Lets a
+    -- later re-authorization (buying a plan that re-grants the group) safely
+    -- auto-resume ONLY the rules IT paused, without reviving a rule the user
+    -- deliberately turned off for unrelated reasons. Any explicit `paused`
+    -- write via update_rule_fields resets this to 0 — a human touching the
+    -- switch always overrides system bookkeeping.
+    auto_paused INTEGER NOT NULL DEFAULT 0,
     listen_port INTEGER NOT NULL,
     protocol TEXT NOT NULL DEFAULT 'tcp',
     -- v0.4.0: three orthogonal fields replace the overloaded entry_transport.
@@ -1346,6 +1355,21 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
     )
     .await?;
     tracing::info!("Migration 36: device_groups.hidden column present");
+
+    // ── Migration 37: v1.0.8 forward_rules.auto_paused ──
+    // Distinguishes system-auto-paused (buy_plan / plan removal revoking
+    // authorization) from human-paused (the on/off switch), so a later
+    // re-authorization can safely auto-resume only rules it paused itself.
+    // Default 0 keeps every existing paused rule as "human paused" (no
+    // surprise auto-resume for pre-existing rows).
+    add_column_if_missing(
+        pool,
+        "forward_rules",
+        "auto_paused",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+    .await?;
+    tracing::info!("Migration 37: forward_rules.auto_paused column present");
 
     Ok(())
 }

--- a/crates/panel/src/db/sqlite_repo/groups.rs
+++ b/crates/panel/src/db/sqlite_repo/groups.rs
@@ -275,4 +275,21 @@ impl GroupRepository for SqliteRepository {
                 .await?;
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
+
+    async fn list_group_names_by_ids(&self, ids: &[i64]) -> Result<Vec<String>, DbError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = vec!["?"; ids.len()].join(", ");
+        let sql = format!(
+            "SELECT name FROM device_groups WHERE id IN ({}) ORDER BY name",
+            placeholders
+        );
+        let mut q = sqlx::query_as(&sql);
+        for id in ids {
+            q = q.bind(id);
+        }
+        let rows: Vec<(String,)> = q.fetch_all(&self.pool).await?;
+        Ok(rows.into_iter().map(|(name,)| name).collect())
+    }
 }

--- a/crates/panel/src/db/sqlite_repo/rules.rs
+++ b/crates/panel/src/db/sqlite_repo/rules.rs
@@ -439,6 +439,11 @@ impl RuleRepository for SqliteRepository {
         }
         if paused.is_some() {
             sets.push("paused = ?");
+            // v1.0.8: an explicit paused write is always a human action (the
+            // on/off switch, batch pause/resume) — clear auto_paused so a later
+            // buy_plan re-authorization doesn't treat this rule as something IT
+            // needs to reconcile.
+            sets.push("auto_paused = 0");
         }
 
         if sets.is_empty() {

--- a/crates/panel/src/db/sqlite_repo/settings.rs
+++ b/crates/panel/src/db/sqlite_repo/settings.rs
@@ -355,16 +355,21 @@ impl PlanRepository for SqliteRepository {
         // Inline the pause logic inside the transaction (using &mut *tx) to
         // avoid acquiring a separate pool connection while the transaction is
         // still open — that would risk a pool-exhaustion deadlock.
+        // v1.0.8: auto_paused=1 marks these as SYSTEM pauses (see the resume
+        // step below and the column doc on forward_rules.auto_paused).
         let n = if new_authorized_group_ids.is_empty() {
-            let r = sqlx::query("UPDATE forward_rules SET paused = 1 WHERE uid = ? AND paused = 0")
-                .bind(user_id)
-                .execute(&mut *tx)
-                .await?;
+            let r = sqlx::query(
+                "UPDATE forward_rules SET paused = 1, auto_paused = 1 \
+                 WHERE uid = ? AND paused = 0",
+            )
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
             r.rows_affected()
         } else {
             let placeholders = vec!["?"; new_authorized_group_ids.len()].join(", ");
             let sql = format!(
-                "UPDATE forward_rules SET paused = 1 \
+                "UPDATE forward_rules SET paused = 1, auto_paused = 1 \
                  WHERE uid = ? AND paused = 0 AND device_group_in NOT IN ({})",
                 placeholders
             );
@@ -380,6 +385,33 @@ impl PlanRepository for SqliteRepository {
                 "buy_plan: user {} purchased plan {}, {} rule(s) paused due to authorization change",
                 user_id, plan_id, n
             );
+        }
+
+        // v1.0.8: symmetric auto-resume — a rule this system previously paused
+        // (auto_paused=1) whose group is back in the new authorized set gets
+        // un-paused here. A rule the user paused THEMSELVES (auto_paused=0,
+        // e.g. via the on/off switch) is deliberately left alone even if its
+        // group is authorized again — buying a plan must never silently revive
+        // a rule the user turned off on purpose.
+        if !new_authorized_group_ids.is_empty() {
+            let placeholders = vec!["?"; new_authorized_group_ids.len()].join(", ");
+            let sql = format!(
+                "UPDATE forward_rules SET paused = 0, auto_paused = 0 \
+                 WHERE uid = ? AND paused = 1 AND auto_paused = 1 \
+                 AND device_group_in IN ({})",
+                placeholders
+            );
+            let mut q = sqlx::query(&sql).bind(user_id);
+            for gid in new_authorized_group_ids {
+                q = q.bind(gid);
+            }
+            let resumed = q.execute(&mut *tx).await?.rows_affected();
+            if resumed > 0 {
+                tracing::info!(
+                    "buy_plan: user {} purchased plan {}, {} previously auto-paused rule(s) resumed",
+                    user_id, plan_id, resumed
+                );
+            }
         }
 
         tx.commit().await?;

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -3202,6 +3202,218 @@ async fn buy_plan_grant_all_then_per_group_resets_all_flag() {
     assert_eq!(db.list_user_device_groups(alice).await.unwrap(), vec![52]);
 }
 
+/// v1.0.8: re-buying a plan that re-grants a group must auto-resume a rule
+/// this system previously auto-paused on that group (not just fix the
+/// authorization set) — otherwise the user pays for the line again but it
+/// stays dark until someone manually clicks resume.
+#[tokio::test]
+async fn buy_plan_resumes_auto_paused_rules_when_group_reauthorized() {
+    let db = repo().await;
+    let (alice, pid_a) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 51, alice).await;
+    let pid_b = db
+        .insert_plan("pB", 10, 1000, "5.00", "data", 0, false, false, "", false)
+        .await
+        .unwrap();
+    db.set_plan_device_groups(pid_a, &[50]).await.unwrap();
+    db.set_plan_device_groups(pid_b, &[51]).await.unwrap();
+
+    // 1) Buy plan A (grants 50) — rule on group 50 is unpaused.
+    sqlx::query(
+        "INSERT INTO forward_rules (id, name, uid, listen_port, device_group_in, \
+         target_addr, target_port, paused) VALUES (200, 'r200', ?, 20000, 50, '127.0.0.1', 80, 0)",
+    )
+    .bind(alice)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+
+    // 2) Buy plan B (grants only 51) — REPLACE revokes group 50, so buy_plan
+    // itself auto-pauses rule 200 (auto_paused=1).
+    db.buy_plan(
+        alice,
+        pid_b,
+        "pB",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[51],
+        &[51],
+    )
+    .await
+    .unwrap();
+    let (paused, auto_paused): (bool, bool) =
+        sqlx::query_as("SELECT paused, auto_paused FROM forward_rules WHERE id = 200")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(paused && auto_paused, "buy_plan must auto-pause rule 200");
+
+    // 3) Buy plan A again (re-grants 50) — the rule must AUTO-RESUME.
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+    let (paused, auto_paused): (bool, bool) =
+        sqlx::query_as("SELECT paused, auto_paused FROM forward_rules WHERE id = 200")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(
+        !paused && !auto_paused,
+        "re-authorizing group 50 must auto-resume the rule buy_plan itself paused"
+    );
+}
+
+/// v1.0.8: a rule the user paused THEMSELVES (via the on/off switch, which
+/// clears auto_paused) must NOT be silently revived by a later purchase, even
+/// if that purchase happens to re-grant the rule's group. Only rules the
+/// SYSTEM paused (auto_paused=1) are eligible for buy_plan's auto-resume.
+#[tokio::test]
+async fn buy_plan_does_not_resume_manually_paused_rules() {
+    let db = repo().await;
+    let (alice, pid_a) = seed_buyer_and_plan(&db, "100.00", 1000, "5.00", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    seed_device_group(&db, 51, alice).await;
+    let pid_b = db
+        .insert_plan("pB", 10, 1000, "5.00", "data", 0, false, false, "", false)
+        .await
+        .unwrap();
+    db.set_plan_device_groups(pid_a, &[50]).await.unwrap();
+    db.set_plan_device_groups(pid_b, &[51]).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO forward_rules (id, name, uid, listen_port, device_group_in, \
+         target_addr, target_port, paused) VALUES (201, 'r201', ?, 20001, 50, '127.0.0.1', 80, 0)",
+    )
+    .bind(alice)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+
+    // buy_plan B auto-pauses rule 201 (group 50 revoked).
+    db.buy_plan(
+        alice,
+        pid_b,
+        "pB",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[51],
+        &[51],
+    )
+    .await
+    .unwrap();
+
+    // The user explicitly re-confirms the pause via the on/off switch
+    // (update_rule_fields) — this clears auto_paused, marking it as a HUMAN
+    // decision regardless of the rule already being paused.
+    let scope = crate::db::repo::ResourceScope::All;
+    db.update_rule_fields(
+        201,
+        &scope,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(true),
+    )
+    .await
+    .unwrap();
+    let (_, auto_paused): (bool, bool) =
+        sqlx::query_as("SELECT paused, auto_paused FROM forward_rules WHERE id = 201")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(
+        !auto_paused,
+        "an explicit paused write must clear auto_paused"
+    );
+
+    // Buy plan A again (re-grants 50) — the rule must STAY paused, since it is
+    // no longer flagged as a system pause.
+    db.buy_plan(
+        alice,
+        pid_a,
+        "pA",
+        500,
+        1000,
+        10,
+        0,
+        false,
+        false,
+        &[50],
+        &[50],
+    )
+    .await
+    .unwrap();
+    let (paused,): (bool,) = sqlx::query_as("SELECT paused FROM forward_rules WHERE id = 201")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(
+        paused,
+        "a manually-paused rule must NOT be auto-resumed by a later purchase"
+    );
+}
+
 #[tokio::test]
 async fn buy_plan_grant_all_sets_flag() {
     let db = repo().await;

--- a/crates/panel/src/db/sqlite_repo/user_groups.rs
+++ b/crates/panel/src/db/sqlite_repo/user_groups.rs
@@ -88,17 +88,23 @@ impl DeviceGroupAuthRepository for SqliteRepository {
         allowed_group_ids: &[i64],
     ) -> Result<u64, DbError> {
         // Empty allowed list → pause ALL of the user's currently-active rules.
+        // v1.0.8: auto_paused=1 marks this as a SYSTEM pause (vs. a human using
+        // the on/off switch), so a later re-authorization can safely auto-resume
+        // it.
         if allowed_group_ids.is_empty() {
-            let r = sqlx::query("UPDATE forward_rules SET paused = 1 WHERE uid = ? AND paused = 0")
-                .bind(user_id)
-                .execute(&self.pool)
-                .await?;
+            let r = sqlx::query(
+                "UPDATE forward_rules SET paused = 1, auto_paused = 1 \
+                 WHERE uid = ? AND paused = 0",
+            )
+            .bind(user_id)
+            .execute(&self.pool)
+            .await?;
             return Ok(r.rows_affected());
         }
         // Build "device_group_in NOT IN (?, ?, ...)" with bound params.
         let placeholders = vec!["?"; allowed_group_ids.len()].join(", ");
         let sql = format!(
-            "UPDATE forward_rules SET paused = 1 \
+            "UPDATE forward_rules SET paused = 1, auto_paused = 1 \
              WHERE uid = ? AND paused = 0 AND device_group_in NOT IN ({})",
             placeholders
         );

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -252,6 +252,13 @@ export interface UserSelf {
   plan_expire_at?: string | null;
   /** v1.0.8: admin suspension (login allowed; forwarding gated). */
   suspended?: boolean;
+  /** v1.0.8: true when unrestricted (admin, or all_device_groups) — every
+   *  inbound line is usable. False = `available_groups` lists the specific
+   *  lines this user is authorized for. */
+  all_groups?: boolean;
+  /** v1.0.8: names of the device groups (lines) this user can currently use.
+   *  Empty when `all_groups` is true or the user has no authorization. */
+  available_groups?: string[];
 }
 
 /** v0.4.10 PR4: admin password reset body (PUT /admin/users/{id}/password). */

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -52,6 +52,9 @@ export const enUS: Dict = {
   accountTrafficLimit: 'Traffic quota',
   accountMemberSince: 'Member since',
   accountLoadFailed: 'Failed to load account info',
+  // v1.0.8: account page "Available Lines" row
+  accountAvailableGroups: 'Available Lines',
+  noneAssigned: 'None assigned',
   // v0.4.11 PR2: regular user nav labels
   myRules: 'My Rules',
   availableNodes: 'Node Status',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -51,6 +51,9 @@ export const zhCN = {
   accountTrafficLimit: '流量额度',
   accountMemberSince: '注册时间',
   accountLoadFailed: '加载账户信息失败',
+  // v1.0.8: account page "可用线路" row
+  accountAvailableGroups: '可用线路',
+  noneAssigned: '未分配',
   // v0.4.11 PR2: regular user nav labels
   myRules: '我的规则',
   availableNodes: '节点状态',

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Card, Descriptions, Spin, Button, Space, Modal, Form, Input, message, Typography, Result, Progress, Alert } from 'antd';
+import { Card, Descriptions, Spin, Button, Space, Modal, Form, Input, message, Typography, Result, Progress, Alert, Tag } from 'antd';
 import { LockOutlined, LogoutOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import api from '../api/client';
@@ -130,6 +130,19 @@ export default function Account() {
           {/* v1.0.8: plan expiry (null = no expiry). */}
           <Descriptions.Item label={t('accountPlanExpiry')}>
             {me.plan_expire_at ? <span className="rp-mono">{me.plan_expire_at}</span> : t('unlimited')}
+          </Descriptions.Item>
+          {/* v1.0.8: available lines — "全部" when unrestricted (admin or
+              all_device_groups), otherwise the specific authorized group names. */}
+          <Descriptions.Item label={t('accountAvailableGroups')}>
+            {me.all_groups ? (
+              <Tag color="green">{t('allGroups')}</Tag>
+            ) : me.available_groups && me.available_groups.length > 0 ? (
+              <Space wrap>
+                {me.available_groups.map((name) => <Tag key={name}>{name}</Tag>)}
+              </Space>
+            ) : (
+              <Text type="secondary">{t('noneAssigned')}</Text>
+            )}
           </Descriptions.Item>
           <Descriptions.Item label={t('accountBalance')}>
             <span className="rp-mono">{me.balance}</span>


### PR DESCRIPTION
## 概述

两块工作,同一 PR:

### 1. 购买重新授权时自动恢复规则(§5 收尾)
之前 `buy_plan` 失权会暂停规则,但重新买回授权时**不会自动恢复**——用户付了钱线路却还是暂停,得手动点启动。

新增 `forward_rules.auto_paused` 区分**系统自动暂停**和**用户手动暂停**:
- schema:`auto_paused`(SQLite Migration 37 / PG Revision 20,PG_SCHEMA_VERSION 19→20),幂等 add-column,默认 0
- `pause_rules_outside_groups` + `buy_plan` 暂停路径 → 打 `auto_paused=1`
- `update_rule_fields`:任何显式 `paused` 写入都清 `auto_paused`(开关是人为动作,永远覆盖系统标记)
- `buy_plan`:对称的自动恢复——`auto_paused=1` 且分组重回授权集的规则自动 un-pause;**用户自己关掉的规则(`auto_paused=0`)即使分组再被授权也不动**
- 测试(双库):重新授权→自动恢复;手动暂停的→不被购买复活

### 2. 个人中心显示可用线路 + 提示中文化
- 个人中心新增「可用线路」行:不受限用户(管理员/all_device_groups)显示「全部分组」;受限用户显示已授权分组名;无授权显示「未分配」
- `/user/me` 返回 `all_groups` + `available_groups`,后端新增 `list_group_names_by_ids`(双库)
- 最后一条英文规则报错中文化(「无法启动未被授权设备分组下的规则」)

## 验证
- `cargo test --workspace`:364(panel)+ 79(node)+ 其余全过
- clippy / fmt 干净;`repo-test-parity` 88 sqlite / 87 pg 对齐
- 前端 tsc / eslint / vite build 干净

不含版本 bump(按攒批流程,发版时统一处理)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)