### PR TITLE
fix(node): TCP_NODELAY (fix jitter on long chains) + disable WS/TLS entry transport

### DIFF
--- a/crates/node/src/forwarder/limiter.rs
+++ b/crates/node/src/forwarder/limiter.rs
@@ -6,11 +6,21 @@
 // get double the budget, and the cap is on the RULE's aggregate traffic, not
 // per-connection.
 //
-// Implementation: a classic continuously-refilled token bucket per direction,
-// refilled lazily on each `acquire()` (elapsed time × rate). When the requested
-// amount exceeds the current balance, the caller sleeps for the deficit time
-// and then consumes. This keeps steady-state throughput at exactly the cap and
-// allows short bursts up to the bucket capacity (= 1 second of traffic).
+// Implementation: a continuously-refilled token bucket per direction. The
+// balance math is done in a SYNCHRONOUS `Bucket::charge()` that runs under the
+// bucket lock and returns how long the caller must sleep; the SLEEP then
+// happens AFTER the lock is released (RuleLimiter::charge). This is critical:
+// the bucket is shared across ALL of a rule's connections, so if a throttled
+// connection slept while holding the lock, every other connection of the rule
+// would be frozen behind it (head-of-line blocking → jitter + unfairness).
+//
+// The balance is allowed to go NEGATIVE ("debt"): a chunk LARGER than the burst
+// capacity is still admitted, it just incurs a proportionally longer wait to
+// repay the debt. (The earlier version capped the balance and looped forever
+// when `want > rate*burst`, hanging any connection whose read chunk exceeded
+// one second of the configured rate — e.g. a 64 KiB read on a sub-512 kbps
+// limit.) Steady-state throughput still equals the cap; short bursts up to one
+// second of traffic are allowed.
 //
 // A rate of 0 / None means unlimited: `acquire()` is a no-op, so unlimited
 // rules pay only a single branch per chunk.
@@ -27,8 +37,10 @@ const BURST_SECS: u64 = 1;
 struct Bucket {
     /// Refill rate in bytes/sec. 0 = this direction is unlimited.
     rate_bps: u64,
-    /// Current token balance (capped at rate_bps * BURST_SECS).
-    tokens: u64,
+    /// Current token balance in bytes. The POSITIVE side is capped at
+    /// rate_bps * BURST_SECS; the balance MAY go negative ("debt") so a chunk
+    /// bigger than the burst capacity is still admitted (with a longer wait).
+    tokens: f64,
     last_refill: Instant,
 }
 
@@ -37,38 +49,41 @@ impl Bucket {
         Self {
             rate_bps,
             // Start full so the first chunk isn't artificially delayed.
-            tokens: rate_bps.saturating_mul(BURST_SECS),
+            tokens: rate_bps.saturating_mul(BURST_SECS) as f64,
             last_refill: Instant::now(),
         }
     }
 
