### PR TITLE
fix(users): lock manual device-group edit while a plan is active

### DIFF
--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -481,6 +481,8 @@ export const enUS: Dict = {
   allDeviceGroups: 'Allow all device groups',
   allDeviceGroupsHint: 'When on, the user may use every inbound group (including ones created later). When off, only the groups selected below.',
   deviceGroupsHint: 'Inbound groups this user can use to create forwarding rules. Empty = cannot forward.',
+  // v1.0.8: when the user has a plan, device groups are managed by the plan and the manual selector is disabled.
+  deviceGroupsManagedByPlan: 'This user has a plan — available groups are managed by the plan automatically. To set them manually, remove the plan first.',
   batchDelete: 'Batch Delete',
   batchExport: 'Batch Export',
   batchDeleteConfirm: 'Delete {count} selected rules? This cannot be undone.',
@@ -521,7 +523,7 @@ export const enUS: Dict = {
   planGrantAll: 'Grant All Groups',
   planGrantAllHint: 'When on, buying this plan grants access to ALL inbound groups (including ones created later).',
   planGrantGroups: 'Granted Lines',
-  planGrantGroupsHint: 'Buying this plan appends these inbound groups to the user (never removes existing; not revoked on expiry).',
+  planGrantGroupsHint: "Buying/assigning this plan REPLACES the user's current authorization with these groups (not appended); not revoked on expiry. Once a user has a plan, the manual \"Device Groups\" control is locked — this is the only place to manage it.",
   planGrantGroupsPlaceholder: 'Select inbound groups to grant',
   days: 'days',
   buyNow: 'Buy Now',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -480,6 +480,8 @@ export const zhCN = {
   allDeviceGroups: '允许所有设备分组',
   allDeviceGroupsHint: '开启后该用户可使用全部入口分组（含日后新建的）；关闭后只能使用下方指定的分组。',
   deviceGroupsHint: '该用户可用于创建转发规则的入口分组。留空 = 不能转发。',
+  // v1.0.8: 用户挂了套餐时，设备分组改由套餐自动管理，手动入口禁用。
+  deviceGroupsManagedByPlan: '该用户已开通套餐，可用分组由套餐自动管理。如需手动指定，请先移除套餐。',
   batchDelete: '批量删除',
   batchExport: '批量导出',
   batchDeleteConfirm: '确定删除选中的 {count} 条规则？此操作不可撤销。',
@@ -520,7 +522,7 @@ export const zhCN = {
   planGrantAll: '授权全部设备组',
   planGrantAllHint: '开启后购买此套餐将授权用户使用全部入口分组（含日后新建的）。',
   planGrantGroups: '授权线路',
-  planGrantGroupsHint: '购买此套餐将把这些入口分组追加到用户授权（不覆盖已有，到期不撤销）。',
+  planGrantGroupsHint: '购买/开通此套餐将用这些分组替换用户当前的授权（不是追加）；到期不自动撤销。用户挂了套餐后，「设备分组」手动入口会被锁定，全部由套餐这里管理。',
   planGrantGroupsPlaceholder: '选择授权的入口分组',
   days: '天',
   buyNow: '立即购买',

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,4 +1,4 @@
-import { Table, Button, Tag, Popconfirm, message, Progress, Tooltip, Modal, Form, Input, InputNumber, Switch, Space, Select, DatePicker, Divider } from 'antd';
+import { Table, Button, Tag, Popconfirm, message, Progress, Tooltip, Modal, Form, Input, InputNumber, Switch, Space, Select, DatePicker, Divider, Alert } from 'antd';
 import { EditOutlined, ReloadOutlined, UndoOutlined, UserOutlined, PlusOutlined, KeyOutlined, ApiOutlined, ShoppingOutlined } from '@ant-design/icons';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -191,7 +191,13 @@ export default function Users() {
     }
     // v1.0.7: send the per-user device-group authorization. Admins are always
     // all-allowed, so the editor hides these and we skip sending them.
-    if (!editing.admin) {
+    // v1.0.8: a plan-holding user's groups are owned by the plan (buy_plan
+    // REPLACEs them); the fields are disabled in the form for these users, but
+    // we ALSO skip sending them here — the form always carries a value for
+    // every field regardless of whether the disabled control was touched, and
+    // sending it would let a routine balance/max_rules save silently re-run
+    // the group write for no reason.
+    if (!editing.admin && !editing.plan_id) {
       payload.all_device_groups = values.all_device_groups;
       // When all_device_groups is on the explicit list is moot, but sending it
       // is harmless (the backend ignores it for authorization). Send [] then so
@@ -458,13 +464,27 @@ export default function Users() {
           </Form.Item>
           {!editing?.admin && (
             <>
+              {/* v1.0.8: a plan now owns device-group authorization end to end
+                  (buy_plan REPLACEs it, auto-pauses/resumes affected rules).
+                  Letting the manual selector below ALSO write user_device_groups
+                  created a silent last-write-wins conflict with whichever the
+                  admin touched second. Lock the manual controls whenever the
+                  user has a plan — remove the plan first to hand-manage groups. */}
+              {!!editing?.plan_id && (
+                <Alert
+                  type="info"
+                  showIcon
+                  message={t('deviceGroupsManagedByPlan')}
+                  style={{ marginBottom: 12 }}
+                />
+              )}
               <Form.Item
                 name="all_device_groups"
                 label={t('allDeviceGroups')}
                 tooltip={t('allDeviceGroupsHint')}
                 valuePropName="checked"
               >
-                <Switch />
+                <Switch disabled={!!editing?.plan_id} />
               </Form.Item>
               <Form.Item
                 name="device_group_ids"
@@ -474,7 +494,7 @@ export default function Users() {
                 <Select
                   mode="multiple"
                   allowClear
-                  disabled={allDeviceGroups}
+                  disabled={allDeviceGroups || !!editing?.plan_id}
                   placeholder={t('selectDeviceGroups')}
                   style={{ width: '100%' }}
                   options={deviceGroups.map(g => ({ value: g.id, label: `${g.name} (#${g.id})` }))}


### PR DESCRIPTION
## 问题

「编辑用户」弹窗里同时存在两个控制设备分组授权的入口:

- **"设备分组"手动多选框** → 点整体"保存" → `PUT /admin/users/{id}`
- **"开通并扣费"**(买套餐) → `buy_plan`,用套餐自己的分组 **REPLACE** 掉 `user_device_groups`

两者互不知道对方存在,**谁最后点谁赢**,没有任何提示——手动选完分组去开套餐,选择被静默覆盖;反过来编辑分组也会覆盖套餐给的授权。

## 方向(已确认)

套餐一旦挂在用户身上,分组授权完全交给套餐管;要手动控制就先移除套餐。

## 改动

- 用户挂着套餐(`plan_id` 非空)时,"允许所有设备分组"开关 + "设备分组"多选框**禁用置灰**,并显示提示:"该用户已开通套餐，可用分组由套餐自动管理。如需手动指定，请先移除套餐。"
- 保存表单时,**不再发送** `all_device_groups`/`device_group_ids` 字段给有套餐的用户——表单本来就会无条件带上这两个字段的当前值,不管有没有被改动过,不跳过的话连改个余额都会顺手把分组重写一次。
- 顺手修了 Plans 管理页一处过期文案(还写着 PR33 之前"追加不覆盖"的旧语义,现已是 REPLACE)。

## 验证

真实起了本地环境(panel + vite)手动跑了一遍,不只是单测:
- 建分组 + 建套餐关联该分组 + 建测试用户(自动继承默认套餐)
- 有套餐 → 两个控件确认禁用,提示正确显示
- 移除套餐 → 立刻解锁
- 重新开通套餐 → 分组正确写入
- **有套餐时只改余额保存 → 分组数据原样保留,未被误清空**

前端 tsc / eslint 干净。不涉及后端改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
