### PR TITLE
feat(node): splice(2) zero-copy forwarding for unlimited TCP rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,7 @@ name = "relay-node"
 version = "1.0.7"
 dependencies = [
  "futures-util",
+ "libc",
  "rcgen",
  "relay-shared",
  "reqwest",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -32,6 +32,10 @@ rustls = { version = "0.23", default-features = false, features = ["std", "tls12
 rustls-pemfile = "2"
 # v1.0.4: low-level socket options for IPv6-only dual-stack binding.
 socket2 = "0.5"
+# v1.0.8: Linux splice(2) zero-copy forwarding for unlimited (non-rate-limited)
+# TCP rules — data moves inside the kernel via a pipe, never copied to
+# userspace. Only used on Linux; other targets fall back to the userspace copy.
+libc = "0.2"
 
 [dev-dependencies]
 # v0.4.16: test-only cert generator for the real WSS (wss://) regression test.

--- a/crates/node/src/forwarder/mod.rs
+++ b/crates/node/src/forwarder/mod.rs
@@ -3,6 +3,10 @@ pub mod limiter;
 pub mod manager;
 pub mod outbound;
 pub mod selector;
+// v1.0.8: Linux-only splice(2) zero-copy forwarding (used by tcp.rs for
+// unlimited rules). Other targets fall back to the userspace copy.
+#[cfg(target_os = "linux")]
+pub mod splice;
 pub mod tcp;
 pub mod tls;
 pub mod udp;

--- a/crates/node/src/forwarder/splice.rs
+++ b/crates/node/src/forwarder/splice.rs
@@ -1,0 +1,256 @@
+//! v1.0.8: Linux splice(2) zero-copy bidirectional TCP forwarding.
+//!
+//! For an UNLIMITED (non-rate-limited) rule, the node forwards bytes with the
+//! `splice(2)` syscall instead of a userspace read/write copy. splice moves
+//! data *inside the kernel* through a pipe — the bytes are never copied into
+//! this process's address space — which removes the two userspace copies (and
+//! the CPU + memory-bandwidth cost) that a plain relay pays per byte. This is
+//! the same technique realm and other high-performance relays use.
+//!
+//! Structure (per direction): a non-blocking pipe is the kernel intermediary.
+//! Step 1 splices `socket → pipe` (pull up to a pipe-full from the source);
+//! step 2 splices `pipe → socket` (push them to the destination, draining
+//! fully). Readiness is driven by tokio (`readable()`/`writable()` + `try_io`),
+//! so the task parks instead of busy-looping on EAGAIN. Because the pipe is
+//! fully drained between reads, an EAGAIN in step 1 always means "source socket
+//! not readable" and in step 2 "destination socket not writable" — never the
+//! pipe — so the readiness we wait on is always the right one.
+//!
+//! Rate limiting is NOT possible here (the bytes never reach userspace to be
+//! throttled) — the caller only takes this path for unlimited rules. Byte
+//! counts ARE available (splice returns the count moved), so the two totals are
+//! returned for traffic accounting / billing, exactly like the userspace path.
+//!
+//! This whole module is Linux-only; the caller falls back to the userspace copy
+//! on other targets.
+
+use std::io;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::Arc;
+use tokio::io::Interest;
+use tokio::net::TcpStream;
+
+/// Pipe capacity we try to set (64 KiB = 16 × 4 KiB pages), matching realm's
+/// default. Best-effort: if `F_SETPIPE_SZ` fails we keep the kernel default.
+const PIPE_SIZE: libc::c_int = 16 * 4096;
+
+/// A non-blocking pipe pair that closes both ends on drop.
+struct Pipe {
+    r: RawFd,
+    w: RawFd,
+}
+
+impl Pipe {
+    fn new() -> io::Result<Pipe> {
+        let mut fds = [0 as libc::c_int; 2];
+        // pipe2 with O_NONBLOCK so both ends never block a runtime worker.
+        let rc = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_NONBLOCK) };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // Best-effort enlarge — a bigger pipe means fewer splice syscalls under
+        // load. Ignore failure (capped by /proc/sys/fs/pipe-max-size, or the
+        // caller may lack permission); the kernel default still works.
+        unsafe { libc::fcntl(fds[1], libc::F_SETPIPE_SZ, PIPE_SIZE) };
+        Ok(Pipe {
+            r: fds[0],
+            w: fds[1],
+        })
+    }
+}
+
+impl Drop for Pipe {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.r);
+            libc::close(self.w);
+        }
+    }
+}
+
+/// One raw `splice` call. Returns Ok(0) on EOF, Ok(n) on success, or an
+/// `io::Error` (WouldBlock is surfaced so the caller can wait for readiness).
+fn splice_raw(from: RawFd, to: RawFd, len: usize) -> io::Result<usize> {
+    let n = unsafe {
+        libc::splice(
+            from,
+            std::ptr::null_mut(),
+            to,
+            std::ptr::null_mut(),
+            len,
+            (libc::SPLICE_F_MOVE | libc::SPLICE_F_NONBLOCK) as libc::c_uint,
+        )
+    };
+    if n < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(n as usize)
+    }
+}
+
+/// Shut down the write half of a socket (SHUT_WR), signalling EOF to the peer.
+/// Best-effort; errors (e.g. the peer already closed) are ignored.
+fn shutdown_write(fd: RawFd) {
+    unsafe {
+        libc::shutdown(fd, libc::SHUT_WR);
+    }
+}
+
+/// Pump one direction, `src → dst`, with splice via a private pipe. Returns the
+/// total bytes moved. On return (EOF or error) the destination's write half is
+/// shut down so the peer sees EOF and the opposite pump can finish too.
+async fn pump(src: &TcpStream, dst: &TcpStream) -> io::Result<u64> {
+    let pipe = Pipe::new()?;
+    let src_fd = src.as_raw_fd();
+    let dst_fd = dst.as_raw_fd();
+    let mut total: u64 = 0;
+
+    let result = async {
+        loop {
+            // Step 1: socket → pipe. The pipe is empty here (fully drained
+            // below), so EAGAIN can only mean the source is not readable.
+            let n = loop {
+                src.readable().await?;
+                match src.try_io(Interest::READABLE, || {
+                    splice_raw(src_fd, pipe.w, PIPE_SIZE as usize)
+                }) {
+                    Ok(n) => break n,
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(e) => return Err(e),
+                }
+            };
+            if n == 0 {
+                break; // source EOF — clean end of stream
+            }
+
+            // Step 2: pipe → socket, drained fully. The pipe is non-empty, so
+            // EAGAIN can only mean the destination is not writable.
+            let mut left = n;
+            while left > 0 {
+                dst.writable().await?;
+                match dst.try_io(Interest::WRITABLE, || splice_raw(pipe.r, dst_fd, left)) {
+                    Ok(0) => return Ok(()), // destination closed for writing
+                    Ok(m) => {
+                        left -= m;
+                        total += m as u64;
+                    }
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+        Ok(())
+    }
+    .await;
+
+    // Whether we ended on EOF or an error, signal EOF to the destination's peer
+    // so the other direction's pump unblocks and the connection tears down.
+    shutdown_write(dst_fd);
+    result.map(|()| total)
+}
+
+/// Forward bytes both ways between `a` and `b` with splice zero-copy until both
+/// directions reach EOF. Returns `(a→b bytes, b→a bytes)`.
+///
+/// The streams are wrapped in `Arc` so both pump tasks can drive readiness on
+/// them concurrently (`readable`/`writable`/`try_io` take `&self`); the raw fds
+/// stay valid for the whole operation because the `Arc`s outlive both pumps.
+pub async fn zero_copy_bidirectional(a: TcpStream, b: TcpStream) -> io::Result<(u64, u64)> {
+    let a = Arc::new(a);
+    let b = Arc::new(b);
+    let (a_up, b_up) = (a.clone(), b.clone());
+    let ab = pump(&a_up, &b_up); // a → b
+    let ba = pump(&b, &a); // b → a
+    let (r_ab, r_ba) = tokio::join!(ab, ba);
+    Ok((r_ab?, r_ba?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    /// End-to-end: client → [splice relay] → echo target. The payload must
+    /// round-trip and the returned byte counts must be exact.
+    #[tokio::test]
+    async fn splice_roundtrips_and_counts_bytes() {
+        // Echo target: read once, echo back, then close.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut s, _) = target.accept().await.unwrap();
+            let mut b = vec![0u8; 1024];
+            let n = s.read(&mut b).await.unwrap();
+            s.write_all(&b[..n]).await.unwrap();
+            s.shutdown().await.unwrap();
+        });
+
+        // Relay: accept a client, connect to target, splice both ways.
+        let relay = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay.local_addr().unwrap();
+        let relay_task = tokio::spawn(async move {
+            let (client, _) = relay.accept().await.unwrap();
+            let upstream = TcpStream::connect(target_addr).await.unwrap();
+            zero_copy_bidirectional(client, upstream).await.unwrap()
+        });
+
+        // Client: send, receive the echo, close.
+        let mut client = TcpStream::connect(relay_addr).await.unwrap();
+        let msg = b"hello-splice-zero-copy";
+        client.write_all(msg).await.unwrap();
+        client.shutdown().await.unwrap(); // half-close: signals EOF upstream
+        let mut got = Vec::new();
+        client.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, msg, "payload must round-trip through the splice relay");
+
+        let (up, down) = relay_task.await.unwrap();
+        assert_eq!(up, msg.len() as u64, "client→target byte count");
+        assert_eq!(down, msg.len() as u64, "target→client byte count");
+    }
+
+    /// A larger transfer (bigger than one pipe-full) must move all bytes.
+    #[tokio::test]
+    async fn splice_moves_large_payload() {
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        // Sink target: drain everything the relay sends.
+        let recv = tokio::spawn(async move {
+            let (mut s, _) = target.accept().await.unwrap();
+            let mut total = 0u64;
+            let mut b = vec![0u8; 64 * 1024];
+            loop {
+                match s.read(&mut b).await.unwrap() {
+                    0 => break,
+                    n => total += n as u64,
+                }
+            }
+            total
+        });
+
+        let relay = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay.local_addr().unwrap();
+        let relay_task = tokio::spawn(async move {
+            let (client, _) = relay.accept().await.unwrap();
+            let upstream = TcpStream::connect(target_addr).await.unwrap();
+            zero_copy_bidirectional(client, upstream).await.unwrap()
+        });
+
+        let mut client = TcpStream::connect(relay_addr).await.unwrap();
+        let payload = vec![0x5au8; 1_000_000]; // ~1 MiB, several pipe-fulls
+        client.write_all(&payload).await.unwrap();
+        client.shutdown().await.unwrap();
+        // Drain any (empty) reverse traffic so the relay's b→a pump ends.
+        let mut sink = Vec::new();
+        client.read_to_end(&mut sink).await.unwrap();
+
+        let (up, _down) = relay_task.await.unwrap();
+        let received = recv.await.unwrap();
+        assert_eq!(
+            received,
+            payload.len() as u64,
+            "target must receive all bytes"
+        );
+        assert_eq!(up, payload.len() as u64, "up count must equal payload size");
+    }
+}

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -183,14 +183,33 @@ async fn handle_tcp_connection(
 
     tracing::debug!("TCP: {} -> {}", client_addr, outbound.peer_addr()?);
 
-    // Bidirectional copy with traffic counting + per-rule rate limiting. We own
+    // v1.0.8: ZERO-COPY fast path. An UNLIMITED rule on Linux is forwarded with
+    // splice(2) — bytes move inside the kernel via a pipe and are never copied
+    // into userspace, which slashes CPU on high-throughput links. A rate-limited
+    // rule CANNOT use splice (the bytes must reach userspace to be throttled),
+    // but that's fine: a capped rule isn't running at max throughput, so the
+    // userspace copy's CPU cost is negligible. Byte counts still come back from
+    // the splice return values, so billing is unaffected. Non-Linux always uses
+    // the userspace copy below.
+    #[cfg(target_os = "linux")]
+    if matches!(rate_limit, RateLimit::Unlimited) {
+        match super::splice::zero_copy_bidirectional(inbound, outbound).await {
+            // (up = client→target, down = target→client) — same attribution as
+            // the userspace path's counter.add(rule_id, up, down).
+            Ok((up, down)) => counter.add(rule_id, up, down).await,
+            Err(e) => tracing::debug!("TCP splice forward (rule {}): {}", rule_id, e),
+        }
+        return Ok(());
+    }
+
+    // Userspace bidirectional copy with traffic counting + per-rule rate
+    // limiting (the rate-limited path, and the fallback on non-Linux). We own
     // both halves and pump both directions concurrently. When either side
     // returns (the remote closed the connection) we shut down the matching write
     // half so the other copy also sees EOF and returns.
     //
     // v0.4.6: each chunk is throttled through the shared RateLimit BEFORE being
-    // written, so the rule's aggregate cap holds across all connections. For
-    // unlimited rules the limiter is a no-op (one branch per chunk).
+    // written, so the rule's aggregate cap holds across all connections.
     let (mut ri, mut wi) = inbound.into_split();
     let (mut ro, mut wo) = outbound.into_split();
 
@@ -201,10 +220,11 @@ async fn handle_tcp_connection(
 
     let upload = Box::pin(async move {
         let mut total = 0u64;
-        // v1.0.8: 64 KiB copy buffer (was 16 KiB) — fewer syscalls / better
-        // throughput on high bandwidth-delay-product links. Heap-allocated as
-        // part of this Box::pin'd future, so it does not grow the task stack.
-        let mut buf = [0u8; 64 * 1024];
+        // v1.0.8: 32 KiB copy buffer (this userspace path is only used by
+        // rate-limited rules, which are capped anyway; the unlimited fast path
+        // uses splice above). Heap-allocated as part of this Box::pin'd future,
+        // so it does not grow the task stack.
+        let mut buf = [0u8; 32 * 1024];
         loop {
             let n = match ri.read(&mut buf).await {
                 Ok(0) => break,
@@ -222,8 +242,8 @@ async fn handle_tcp_connection(
     });
     let download = Box::pin(async move {
         let mut total = 0u64;
-        // v1.0.8: 64 KiB copy buffer (see the upload side above).
-        let mut buf = [0u8; 64 * 1024];
+        // v1.0.8: 32 KiB copy buffer (see the upload side above).
+        let mut buf = [0u8; 32 * 1024];
         loop {
             let n = match ro.read(&mut buf).await {
                 Ok(0) => break,


### PR DESCRIPTION
## 双路零拷贝转发

保留限速、按 realm 的思路做 splice。

### 分路
- **不限速规则 + Linux** → 新增 `forwarder/splice.rs`,用 `splice(2)` 经内核 pipe 搬数据,**全程不进用户态**。去掉转发代理每字节两次的用户态拷贝,高吞吐下大幅省 CPU/内存带宽。
  - **half-close 正确处理**(一方结束时对目标 `shutdown(SHUT_WR)`,让对向 pump 收到 EOF 收尾)
  - 就绪由 tokio 驱动(`readable/writable` + `try_io`,EAGAIN 不忙等)
  - `splice` 返回值给出**精确双向字节数** → 计费/流量统计不受影响
- **限速规则 / 非 Linux** → 走现有用户态拷贝(限速规则本来就被压着,拷贝开销可忽略;splice 没法限速)。**限速功能完整保留。**
- 用户态路径 buffer 64K→32K(realm 自己才 8K,这条现在只服务限速规则,32K 绰绰有余、省内存)。

`splice.rs` 是 `#[cfg(target_os = "linux")]`;tcp.rs 的分派也 cfg 门控,非 Linux 一律走用户态拷贝。

### 验证
- Windows 构建 + **82 个 node 测试通过**(用户态路径 + cfg 门控)
- `splice.rs` 用隔离 crate **交叉编译 + clippy 干净**(x86_64-unknown-linux-gnu)——整个 node crate 无法在本机交叉编译(ring 需要 Linux C 工具链)
- **Linux splice 构建 + 往返/大流量/字节数三个测试在 CI(ubuntu)跑**

> 注:这不解决之前那个 200M→40M 的投诉(那是网络丢包/带宽)。splice 是省 CPU、提吞吐上限。改的是节点二进制,合并后需发版 + 重装/升级节点才生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)