-    /// Refill based on elapsed wall time, then consume `want` bytes (sleeping
-    /// if the balance is too low). Returns the bytes actually reserved (always
-    /// == want once the await completes).
-    async fn acquire(&mut self, want: u64) {
+    /// SYNCHRONOUS: refill by elapsed wall time (positive side capped at the
+    /// burst ceiling), then charge `want` bytes — the balance is allowed to go
+    /// negative. Returns `Some(wait)` if the caller must sleep to repay the
+    /// resulting debt, or `None` if there was enough balance.
+    ///
+    /// This intentionally does NOT sleep: the caller (RuleLimiter::charge) holds
+    /// the bucket lock only for this call and releases it BEFORE sleeping, so a
+    /// throttled connection never blocks the other connections sharing the
+    /// bucket. Because `want` is charged unconditionally (into debt if needed),
+    /// there is no unbounded retry loop — a large chunk simply yields a larger
+    /// (but finite) `wait`.
+    fn charge(&mut self, want: u64) -> Option<Duration> {
         if self.rate_bps == 0 {
-            return;
+            return None;
         }
-        let cap = self.rate_bps.saturating_mul(BURST_SECS);
-        loop {
-            let now = Instant::now();
-            let elapsed = now.duration_since(self.last_refill).as_secs_f64();
-            // Lazily refill, capped at the burst ceiling.
-            self.tokens = (self.tokens as f64 + elapsed * self.rate_bps as f64) as u64;
-            if self.tokens > cap {
-                self.tokens = cap;
-            }
-            self.last_refill = now;
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.last_refill = now;
 
-            if self.tokens >= want {
-                self.tokens -= want;
-                return;
-            }
-            // Not enough: sleep for the time needed to earn the remaining bytes,
-            // then loop to recompute (avoids underflow on u64).
-            let deficit = want - self.tokens;
-            let wait = Duration::from_secs_f64(deficit as f64 / self.rate_bps as f64);
-            tokio::time::sleep(wait).await;
+        let cap = self.rate_bps.saturating_mul(BURST_SECS) as f64;
+        self.tokens += elapsed * self.rate_bps as f64;
+        if self.tokens > cap {
+            // Only the positive (burst-credit) side is capped; debt is not.
+            self.tokens = cap;
+        }
+        self.tokens -= want as f64;
+        if self.tokens >= 0.0 {
+            None
+        } else {
+            Some(Duration::from_secs_f64(-self.tokens / self.rate_bps as f64))
         }
     }
 }
@@ -103,12 +118,23 @@ impl RuleLimiter {
         self.unlimited
     }
 
+    /// Charge `n` bytes against a bucket, then sleep for any resulting debt.
+    /// The lock is held ONLY for the synchronous `charge()` and is dropped
+    /// (end of the block) BEFORE the sleep — so a throttled connection never
+    /// holds the shared bucket lock while it waits.
+    async fn charge(bucket: &Mutex<Bucket>, n: u64) {
+        let wait = { bucket.lock().await.charge(n) };
+        if let Some(w) = wait {
+            tokio::time::sleep(w).await;
+        }
+    }
+
     /// Reserve `n` upload (client→target) bytes. No-op for unlimited limiters.
     pub async fn acquire_upload(&self, n: u64) {
         if self.unlimited {
             return;
         }
-        self.upload.lock().await.acquire(n).await;
+        Self::charge(&self.upload, n).await;
     }
 
     /// Reserve `n` download (target→client) bytes. No-op for unlimited limiters.
@@ -116,7 +142,7 @@ impl RuleLimiter {
         if self.unlimited {
             return;
         }
-        self.download.lock().await.acquire(n).await;
+        Self::charge(&self.download, n).await;
     }
 }
 
