### PR TITLE
fix(rules): keep existing targets when editing only a Basic-tab field

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -883,6 +883,12 @@ const IMPORT_DEFAULTS = {
             },
             {
               key: 'forward',
+              // v1.0.9: force-render so the targets Form.List mounts even while
+              // the Basic tab is active. Without this, editing only a Basic field
+              // (e.g. listen_port) and submitting without opening this tab left
+              // `values.targets` unregistered — handleUpdate then read it as
+              // "targets cleared" and rejected with "add at least one target".
+              forceRender: true,
               label: t('tabForward'),
               children: (<>
                 {renderTargetsEditor()}


### PR DESCRIPTION
## 问题
编辑规则时，如果只改「基础」tab 的字段（比如监听端口），没点开「转发」tab 就提交，会报 **「请至少添加一个转发目标」**——即使转发目标根本没动。

## 原因
编辑弹窗的 Tabs 是懒渲染：默认停在「基础」tab，「转发」tab 里的目标 `Form.List` 从未挂载。提交时 `values.targets` 未注册 → `handleUpdate` 把它当成「目标被清空」→ 触发校验报错。

## 修复
给**编辑弹窗**的「转发」tab 加 `forceRender: true`，让目标列表无论当前在哪个 tab 都挂载并从规则预填。仅限编辑弹窗——创建弹窗本就要求填目标，给它加反而会把校验错藏在未激活的 tab 上、不如现在的 toast 清晰。

## 验证
`tsc --noEmit` + `eslint` 均通过。独立于 PR43。

🤖 Generated with [Claude Code](https://claude.com/claude-code)