### PR TITLE
perf(node/udp): shard session map + throttle tracker touch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +665,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1590,6 +1610,7 @@ dependencies = [
 name = "relay-node"
 version = "1.0.8"
 dependencies = [
+ "dashmap",
  "futures-util",
  "libc",
  "rcgen",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -36,6 +36,10 @@ socket2 = "0.5"
 # TCP rules — data moves inside the kernel via a pipe, never copied to
 # userspace. Only used on Linux; other targets fall back to the userspace copy.
 libc = "0.2"
+# v1.0.9: sharded concurrent map for per-listener UDP sessions — per-packet
+# lookups take a per-shard lock instead of one listener-wide mutex, removing
+# session-lock contention on the hot UDP path.
+dashmap = "6"
 
 [dev-dependencies]
 # v0.4.16: test-only cert generator for the real WSS (wss://) regression test.

--- a/crates/node/src/forwarder/udp.rs
+++ b/crates/node/src/forwarder/udp.rs
@@ -16,12 +16,12 @@
 // UDP_SESSION_TIMEOUT (60s) of inactivity. This makes the panel's
 // "connections" column reflect real UDP activity instead of always 0.
 
-use std::collections::HashMap;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
-use tokio::sync::Mutex;
 use tokio::time;
 
 use super::limiter::RateLimit;
@@ -33,10 +33,18 @@ const UDP_BUF_SIZE: usize = 65535;
 /// shared UDP_SESSION_TIMEOUT; this just controls how quickly an idle node
 // converges back to 0 in the absence of new datagrams.
 const CLEANUP_INTERVAL: Duration = Duration::from_secs(15);
+/// v1.0.9: how often (per session) we refresh the node-wide ConnectionTracker.
+/// `udp_touch` takes a process-wide lock, so touching it on EVERY datagram
+/// dominates cost at high PPS. We touch on session open and then at most once
+/// per this interval — kept well under UDP_SESSION_TIMEOUT (60s) so the tracker
+/// entry never expires between touches while the session is active.
+const TRACKER_TOUCH_INTERVAL: Duration = Duration::from_secs(15);
 
 struct UdpSession {
     outbound: Arc<UdpSocket>,
     last_active: tokio::time::Instant,
+    /// Last time we refreshed the node-wide tracker for this session (throttle).
+    last_touch: tokio::time::Instant,
 }
 
 /// v1.0.4: serve an ALREADY-BOUND UDP socket. Binding happens in the manager
@@ -95,8 +103,10 @@ pub async fn serve_udp_listener(
         return Err("no resolvable target".into());
     }
 
-    let sessions: Arc<Mutex<HashMap<SocketAddr, UdpSession>>> =
-        Arc::new(Mutex::new(HashMap::new()));
+    // v1.0.9: sharded concurrent map — per-packet lookups take a per-shard lock
+    // (keyed by client addr) instead of one listener-wide mutex, so datagrams
+    // from different clients don't serialize on each other.
+    let sessions: Arc<DashMap<SocketAddr, UdpSession>> = Arc::new(DashMap::new());
 
     // Background cleanup of expired local session entries (outbound sockets).
     // This mirrors the ConnectionTracker's own expiry; together they make sure
@@ -113,10 +123,9 @@ pub async fn serve_udp_listener(
             // Drop our local outbound sockets for clients whose local entry is
             // older than the timeout. The tracker already stopped counting
             // them; here we release the socket resources too.
-            let mut sessions = sessions_clone.lock().await;
-            let before = sessions.len();
-            sessions.retain(|_, s| s.last_active.elapsed() < UDP_SESSION_TIMEOUT);
-            let removed = before - sessions.len();
+            let before = sessions_clone.len();
+            sessions_clone.retain(|_, s| s.last_active.elapsed() < UDP_SESSION_TIMEOUT);
+            let removed = before - sessions_clone.len();
             if removed > 0 {
                 tracing::debug!(
                     "UDP port {}: cleaned up {} expired outbound sockets",
@@ -148,29 +157,29 @@ pub async fn serve_udp_listener(
             Err(e) => return Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
         };
 
-        // Register/refresh this client as an active UDP session so the panel
-        // counts it. Returns true on the FIRST datagram from this client.
-        let opened = connections.udp_touch(src, rule_id).await;
+        // Pick or refresh this client's session. v1.0.9: the session map is a
+        // sharded DashMap, so this per-packet lookup takes only a per-shard lock
+        // (sync — the guard is dropped before any .await). We ALSO throttle the
+        // node-wide ConnectionTracker refresh here (see TRACKER_TOUCH_INTERVAL)
+        // so it isn't hit on every datagram.
+        let hit = sessions.get_mut(&src).map(|mut s| {
+            let now = tokio::time::Instant::now();
+            s.last_active = now;
+            let touch = s.last_touch.elapsed() >= TRACKER_TOUCH_INTERVAL;
+            if touch {
+                s.last_touch = now;
+            }
+            (s.outbound.clone(), touch)
+        });
 
-        // Pick or create a local session (with its own outbound socket) for
-        // this client.
-        // v1.0.9: the outbound bind + connect (network ops) run WITHOUT holding
-        // the session-map lock, so slow setup for one new client no longer
-        // serializes every other packet on this listener. Fast path (existing
-        // session) takes and releases the lock immediately.
-        let sessions_arc = sessions.clone();
-        let existing = {
-            let mut map = sessions_arc.lock().await;
-            map.get_mut(&src).map(|s| {
-                s.last_active = tokio::time::Instant::now();
-                s.outbound.clone()
-            })
-        };
-        let outbound_sock = if let Some(sock) = existing {
+        let outbound_sock = if let Some((sock, touch)) = hit {
+            if touch {
+                connections.udp_touch(src, rule_id).await;
+            }
             sock
         } else {
             // New session: bind an ephemeral outbound socket + pick/connect the
-            // target, all OUTSIDE the map lock.
+            // target, all WITHOUT holding any map guard.
             let outbound = match super::outbound::udp_outbound_socket(source_ipv4).await {
                 Ok(s) => s,
                 Err(e) => {
@@ -204,30 +213,39 @@ pub async fn serve_udp_listener(
             }
             let outbound = Arc::new(outbound);
 
-            // Re-acquire the lock ONLY to publish the session. Double-check for a
-            // concurrent datagram from the same client that won the race while we
-            // were connecting — if one did, use the winner and drop ours.
-            let (chosen, we_won) = {
-                let mut map = sessions_arc.lock().await;
-                if let Some(s) = map.get_mut(&src) {
-                    s.last_active = tokio::time::Instant::now();
-                    (s.outbound.clone(), false)
-                } else {
-                    map.insert(
-                        src,
-                        UdpSession {
-                            outbound: outbound.clone(),
-                            last_active: tokio::time::Instant::now(),
-                        },
-                    );
+            // Publish via the entry API (per-shard lock, sync — no .await while
+            // the guard is held). Double-check for a concurrent datagram from the
+            // same client that won the race while we were connecting: if one did,
+            // use the winner and drop ours.
+            let now = tokio::time::Instant::now();
+            let (chosen, we_won) = match sessions.entry(src) {
+                Entry::Occupied(mut e) => {
+                    e.get_mut().last_active = now;
+                    (e.get().outbound.clone(), false)
+                }
+                Entry::Vacant(e) => {
+                    e.insert(UdpSession {
+                        outbound: outbound.clone(),
+                        last_active: now,
+                        last_touch: now,
+                    });
                     (outbound.clone(), true)
                 }
             };
 
             if we_won {
+                // First datagram from this client → register it with the tracker.
+                connections.udp_touch(src, rule_id).await;
+                tracing::debug!(
+                    "UDP port {}: new session {} -> {} (rule {})",
+                    port,
+                    src,
+                    target,
+                    rule_id
+                );
                 // Spawn the target -> client reader for OUR socket.
                 let inbound_c = inbound.clone();
-                let sessions_c = sessions_arc.clone();
+                let sessions_c = sessions.clone();
                 let connections_c = connections.clone();
                 let counter_c = counter.clone();
                 let rl_c = rate_limit.clone();
@@ -244,15 +262,24 @@ pub async fn serve_udp_listener(
                                 // forwarding back to the client.
                                 rl_c.acquire_download(m as u64).await;
                                 counter_c.add(rule_id, 0, m as u64).await;
-                                // A reply from the target counts as activity too
-                                // — refresh the session so a long-lived
-                                // request/response flow isn't expired mid-flight.
-                                connections_c.udp_touch(src_c, rule_id).await;
+                                // Refresh activity + (throttled) tracker touch.
+                                // The DashMap guard is dropped before the awaits.
+                                let touch = if let Some(mut s) = sessions_c.get_mut(&src_c) {
+                                    let now = tokio::time::Instant::now();
+                                    s.last_active = now;
+                                    let t = s.last_touch.elapsed() >= TRACKER_TOUCH_INTERVAL;
+                                    if t {
+                                        s.last_touch = now;
+                                    }
+                                    t
+                                } else {
+                                    false
+                                };
+                                if touch {
+                                    connections_c.udp_touch(src_c, rule_id).await;
+                                }
                                 if inbound_c.send_to(&rbuf[..m], src_c).await.is_err() {
                                     break;
-                                }
-                                if let Some(s) = sessions_c.lock().await.get_mut(&src_c) {
-                                    s.last_active = tokio::time::Instant::now();
                                 }
                             }
                             Err(e) => {
@@ -263,18 +290,9 @@ pub async fn serve_udp_listener(
                     }
                     // Outbound side ended (target closed / error): release this
                     // client's session immediately rather than waiting for timeout.
-                    sessions_c.lock().await.remove(&src_c);
+                    sessions_c.remove(&src_c);
                     connections_c.udp_close(src_c, rule_id).await;
                 });
-                if opened {
-                    tracing::debug!(
-                        "UDP port {}: new session {} -> {} (rule {})",
-                        port,
-                        src,
-                        target,
-                        rule_id
-                    );
-                }
             }
             chosen
         };

--- a/crates/node/src/forwarder/udp.rs
+++ b/crates/node/src/forwarder/udp.rs
@@ -33,18 +33,10 @@ const UDP_BUF_SIZE: usize = 65535;
 /// shared UDP_SESSION_TIMEOUT; this just controls how quickly an idle node
 // converges back to 0 in the absence of new datagrams.
 const CLEANUP_INTERVAL: Duration = Duration::from_secs(15);
-/// v1.0.9: how often (per session) we refresh the node-wide ConnectionTracker.
-/// `udp_touch` takes a process-wide lock, so touching it on EVERY datagram
-/// dominates cost at high PPS. We touch on session open and then at most once
-/// per this interval — kept well under UDP_SESSION_TIMEOUT (60s) so the tracker
-/// entry never expires between touches while the session is active.
-const TRACKER_TOUCH_INTERVAL: Duration = Duration::from_secs(15);
 
 struct UdpSession {
     outbound: Arc<UdpSocket>,
     last_active: tokio::time::Instant,
-    /// Last time we refreshed the node-wide tracker for this session (throttle).
-    last_touch: tokio::time::Instant,
 }
 
 /// v1.0.4: serve an ALREADY-BOUND UDP socket. Binding happens in the manager
@@ -125,7 +117,9 @@ pub async fn serve_udp_listener(
             // them; here we release the socket resources too.
             let before = sessions_clone.len();
             sessions_clone.retain(|_, s| s.last_active.elapsed() < UDP_SESSION_TIMEOUT);
-            let removed = before - sessions_clone.len();
+            // saturating: len() is read across shards without a global lock, so a
+            // concurrent insert between the two reads must not underflow usize.
+            let removed = before.saturating_sub(sessions_clone.len());
             if removed > 0 {
                 tracing::debug!(
                     "UDP port {}: cleaned up {} expired outbound sockets",
@@ -157,25 +151,21 @@ pub async fn serve_udp_listener(
             Err(e) => return Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
         };
 
-        // Pick or refresh this client's session. v1.0.9: the session map is a
-        // sharded DashMap, so this per-packet lookup takes only a per-shard lock
-        // (sync — the guard is dropped before any .await). We ALSO throttle the
-        // node-wide ConnectionTracker refresh here (see TRACKER_TOUCH_INTERVAL)
-        // so it isn't hit on every datagram.
-        let hit = sessions.get_mut(&src).map(|mut s| {
-            let now = tokio::time::Instant::now();
-            s.last_active = now;
-            let touch = s.last_touch.elapsed() >= TRACKER_TOUCH_INTERVAL;
-            if touch {
-                s.last_touch = now;
-            }
-            (s.outbound.clone(), touch)
+        // Register/refresh this client with the tracker on EVERY datagram. The
+        // tracker is a sharded DashMap (keyed by client+rule), so this is a cheap
+        // per-shard op — not a process-wide lock — and keeps the panel's count
+        // accurate without any throttling.
+        connections.udp_touch(src, rule_id).await;
+
+        // Fast path: existing session. The session map is a sharded DashMap, so
+        // this per-packet lookup takes only a per-shard lock (sync guard, dropped
+        // before any .await).
+        let existing = sessions.get_mut(&src).map(|mut s| {
+            s.last_active = tokio::time::Instant::now();
+            s.outbound.clone()
         });
 
-        let outbound_sock = if let Some((sock, touch)) = hit {
-            if touch {
-                connections.udp_touch(src, rule_id).await;
-            }
+        let outbound_sock = if let Some(sock) = existing {
             sock
         } else {
             // New session: bind an ephemeral outbound socket + pick/connect the
@@ -227,15 +217,14 @@ pub async fn serve_udp_listener(
                     e.insert(UdpSession {
                         outbound: outbound.clone(),
                         last_active: now,
-                        last_touch: now,
                     });
                     (outbound.clone(), true)
                 }
             };
 
             if we_won {
-                // First datagram from this client → register it with the tracker.
-                connections.udp_touch(src, rule_id).await;
+                // The tracker was already refreshed at the top of the loop; just
+                // log the new session (the target is known only on this path).
                 tracing::debug!(
                     "UDP port {}: new session {} -> {} (rule {})",
                     port,
@@ -262,24 +251,15 @@ pub async fn serve_udp_listener(
                                 // forwarding back to the client.
                                 rl_c.acquire_download(m as u64).await;
                                 counter_c.add(rule_id, 0, m as u64).await;
-                                // Refresh activity + (throttled) tracker touch.
-                                // The DashMap guard is dropped before the awaits.
-                                let touch = if let Some(mut s) = sessions_c.get_mut(&src_c) {
-                                    let now = tokio::time::Instant::now();
-                                    s.last_active = now;
-                                    let t = s.last_touch.elapsed() >= TRACKER_TOUCH_INTERVAL;
-                                    if t {
-                                        s.last_touch = now;
-                                    }
-                                    t
-                                } else {
-                                    false
-                                };
-                                if touch {
-                                    connections_c.udp_touch(src_c, rule_id).await;
-                                }
+                                // A reply is activity too: refresh the tracker
+                                // (cheap, sharded) and the session's last_active
+                                // so a long request/response flow isn't expired.
+                                connections_c.udp_touch(src_c, rule_id).await;
                                 if inbound_c.send_to(&rbuf[..m], src_c).await.is_err() {
                                     break;
+                                }
+                                if let Some(mut s) = sessions_c.get_mut(&src_c) {
+                                    s.last_active = tokio::time::Instant::now();
                                 }
                             }
                             Err(e) => {

--- a/crates/node/src/reporter.rs
+++ b/crates/node/src/reporter.rs
@@ -1,4 +1,6 @@
 use crate::config::NodeConfig;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 use relay_shared::protocol::{
     ApiResponse, ListenerError, StatusReport, TrafficEntry, TrafficReport,
 };
@@ -151,10 +153,10 @@ pub const UDP_SESSION_TIMEOUT: Duration = Duration::from_secs(60);
 /// - **UDP**: there is no "connection"; instead we count active UDP sessions,
 ///   keyed by `(client_addr, rule_id)`. A session is created on the first
 ///   datagram from a client and considered expired after
-///   `UDP_SESSION_TIMEOUT` with no further traffic. v1.0.9: `touch` no longer
-///   prunes (it runs per packet); expiry is handled by `current()` and the UDP
-///   listener's periodic sweeper (`udp_prune_expired`), so the count still
-///   converges on zero shortly after traffic stops.
+///   `UDP_SESSION_TIMEOUT` with no further traffic. `touch` runs per datagram
+///   but does NOT prune (that's O(sessions) per packet); expiry is handled by
+///   `current()` and the UDP listener's periodic sweeper (`udp_prune_expired`),
+///   so the count still converges on zero shortly after traffic stops.
 ///
 /// `current()` reports `active_tcp + active_udp_sessions`.
 ///
@@ -162,11 +164,12 @@ pub const UDP_SESSION_TIMEOUT: Duration = Duration::from_secs(60);
 /// from the plain-HTTP `report_status` loop, so connection counts keep
 /// updating even if WS is down.
 ///
-/// Locking: TCP uses an `AtomicU64` (lock-free), UDP uses a `Mutex<HashMap>`.
-/// Both are fine-grained — neither is a global lock that could block forwarding.
+/// Locking: TCP uses an `AtomicU64` (lock-free); UDP uses a sharded `DashMap`
+/// keyed by (client, rule), so a per-packet `udp_touch` takes only that shard's
+/// lock (v1.0.9) — never a process-wide lock that could block forwarding.
 pub struct ConnectionTracker {
     tcp: Arc<AtomicU64>,
-    udp: Arc<Mutex<HashMap<UdpSessionKey, Instant>>>,
+    udp: DashMap<UdpSessionKey, Instant>,
 }
 
 /// Identity of a single UDP "connection". A client's source port plus the
@@ -181,7 +184,7 @@ impl ConnectionTracker {
     pub fn new() -> Self {
         Self {
             tcp: Arc::new(AtomicU64::new(0)),
-            udp: Arc::new(Mutex::new(HashMap::new())),
+            udp: DashMap::new(),
         }
     }
 
@@ -205,31 +208,31 @@ impl ConnectionTracker {
             client_addr,
             rule_id,
         };
-        // v1.0.9: do NOT prune here. udp_touch runs on EVERY datagram (both
-        // directions); a full-table `retain` scan per packet is O(sessions) per
-        // packet and dominates cost on busy links. Expiry is handled by the
-        // periodic sweeper (udp_prune_expired, called from the UDP listener's
-        // cleanup interval) and by current(); the map just holds a few stale
-        // entries between sweeps, which is harmless.
-        let mut map = self.udp.lock().await;
-        use std::collections::hash_map::Entry;
-        match map.entry(key) {
+        // Sharded map (keyed by client+rule): this takes only the target shard's
+        // lock, so per-packet touching doesn't serialize on a process-wide lock.
+        // We do NOT prune here (an O(sessions) scan per packet); expiry is
+        // handled by the periodic sweeper (udp_prune_expired) and current().
+        let is_new = match self.udp.entry(key) {
             Entry::Occupied(mut e) => {
                 *e.get_mut() = Instant::now();
                 false
             }
             Entry::Vacant(e) => {
                 e.insert(Instant::now());
-                let active = map.len();
-                tracing::debug!(
-                    "udp session opened (client={}, rule={}), udp_active={}",
-                    client_addr,
-                    rule_id,
-                    active
-                );
                 true
             }
+        };
+        // len() locks shards briefly; call it only AFTER the entry guard above
+        // is released (holding a shard guard across len() would deadlock).
+        if is_new {
+            tracing::debug!(
+                "udp session opened (client={}, rule={}), udp_active={}",
+                client_addr,
+                rule_id,
+                self.udp.len()
+            );
         }
+        is_new
     }
 
     /// Remove a single UDP session (e.g. when its outbound recv loop ends).
@@ -238,13 +241,12 @@ impl ConnectionTracker {
             client_addr,
             rule_id,
         };
-        let mut map = self.udp.lock().await;
-        if map.remove(&key).is_some() {
+        if self.udp.remove(&key).is_some() {
             tracing::debug!(
                 "udp session closed (client={}, rule={}), udp_active={}",
                 client_addr,
                 rule_id,
-                map.len()
+                self.udp.len()
             );
         }
     }
@@ -252,8 +254,7 @@ impl ConnectionTracker {
     /// Drop every UDP session older than `UDP_SESSION_TIMEOUT`. Called both by
     /// the UDP listener's periodic sweeper and as part of `current()`.
     pub async fn udp_prune_expired(&self) -> usize {
-        let mut map = self.udp.lock().await;
-        prune_expired_locked(&mut map)
+        prune_expired(&self.udp)
     }
 
     /// Total active connections reported to the panel:
@@ -262,22 +263,21 @@ impl ConnectionTracker {
         // TCP count is exact; UDP count is pruned-of-expired first so a quiet
         // node reports 0 shortly after traffic stops.
         let tcp = self.tcp.load(Ordering::Relaxed) as u32;
-        let udp = {
-            let mut map = self.udp.lock().await;
-            prune_expired_locked(&mut map);
-            map.len() as u32
-        };
+        prune_expired(&self.udp);
+        let udp = self.udp.len() as u32;
         tcp.saturating_add(udp)
     }
 }
 
-/// Prune sessions whose `last_active` is older than the timeout. Borrowed
-/// mutably so callers don't need to re-lock. Returns how many were removed.
-fn prune_expired_locked(map: &mut HashMap<UdpSessionKey, Instant>) -> usize {
+/// Prune sessions whose `last_active` is older than the timeout. Returns how
+/// many were removed. `retain` runs per shard; `before`/`after` are read across
+/// shards without a global lock, so use saturating_sub in case a concurrent
+/// insert lands between the two reads.
+fn prune_expired(map: &DashMap<UdpSessionKey, Instant>) -> usize {
     let now = Instant::now();
     let before = map.len();
     map.retain(|_, last_active| now.duration_since(*last_active) < UDP_SESSION_TIMEOUT);
-    let removed = before - map.len();
+    let removed = before.saturating_sub(map.len());
     if removed > 0 {
         tracing::debug!(
             "udp: pruned {} expired sessions, udp_active={}",
@@ -1172,16 +1172,13 @@ mod tests {
         let tracker = ConnectionTracker::new();
         // Manually backdate a session to simulate "no traffic for longer than
         // the timeout" — we can't sleep 60s in a unit test.
-        {
-            let mut map = tracker.udp.lock().await;
-            map.insert(
-                UdpSessionKey {
-                    client_addr: addr(6000),
-                    rule_id: 7,
-                },
-                Instant::now() - (UDP_SESSION_TIMEOUT + Duration::from_secs(1)),
-            );
-        }
+        tracker.udp.insert(
+            UdpSessionKey {
+                client_addr: addr(6000),
+                rule_id: 7,
+            },
+            Instant::now() - (UDP_SESSION_TIMEOUT + Duration::from_secs(1)),
+        );
         // The expired session must NOT be counted by current().
         assert_eq!(tracker.current().await, 0);
     }


### PR DESCRIPTION
消除 UDP 热路径上的逐包锁热点(codex 指出的 ①②),并按后续高强度审计做了更深的修法。含两个提交,建议 squash 合并。

## 最终代码做了什么

### 会话表分片(每监听器)
每监听器的 UDP 会话表由 `Mutex<HashMap>` 改为 **DashMap**(按客户端地址分片)。逐包查会话只取分片同步锁(await 前释放),不同客户端的包不再互相串行。新会话走 entry API + 双检竞态。

### tracker 也分片(进程级锁彻底消除)
`ConnectionTracker` 的 UDP 会话表(按 client+rule 键)同样由**进程级 `Mutex<HashMap>` 改为 DashMap**。`udp_touch`/`udp_close` 只取目标分片的锁——连新会话开启/关闭都不再打全局锁。

> 注:最初版本是用"每 15s 最多 touch 一次"的节流来回避进程级锁;审计后改为直接把 tracker 分片,于是**节流逻辑整个删除**(`last_touch` 字段、间隔常量、两处重复代码都没了),恢复"每包双向无条件 touch",代码更简单且连接数计数更准。

## 审计修复(#1–#4)
- **#1** sweeper 与 tracker prune 用 `saturating_sub`:DashMap `len()` 跨分片读取无全局锁,并发插入落在两次读之间不能让 usize 下溢(原本 debug 构建会 panic 杀死清理任务→socket 泄漏;release 出垃圾日志)。
- **#2** 会话中途被清后仍持续计数:改回每包无条件 touch,不再少计。
- **#3** tracker 进程级锁:已分片消除。
- **#4** 重复的节流逻辑:随节流删除而消失。

## 不做(③,单独评估)
入口仍是单 `recv→send` 循环。不限速场景 send 极少真阻塞,真正成本是上面这些锁(已消除);拆分收发需有界队列/背压/保序设计,应等实际 UDP 压测确认瓶颈后再做。

## 验证
新增 `dashmap` 依赖;`cargo clippy -p relay-node` 0 警告;node 测试 84+4 全过;fmt 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)