@@ -200,5 +226,53 @@ mod tests {
         // two halves may serialize on the bucket lock, but the refill time is
         // bounded by the aggregate amount).
         assert!(start.elapsed() >= Duration::from_millis(900));
+    }
+
+    /// Regression: a chunk LARGER than the burst capacity (rate * BURST_SECS)
+    /// must still complete, not loop forever. The old code capped the balance
+    /// below `want` and spun forever, hanging the connection. Rate is high so
+    /// the real wait is short (~0.5s).
+    #[tokio::test]
+    async fn large_chunk_over_burst_does_not_hang() {
+        // 100_000 B/s, burst cap = 100_000. Ask for 150_000 (1.5× the cap).
+        let r = RateLimit::new(Some(100_000), None);
+        let start = Instant::now();
+        r.acquire_upload(150_000).await;
+        let elapsed = start.elapsed();
+        // Starts with the full 100_000 burst → 50_000 debt at 100_000 B/s ≈ 0.5s.
+        assert!(
+            elapsed >= Duration::from_millis(400),
+            "must wait to repay the debt, got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "must not hang — the wait is finite, got {:?}",
+            elapsed
+        );
+    }
+
+    /// Two connections sharing a rate-limited bucket both complete and the
+    /// aggregate is paced to the cap (not doubled). The lock is provably NOT
+    /// held during the sleep because `Bucket::charge` is synchronous and its
+    /// guard is dropped before `RuleLimiter::charge` sleeps.
+    #[tokio::test]
+    async fn concurrent_charges_complete_and_pace_to_cap() {
+        let r = RateLimit::new(Some(100_000), None);
+        r.acquire_upload(100_000).await; // drain the burst
+        let r2 = r.clone();
+        let start = Instant::now();
+        let h1 = tokio::spawn(async move { r.acquire_upload(50_000).await });
+        let h2 = tokio::spawn(async move { r2.acquire_upload(50_000).await });
+        h1.await.unwrap();
+        h2.await.unwrap();
+        // 100_000 bytes of debt at 100_000 B/s → the later charger waits ~1s;
+        // both sleep concurrently, so total ≈ 1s (bounded, no deadlock).
+        let elapsed = start.elapsed();
+        assert!(
+            (Duration::from_millis(800)..Duration::from_secs(3)).contains(&elapsed),
+            "aggregate must pace to the cap, got {:?}",
+            elapsed
+        );
     }
 }

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -359,21 +359,32 @@ impl ForwarderManager {
                 );
                 continue;
             }
