### PR TITLE
fix: stop re-seeding the default plan on every panel start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ capping off the plan-model / performance / correctness work of the 1.0.x line.
 
 ### Fixed
 
+- The default "free" plan no longer reappears in the shop after every panel
+  update. It is now seeded only on a fresh (empty) database, so an admin who
+  deletes it (once other plans exist) won't see it come back on restart.
 - Shop plan cards no longer render ragged when a plan grants no lines — the
   "granted lines" row now shows "无 / None" so all cards stay aligned.
 

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -3081,6 +3081,58 @@ async fn pg_buy_plan_renew_keeps_traffic_used() {
     cleanup(&db).await;
 }
 
+// ── v1.1.0: default plan is not re-seeded on restart ──
+
+/// Postgres parity for [`default_plan_not_reseeded_on_restart`].
+#[tokio::test]
+async fn pg_default_plan_not_reseeded_on_restart() {
+    let Some(db) = repo("default_plan_reseed").await else {
+        return;
+    };
+    assert!(
+        db.list_plans()
+            .await
+            .unwrap()
+            .iter()
+            .any(|p| p.name == "free"),
+        "a fresh DB seeds the default free plan"
+    );
+
+    let keep = db
+        .insert_plan(
+            "keep", 10, 1_000, "5.00", "data", 0, false, false, "d", false,
+        )
+        .await
+        .unwrap();
+    sqlx::query("UPDATE app_settings SET default_registration_plan_id = $1")
+        .bind(keep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM plans WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    // Simulate a restart: re-apply the baseline schema.
+    apply_pg_schema(&db.pool).await.expect("re-apply schema");
+
+    let names: Vec<String> = db
+        .list_plans()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    assert!(
+        !names.contains(&"free".to_string()),
+        "deleted default plan must not reappear after restart"
+    );
+    assert!(names.contains(&"keep".to_string()), "other plans survive");
+
+    cleanup(&db).await;
+}
+
 // ── v1.0.8: plan CRUD ──
 
 #[tokio::test]

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -223,10 +223,13 @@ INSERT INTO users (id, username, password, admin, max_rules)
 VALUES (1, 'admin', '$2b$12$PLACEHOLDER_WILL_BE_HASHED_ON_INIT', TRUE, 999)
 ON CONFLICT (id) DO NOTHING;
 
--- Default plan. Same id-pinning + ON CONFLICT DO NOTHING idempotency.
+-- Default plan. v1.1.0: seed ONLY when the plans table is empty (fresh DB), so
+-- an admin who deletes the default plan doesn't see it reappear on every panel
+-- update. (The old VALUES + ON CONFLICT DO NOTHING re-created it whenever id=1
+-- was absent.)
 INSERT INTO plans (id, name, max_rules, traffic, speed_limit, ip_limit, price)
-VALUES (1, 'free', 5, 107374182400, 0, 3, '0')
-ON CONFLICT (id) DO NOTHING;
+SELECT 1, 'free', 5, 107374182400, 0, 3, '0'
+WHERE NOT EXISTS (SELECT 1 FROM plans);
 
 -- Builtin tunnel profiles (is_builtin=TRUE). Same five as the SQLite seed
 -- (Migration 6 minus the deleted wss-via-caddy). name is UNIQUE so

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -247,9 +247,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_fr_port_udp
 INSERT OR IGNORE INTO users (id, username, password, admin, max_rules)
 VALUES (1, 'admin', '$2b$12$PLACEHOLDER_WILL_BE_HASHED_ON_INIT', 1, 999);
 
--- Default plan
-INSERT OR IGNORE INTO plans (id, name, max_rules, traffic, speed_limit, ip_limit, price)
-VALUES (1, 'free', 5, 107374182400, 0, 3, '0');
+-- Default plan. v1.1.0: seed ONLY when the plans table is completely empty
+-- (fresh DB). The old `INSERT OR IGNORE ... VALUES (1, ...)` re-created the
+-- 'free' plan on EVERY startup whenever id=1 was absent — so an admin who
+-- deleted the default plan saw it reappear after every panel update. Seeding by
+-- emptiness respects the deletion once any other plan exists.
+INSERT INTO plans (id, name, max_rules, traffic, speed_limit, ip_limit, price)
+SELECT 1, 'free', 5, 107374182400, 0, 3, '0'
+WHERE NOT EXISTS (SELECT 1 FROM plans);
 
 -- v0.4.10 PR3: application settings (registration config). Single-row table
 -- (id is fixed to 1). The row is NOT seeded here — main.rs seeds it via

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -3058,6 +3058,57 @@ async fn buy_plan_renew_keeps_traffic_used() {
     assert_eq!(traffic_used, 400, "renew keeps usage");
 }
 
+// ── v1.1.0: default plan is not re-seeded on restart ──
+
+/// Regression (v1.1.0): once an admin deletes the seeded "free" plan and other
+/// plans exist, re-applying the schema (what every panel start/update does) must
+/// NOT bring it back. The seed now runs only when the plans table is empty.
+#[tokio::test]
+async fn default_plan_not_reseeded_on_restart() {
+    let db = repo().await;
+    assert!(
+        db.list_plans()
+            .await
+            .unwrap()
+            .iter()
+            .any(|p| p.name == "free"),
+        "a fresh DB seeds the default free plan"
+    );
+
+    // Admin adds a real plan, repoints registration off the default, deletes it.
+    let keep = db
+        .insert_plan(
+            "keep", 10, 1_000, "5.00", "data", 0, false, false, "d", false,
+        )
+        .await
+        .unwrap();
+    sqlx::query("UPDATE app_settings SET default_registration_plan_id = ?")
+        .bind(keep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM plans WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    // Simulate a restart: re-apply the baseline schema.
+    sqlx::query(SCHEMA_SQL).execute(&db.pool).await.unwrap();
+
+    let names: Vec<String> = db
+        .list_plans()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    assert!(
+        !names.contains(&"free".to_string()),
+        "deleted default plan must not reappear after restart"
+    );
+    assert!(names.contains(&"keep".to_string()), "other plans survive");
+}
+
 // ── v1.0.8: plan CRUD ──
 
 #[tokio::test]


### PR DESCRIPTION
## 问题

每次面板更新/重启后,商店里被删掉的默认「free」套餐又会冒出来。

根因:schema 每次启动都会重跑,而默认套餐用的是无条件 `INSERT`(`INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`),所以管理员删掉 id=1 的 free 套餐后,下次重启又被重新插入。

## 修复

改成只在 plans 表**完全为空**(全新库)时才 seed:

```sql
INSERT INTO plans (...)
SELECT 1, 'free', ...
WHERE NOT EXISTS (SELECT 1 FROM plans);
```

SQLite / Postgres 两套 schema 同步修改。

## 测试

- 两个 repo 各加一条回归测试:插入其它套餐 → 改注册默认套餐 → 删除 free → 重跑 schema → 断言 free 不再出现、其它套餐还在。
- `cargo fmt` / `clippy` / `cargo test -p relay-panel`(376 通过)/ repo-test-parity 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)