### PR TITLE
release: v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.0.9] - 2026-07-02
+
+Finalizes the plan model to a **single current plan** (renew vs. switch), a
+substantial **UDP/TCP forwarding performance pass**, and a round of correctness
+fixes across billing, admin actions, and the rule editor.
+
+### Changed
+
+- **A user holds exactly one current plan.** Buying the **same** plan *renews*
+  it (traffic stacks; a time plan's expiry extends from its current end). Buying
+  a **different** plan *switches*: `traffic_limit` becomes the new plan's quota
+  (not stacked), `traffic_used` resets to 0, the expiry is recomputed from now,
+  and device-group authorization is fully replaced. The shop and the admin panel
+  both confirm before a switch. This replaces the short-lived additive model —
+  to give a user several lines, sell a bundled plan.
+- **Rate-limited rules pick up limit changes without a node restart.** A rule's
+  upload/download cap is part of the listener fingerprint now, so changing or
+  clearing a limit hot-reloads the listener instead of running the old cap until
+  the next restart.
+
+### Added
+
+- Shop plan cards resolve the **names** of the lines a plan grants server-side
+  (previously they could show a raw `#id` for lines the buyer wasn't yet
+  authorized for).
+- **DNS cache** for outbound TCP targets: domain targets no longer re-resolve on
+  every new connection, with a stale-entry fallback when the resolver blips.
+
+### Performance
+
+- **UDP forwarding.** Removed the per-packet full-table session scan; made the
+  traffic counter lock-free (atomic per rule); moved the outbound bind/connect
+  out of the session lock; sharded both the per-listener session map and the
+  connection tracker (concurrent maps); and enlarged UDP socket buffers. Large
+  reduction in per-packet lock contention on high-PPS links.
+
+### Fixed
+
+- **Traffic billing** is charged on upload **and** download (their sum × the
+  line's rate); this is now documented explicitly.
+- Plan **create** and admin **remove-plan** run as single transactions, so a
+  mid-operation DB error can't leave a plan with no lines or a half-revoked user.
+- **Batch rule delete** reports actual success/failure counts instead of always
+  claiming every selected rule was deleted.
+- List endpoints (plans / shop) return a real error on a DB failure instead of a
+  fake empty "success" list.
+- `update_plan` rejects setting `duration_days = 0` on a time plan.
+- Editing only a Basic-tab field of a rule (e.g. the listen port) no longer
+  wrongly demands "add a forward target".
+- `relay-node-install.sh` no longer fails with a `getcwd` error when run from a
+  directory that has since been deleted.
+- The device-group edit form no longer offers the unused **outbound/egress**
+  type; the inbound-group dropdown drops the redundant "(shared)" suffix; the
+  rule list shows all target IPs on hover.
+
+---
+
 ## [1.0.8] - 2026-07-01
 
 A performance & correctness release for the node's TCP forwarding path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.0.8";
+const COMPILED_APP_VERSION: &str = "1.0.9";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -17,7 +17,7 @@
 
 services:
   panel:
-    image: ghcr.io/moeshinx/relay-panel-panel:1.0.8
+    image: ghcr.io/moeshinx/relay-panel-panel:1.0.9
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -50,7 +50,7 @@ services:
   # separate forwarding server. To enable it on this host, use --profile node
   # and set NODE_TOKEN to a real inbound-group token from the panel UI.
   node:
-    image: ghcr.io/moeshinx/relay-panel-node:1.0.8
+    image: ghcr.io/moeshinx/relay-panel-node:1.0.9
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.0.8"
+SCRIPT_VERSION="1.0.9"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
v1.0.9 发布准备。汇总自 v1.0.8 以来合并的 PR40–44。

## 版本同步(release-check.sh 1.0.9 → 0 FAIL)
node/panel Cargo.toml、Cargo.lock、`COMPILED_APP_VERSION`、`relay-node-install.sh` SCRIPT_VERSION、docker-compose release 镜像 tag,全部 → 1.0.9;新增 CHANGELOG `[1.0.9]`。

## 本次发布内容
- **单套餐模型**:续费(相同套餐叠加/延期)vs 切换(不同套餐替换,流量/已用/到期/授权全重置,前端弹确认)
- **UDP/TCP 性能**:去逐包全表扫、原子计数、会话锁不跨网络、会话表+连接跟踪双分片(DashMap)、UDP 缓冲调大;TCP 限速热更新;DNS 缓存
- **正确性**:套餐建/删事务化、批量删规则准确汇报、DB 错误返 500、duration_days=0 拦截、编辑规则只改基础字段不再误报缺目标、安装脚本 cwd 修复
- **UI**:去出口类型、去"(共享)"后缀、目标列悬停显示全部 IP

## 验证
`cargo fmt/clippy/test --workspace` 全绿(84+4+374+16);前端 tsc+build 通过;release-check 0 FAIL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)