-            // v0.4.1: TlsSimple requires a configured TLS acceptor. If none is
-            // set (no TLS_CERT_PATH/TLS_KEY_PATH), skip the listener + report
-            // an error so the operator knows why it's not forwarding. Raw/WS
-            // listeners are completely unaffected.
-            if listener.node_transport == NodeTransport::TlsSimple && self.tls_acceptor.is_none() {
+            // v1.0.8: WS / TLS entry transports are DISABLED at runtime. The
+            // panel hid them in v0.4.20 (every rule is `raw`), and having the
+            // NODE terminate WS/TLS is fundamentally incompatible with
+            // transparently relaying an end-to-end tunnel — VLESS+WS+TLS,
+            // Trojan, VMess, etc. MUST be raw-forwarded, because the client's
+            // WS/TLS handshake is meant for the FINAL server, not this relay.
+            // The implementations (ws.rs / tls.rs / cert_reloader.rs) are kept
+            // for possible future revival but are never served. A stray ws/tls
+            // config is skipped + reported so the operator can see why the port
+            // isn't forwarding (the `(Tcp, Ws)` / `(Tcp, TlsSimple)` match arms
+            // below are consequently unreachable at runtime — kept on purpose).
+            if matches!(
+                listener.node_transport,
+                NodeTransport::Ws | NodeTransport::TlsSimple
+            ) {
                 tracing::warn!(
-                    "rule {}: tls_simple listener on {} skipped — no TLS cert configured \
-                     (set TLS_CERT_PATH + TLS_KEY_PATH)",
+                    "rule {}: node_transport {:?} is disabled and will not be served — \
+                     skipping listener on port {} (use raw; WS/TLS entry transport is retired)",
                     rule_id,
+                    listener.node_transport,
                     port
                 );
                 errors.lock().await.push(ListenerError {
                     port,
                     protocol: proto_str.clone(),
-                    error: "tls_simple skipped: no TLS certificate configured".into(),
+                    error: format!("{:?} entry transport is disabled", listener.node_transport),
                 });
                 continue;
             }
@@ -776,32 +787,36 @@ mod tests {
         assert!(keys.contains(&(40002, Protocol::Udp, NodeTransport::Raw)));
     }
 
+    /// v1.0.8: WS entry transport is disabled — a ws rule must NOT start a
+    /// listener, and a listener_error must be reported so the panel shows why.
     #[tokio::test]
-    async fn ws_ingress_is_scheduled() {
+    async fn ws_ingress_is_disabled() {
         let mut mgr = fresh_mgr();
         mgr.apply_config(&one_rule(40010, Protocol::Tcp, NodeTransport::Ws))
             .await;
-        assert!(mgr
-            .listener_keys()
-            .contains(&(40010, Protocol::Tcp, NodeTransport::Ws)));
+        assert!(
+            mgr.listener_keys().is_empty(),
+            "ws entry transport is disabled — no listener must start"
+        );
+        let errs = mgr.take_listener_errors().await;
+        assert_eq!(errs.len(), 1, "a listener_error must be pushed");
+        assert!(errs[0].error.contains("disabled"), "got: {}", errs[0].error);
     }
 
+    /// v1.0.8: TLS entry transport is disabled — a tls_simple rule is skipped
+    /// (regardless of whether a cert is configured) with a reported error.
     #[tokio::test]
-    async fn tls_simple_skipped_when_no_cert_configured() {
-        // v0.4.1: without a TLS acceptor (no TLS_CERT_PATH), a tls_simple rule
-        // is skipped + an error is pushed. Raw/WS listeners are unaffected.
+    async fn tls_simple_is_disabled() {
         let mut mgr = fresh_mgr();
-        // tls_acceptor is None by default (fresh_mgr doesn't set it).
         mgr.apply_config(&one_rule(40030, Protocol::Tcp, NodeTransport::TlsSimple))
             .await;
         assert!(
             mgr.listener_keys().is_empty(),
-            "tls_simple without cert must not start"
+            "tls_simple is disabled — no listener must start"
         );
-        // The error must be reported so the panel shows it.
         let errs = mgr.take_listener_errors().await;
         assert_eq!(errs.len(), 1, "a listener_error must be pushed");
-        assert!(errs[0].error.contains("no TLS certificate configured"));
+        assert!(errs[0].error.contains("disabled"), "got: {}", errs[0].error);
     }
 
     #[tokio::test]
@@ -812,8 +827,11 @@ mod tests {
         assert!(mgr.listener_keys().is_empty());
     }
 
+    /// The ListenerKey includes the protocol, so a TCP and a UDP raw listener
+    /// on the SAME port are two distinct listeners. (v1.0.8: this used to pair
+    /// raw+ws, but ws is disabled now; tcp+udp is the remaining same-port case.)
     #[tokio::test]
-    async fn same_port_different_transport_are_distinct_listeners() {
+    async fn same_port_tcp_and_udp_are_distinct_listeners() {
         let mut mgr = fresh_mgr();
         let c = NodeConfigResponse {
             listeners: vec![
@@ -831,8 +849,8 @@ mod tests {
                 ListenerConfig {
                     rule_id: 2,
                     port: 40050,
-                    protocol: Protocol::Tcp,
-                    node_transport: NodeTransport::Ws,
+                    protocol: Protocol::Udp,
+                    node_transport: NodeTransport::Raw,
                     ws_path: None,
                     targets: vec!["127.0.0.1:1".into()],
                     load_balance_strategy: relay_shared::protocol::LoadBalanceStrategy::First,
@@ -972,12 +990,12 @@ mod tests {
         assert_eq!(fp2.load_balance_strategy, LoadBalanceStrategy::RoundRobin);
     }
 
-    /// v0.4.7: a node_transport change (e.g. raw→ws via a tunnel profile) must
-    /// restart the listener so the right forwarder is spawned. The fingerprint
-    /// now includes node_transport, so a transport flip is a different
-    /// fingerprint even when targets/ws_path are unchanged.
+    /// v1.0.8: flipping a raw listener to a now-DISABLED transport (ws) must
+    /// tear the raw listener down and serve nothing — the disabled transport is
+    /// skipped, so no new key appears. (Before ws was disabled this tested the
+    /// raw→ws restart; ws.rs is kept but no longer served.)
     #[tokio::test]
-    async fn transport_change_restarts_listener() {
+    async fn transport_change_to_disabled_stops_listener() {
         let mut mgr = fresh_mgr();
         let mk = |transport: NodeTransport| NodeConfigResponse {
             listeners: vec![ListenerConfig {
@@ -993,12 +1011,11 @@ mod tests {
             }],
         };
         mgr.apply_config(&mk(NodeTransport::Raw)).await;
-        // raw listener keyed under Raw transport.
         assert!(mgr
             .fingerprint(&(40066, Protocol::Tcp, NodeTransport::Raw))
             .is_some());
-        // Flip transport to Ws on the same port. The old Raw key must be gone
-        // and a new Ws key must exist — i.e. the listener was restarted.
+        // Flip to ws (disabled): the old raw listener is stopped, and ws is
+        // skipped, so NO listener remains for this port.
         mgr.apply_config(&mk(NodeTransport::Ws)).await;
         assert!(
             mgr.fingerprint(&(40066, Protocol::Tcp, NodeTransport::Raw))
@@ -1007,42 +1024,12 @@ mod tests {
         );
         assert!(
             mgr.fingerprint(&(40066, Protocol::Tcp, NodeTransport::Ws))
-                .is_some(),
-            "new ws listener must be started after transport flip"
+                .is_none(),
+            "ws is disabled — no ws listener may start"
         );
-    }
-
-    /// ws_path change on a WS listener must restart it.
-    #[tokio::test]
-    async fn ws_path_change_restarts_listener() {
-        let mut mgr = fresh_mgr();
-        let c1 = cfg(
-            40063,
-            Protocol::Tcp,
-            NodeTransport::Ws,
-            vec!["127.0.0.1:9"],
-            Some("/a"),
-        );
-        mgr.apply_config(&c1).await;
-        assert_eq!(
-            mgr.fingerprint(&(40063, Protocol::Tcp, NodeTransport::Ws))
-                .unwrap()
-                .ws_path,
-            Some("/a".to_string())
-        );
-        let c2 = cfg(
-            40063,
-            Protocol::Tcp,
-            NodeTransport::Ws,
-            vec!["127.0.0.1:9"],
-            Some("/b"),
-        );
-        mgr.apply_config(&c2).await;
-        assert_eq!(
-            mgr.fingerprint(&(40063, Protocol::Tcp, NodeTransport::Ws))
-                .unwrap()
-                .ws_path,
-            Some("/b".to_string())
+        assert!(
+            mgr.listener_keys().is_empty(),
+            "no listener should remain for the port"
         );
     }
 

--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -159,17 +159,30 @@ fn interface_ipv4(name: &str) -> Result<Ipv4Addr, OutboundError> {
 
 /// Create a TCP stream connected to `target`, optionally binding to
 /// `source_ipv4:0` first.
+///
+/// v1.0.8: TCP_NODELAY is set on the outbound stream. This node is a relay —
+/// disabling Nagle's algorithm is essential. With Nagle ON, small writes are
+/// buffered until an ACK returns, and combined with the peer's delayed-ACK
+/// (~40ms) this adds up to ~40ms of variable latency PER HOP. On a long relay
+/// chain that compounds into severe jitter and makes interactive traffic
+/// (SSH/RDP/gaming/request-response) unusable. Every serious proxy sets
+/// TCP_NODELAY on both ends; the inbound (accept) side is set in tcp.rs.
 pub async fn tcp_connect(
     target: &str,
     source_ipv4: Option<Ipv4Addr>,
     _timeout_secs: u64,
 ) -> Result<TcpStream, OutboundError> {
-    match source_ipv4 {
+    let stream = match source_ipv4 {
         None => TcpStream::connect(target)
             .await
-            .map_err(OutboundError::Connect),
-        Some(src) => tcp_connect_bound(target, src).await,
+            .map_err(OutboundError::Connect)?,
+        Some(src) => tcp_connect_bound(target, src).await?,
+    };
+    // Non-fatal: a socket that just connected virtually never rejects this.
+    if let Err(e) = stream.set_nodelay(true) {
+        tracing::debug!("outbound: set_nodelay(true) failed for {}: {}", target, e);
     }
+    Ok(stream)
 }
 
 async fn tcp_connect_bound(target: &str, src: Ipv4Addr) -> Result<TcpStream, OutboundError> {
@@ -437,6 +450,39 @@ mod tests {
             .expect("auto-route connect must succeed");
         assert!(stream.peer_addr().unwrap().port() == port);
         assert!(accept.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn tcp_connect_sets_nodelay() {
+        // v1.0.8: the outbound stream MUST have TCP_NODELAY enabled (Nagle off)
+        // — the core of the long-chain jitter fix. Verify via the getter for
+        // both the auto-route and the source-bound paths.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let target = format!("127.0.0.1:{}", port);
+        let accept = tokio::spawn(async move {
+            // Accept twice (auto + bound connects below).
+            let a = listener.accept().await.map(|(s, _)| s);
+            let b = listener.accept().await.map(|(s, _)| s);
+            (a, b)
+        });
+
+        let auto = tcp_connect(&target, None, 5).await.expect("auto connect");
+        assert!(
+            auto.nodelay().unwrap(),
+            "auto-route stream must have NODELAY"
+        );
+
+        let bound = tcp_connect(&target, Some(Ipv4Addr::LOCALHOST), 5)
+            .await
+            .expect("bound connect");
+        assert!(
+            bound.nodelay().unwrap(),
+            "source-bound stream must have NODELAY"
+        );
+
+        let (ra, rb) = accept.await.unwrap();
+        assert!(ra.is_ok() && rb.is_ok());
     }
 
     #[tokio::test]

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -35,6 +35,17 @@ pub async fn serve_tcp_listener(
     loop {
         match listener.accept().await {
             Ok((inbound, client_addr)) => {
+                // v1.0.8: disable Nagle on the accepted (client-facing) socket.
+                // See the note in outbound::tcp_connect — a relay MUST set
+                // TCP_NODELAY on both ends or small packets get buffered ~40ms
+                // per hop, which compounds into heavy jitter on long chains.
+                if let Err(e) = inbound.set_nodelay(true) {
+                    tracing::debug!(
+                        "TCP accept {}: set_nodelay(true) failed: {}",
+                        client_addr,
+                        e
+                    );
+                }
                 let targets = targets.clone();
                 let selector = selector.clone();
                 let rate_limit = rate_limit.clone();
@@ -190,7 +201,10 @@ async fn handle_tcp_connection(
 
     let upload = Box::pin(async move {
         let mut total = 0u64;
-        let mut buf = [0u8; 16 * 1024];
+        // v1.0.8: 64 KiB copy buffer (was 16 KiB) — fewer syscalls / better
+        // throughput on high bandwidth-delay-product links. Heap-allocated as
+        // part of this Box::pin'd future, so it does not grow the task stack.
+        let mut buf = [0u8; 64 * 1024];
         loop {
             let n = match ri.read(&mut buf).await {
                 Ok(0) => break,
@@ -208,7 +222,8 @@ async fn handle_tcp_connection(
     });
     let download = Box::pin(async move {
         let mut total = 0u64;
-        let mut buf = [0u8; 16 * 1024];
+        // v1.0.8: 64 KiB copy buffer (see the upload side above).
+        let mut buf = [0u8; 64 * 1024];
         loop {
             let n = match ro.read(&mut buf).await {
                 Ok(0) => break,
@@ -229,4 +244,63 @@ async fn handle_tcp_connection(
 
     tracing::debug!("TCP: connection closed for {}", client_addr);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forwarder::outbound::bind_tcp_listener;
+    use relay_shared::protocol::LoadBalanceStrategy;
+    use std::net::IpAddr;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// v1.0.8: end-to-end raw TCP forwarding still works after the NODELAY /
+    /// 64 KiB buffer changes, and the client-facing socket has Nagle disabled.
+    /// Topology: client → [serve_tcp_listener] → echo target.
+    #[tokio::test]
+    async fn raw_tcp_forward_roundtrips_and_client_has_nodelay() {
+        // Echo target: read a chunk, write it straight back.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut s, _)) = target.accept().await {
+                let mut b = vec![0u8; 1024];
+                if let Ok(n) = s.read(&mut b).await {
+                    let _ = s.write_all(&b[..n]).await;
+                }
+            }
+        });
+
+        // Relay listener on an ephemeral port, forwarding to the echo target.
+        let listener = bind_tcp_listener(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+        let selector = Arc::new(TargetSelector::new(LoadBalanceStrategy::First, 1));
+        let counter = Arc::new(TrafficCounter::new());
+        let connections = Arc::new(ConnectionTracker::new());
+        tokio::spawn(serve_tcp_listener(
+            listener,
+            vec![target_addr.to_string()],
+            selector,
+            RateLimit::Unlimited,
+            counter.clone(),
+            connections,
+            1,
+            None,
+        ));
+
+        // Client connects to the relay and round-trips through to the echo.
+        let mut client = TcpStream::connect(listen_addr).await.unwrap();
+        // The client's own socket having NODELAY isn't what we set (we set it on
+        // the RELAY's accepted socket), but we can at least prove the relay path
+        // forwards bytes correctly under the new buffer/nodelay code.
+        client.write_all(b"ping-through-relay").await.unwrap();
+        let mut got = vec![0u8; 64];
+        let n = client.read(&mut got).await.unwrap();
+        assert_eq!(
+            &got[..n],
+            b"ping-through-relay",
+            "relay must echo the target"
+        );
+    }
 }


### PR DESCRIPTION
## 问题

用户反馈**抖动很大、很长的转发链无法满足**。

## 根因 + 修复

### 1. 核心:双侧缺 `TCP_NODELAY`(Nagle 算法)
节点所有 TCP 路径都没设过 `TCP_NODELAY`。Nagle + 对端延迟 ACK(~40ms)每跳给交互流量加 0~40ms 不确定延迟,长链累积 = 大抖动,SSH/RDP/游戏等不可用。
- 出口(`outbound::tcp_connect`,auto + 源绑定)+ 入口(tcp.rs accept)双侧设 `TCP_NODELAY`。

### 2. 吞吐:拷贝 buffer 16K→64K
减少 syscall,`Box::pin` 堆分配不涨栈。

### 3. 禁用 WS/TLS 入口传输(保留代码+依赖)
前端 v0.4.20 已隐藏;节点终结 WS/TLS 与透传端到端隧道冲突(VLESS+WS+TLS/Trojan/VMess 必须走 raw)。manager.rs 运行时跳过并上报 error,`ws.rs`/`tls.rs`/`cert_reloader.rs` 及依赖原样保留。**对透传场景零影响。**

### 4. 限速器两个 bug(限速场景才触发,一并修)
- **队头阻塞**:`acquire` 在持有共享 Mutex 时 sleep → 同规则一条连接卡住,其它连接全被冻结 → 限速下延迟抖动、连接互拖。改成 `charge` 同步算完等待时长、**释放锁再 sleep**。
- **单 chunk 大于突发容量 → 死循环挂起**:token 被钳在 `rate*1s`,`want>rate` 时永远取不够、死循环。**而 #2 的 64K buffer 把触发门槛从 <128kbps 放大到 <512kbps**(低限速规则跑批量传输会卡死)。改成允许透支(token 可为负),大 chunk 也能有限等待通过。

## 测试
- 新增:端到端 raw 转发往返、`tcp_connect_sets_nodelay`、ws/tls 禁用断言、大 chunk 不死循环、并发共享限速不互阻。
- node 测试 **82 通过**;clippy + fmt 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)