### PR TITLE
fix(shop): align plan cards when a plan grants no lines

### DIFF
--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -526,6 +526,7 @@ export const enUS: Dict = {
   planResetTrafficHint: 'Zero traffic_used on purchase',
   planDescription: 'Description',
   planGrantAll: 'Grant All Groups',
+  planGrantNone: 'None',
   planGrantAllHint: 'When on, buying this plan grants access to ALL inbound groups (including ones created later).',
   planGrantGroups: 'Granted Lines',
   planGrantGroupsHint: "Buying/assigning this plan REPLACES the user's current authorization with these groups (not appended); not revoked on expiry. Device-group authorization is managed entirely by the plan (there is no manual assignment in the edit-user modal).",

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -525,6 +525,7 @@ export const zhCN = {
   planResetTrafficHint: '购买后清零已用流量',
   planDescription: '说明',
   planGrantAll: '授权全部设备组',
+  planGrantNone: '无',
   planGrantAllHint: '开启后购买此套餐将授权用户使用全部入口分组（含日后新建的）。',
   planGrantGroups: '授权线路',
   planGrantGroupsHint: '购买/开通此套餐将用这些分组替换用户当前的授权（不是追加）；到期不自动撤销。设备分组授权完全由套餐管理（编辑用户里已无手动分配入口）。',

--- a/frontend/src/pages/Shop.tsx
+++ b/frontend/src/pages/Shop.tsx
@@ -136,11 +136,15 @@ export default function Shop() {
                     resolved server-side (device_group_names) — the buyer isn't
                     authorized for these groups yet, so the client can't resolve
                     the ids itself. */}
+                {/* v1.0.10: always render this row (show "无" when a plan grants
+                    no lines) so plan cards stay vertically aligned. */}
                 {p.grant_all_groups ? (
                   <div>{t('planGrantGroups')}: <Tag color="gold">{t('planGrantAll')}</Tag></div>
                 ) : (p.device_group_names && p.device_group_names.length > 0) ? (
                   <div>{t('planGrantGroups')}: {p.device_group_names.join(', ')}</div>
-                ) : null}
+                ) : (
+                  <div>{t('planGrantGroups')}: <Text type="secondary">{t('planGrantNone')}</Text></div>
+                )}
                 {p.reset_traffic && <div><Tag color="green">{t('planResetTraffic')}</Tag></div>}
               </div>
               <Button type="primary" block style={{ marginTop: 16 }} onClick={() => setBuying(p)}>


### PR DESCRIPTION
商店套餐卡片:无授权线路时「授权线路」行原本不渲染(`: null`),导致卡片高度不一、排版参差。改为始终渲染该行,无线路时显示「无」。tsc/eslint/build 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)