### PR TITLE
#50 规则创建事务修复（跨分组串规则 + 单事务原子性）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Creating a forward rule no longer cross-writes into a different rule when
+  two inbound groups reuse the same listen port.** Previously, after the rule
+  row was inserted, the new rule's id was recovered by re-querying
+  `(owner_uid, listen_port)` — which ignored `device_group_in`. Because the
+  port-uniqueness constraint is *per inbound group*, two rules on two groups
+  can legally share a port, and the lookup returned the wrong (first) rule,
+  so its targets, load-balance strategy and rate limits were overwritten. Rule
+  creation now does the row INSERT + targets + load-balance strategy + rate
+  limits + tunnel profile in a **single transaction** and takes the new id
+  directly from the INSERT (SQLite `last_insert_rowid()` / PostgreSQL
+  `RETURNING id`), so any mid-creation failure rolls back completely (no
+  half-rule) and the side-tables always land on the right row. Existing
+  port-conflict, `max_rules` quota and ownership checks are unchanged.
+  (`create_rule_full` on the Repository trait, used by `create_rule`.)
+
+### Security
+
+- Pinned by regression test: a freshly-registered user has **no usable device
+  groups** by design (`all_device_groups = false`, `user_device_groups` empty),
+  so they cannot forward until a plan or admin grants authorization. Covered
+  on both SQLite and PostgreSQL to guard against a future auto-grant-on-register
+  change flipping this silently.
+
+---
+
 ## [1.1.0] - 2026-07-02
 
 Minor release headlined by **one-click remote node upgrades** from the panel,

--- a/crates/panel/src/db/pg_repo/rules.rs
+++ b/crates/panel/src/db/pg_repo/rules.rs
@@ -357,6 +357,202 @@ impl RuleRepository for PgRepository {
         }
     }
 
+    async fn create_rule_full(
+        &self,
+        name: &str,
+        uid: i64,
+        listen_port: i32,
+        protocol: &str,
+        public_transport: &str,
+        node_transport: &str,
+        route_mode: &str,
+        entry_transport: &str,
+        ws_path: Option<&str>,
+        device_group_in: i64,
+        device_group_out: Option<i64>,
+        forward_mode: &str,
+        target_addr: &str,
+        target_port: i32,
+        targets: &[relay_shared::protocol::RuleTargetRequest],
+        load_balance_strategy: &str,
+        upload_limit_mbps: i32,
+        download_limit_mbps: i32,
+        tunnel_profile_id: Option<i64>,
+    ) -> Result<Option<i64>, DbError> {
+        // v1.2: atomic create. Same advisory-xact-lock + user-row FOR UPDATE +
+        // conflict pre-check + quota-guarded INSERT shape as
+        // insert_quota_guarded, but the INSERT is a RETURNING-id, followed by
+        // the targets / LB / rate-limit / tunnel writes INSIDE the same tx.
+        // The new id comes from RETURNING (not a post-commit listen_port
+        // re-lookup), so two inbound groups reusing a port can't cross-write.
+
+        let needs_tcp = matches!(protocol, "tcp" | "tcp_udp");
+        let needs_udp = matches!(protocol, "udp" | "tcp_udp");
+
+        let mut tx = self.pool.begin().await?;
+
+        // Convert any sqlx error into a rollback + DbError early return so the
+        // body stays linear. Evaluates to `!`, so `try_!(expr)` is well-typed
+        // for any sqlx::Error-producing statement.
+        macro_rules! try_ {
+            ($tx:expr, $expr:expr) => {
+                match $expr {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = $tx.rollback().await;
+                        return Err(DbError::from(e));
+                    }
+                }
+            };
+        }
+
+        // Lock order: advisory(group) then row(user) — identical to
+        // insert_quota_guarded so no deadlock cycle can form.
+        try_!(
+            tx,
+            sqlx::query("SELECT pg_advisory_xact_lock($1)")
+                .bind(device_group_in)
+                .execute(&mut *tx)
+                .await
+        );
+
+        try_!(
+            tx,
+            sqlx::query("SELECT 1 FROM users WHERE id = $1 FOR UPDATE")
+                .bind(uid)
+                .fetch_optional(&mut *tx)
+                .await
+        );
+
+        let conflict: Option<(i32,)> = try_!(
+            tx,
+            sqlx::query_as(
+                "SELECT 1 FROM forward_rules \
+                 WHERE device_group_in = $1 AND listen_port = $2 \
+                   AND ( ($3 AND protocol IN ('tcp', 'tcp_udp')) \
+                      OR ($4 AND protocol IN ('udp', 'tcp_udp')) ) \
+                 LIMIT 1",
+            )
+            .bind(device_group_in)
+            .bind(listen_port)
+            .bind(needs_tcp)
+            .bind(needs_udp)
+            .fetch_optional(&mut *tx)
+            .await
+        );
+        if conflict.is_some() {
+            let _ = tx.rollback().await;
+            return Err(DbError::PortConflict);
+        }
+
+        // RETURNING id so we get the new row's id directly. The WHERE quota
+        // guard is the same as SQLite's; when it matches 0 rows the SELECT
+        // yields no id → Option<i64> None → quota exhausted.
+        let rule_id: Option<i64> = try_!(
+            tx,
+            sqlx::query_scalar(
+                "INSERT INTO forward_rules \
+                   (name, uid, listen_port, protocol, public_transport, node_transport, \
+                    route_mode, entry_transport, ws_path, \
+                    device_group_in, device_group_out, forward_mode, target_addr, target_port) \
+                 SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14 \
+                 WHERE (SELECT max_rules FROM users WHERE id = $15) = 0 \
+                    OR (SELECT COUNT(*) FROM forward_rules WHERE uid = $16) \
+                       < (SELECT max_rules FROM users WHERE id = $17) \
+                 RETURNING id",
+            )
+            .bind(name)
+            .bind(uid)
+            .bind(listen_port)
+            .bind(protocol)
+            .bind(public_transport)
+            .bind(node_transport)
+            .bind(route_mode)
+            .bind(entry_transport)
+            .bind(ws_path)
+            .bind(device_group_in)
+            .bind(device_group_out)
+            .bind(forward_mode)
+            .bind(target_addr)
+            .bind(target_port)
+            .bind(uid)
+            .bind(uid)
+            .bind(uid)
+            .fetch_optional(&mut *tx)
+            .await
+        );
+
+        let Some(rule_id) = rule_id else {
+            // Quota exhausted — nothing inserted. Commit the empty tx.
+            tx.commit().await?;
+            return Ok(None);
+        };
+
+        try_!(
+            tx,
+            sqlx::query("DELETE FROM forward_rule_targets WHERE rule_id = $1")
+                .bind(rule_id)
+                .execute(&mut *tx)
+                .await
+        );
+        for (idx, target) in targets.iter().enumerate() {
+            try_!(
+                tx,
+                sqlx::query(
+                    "INSERT INTO forward_rule_targets (rule_id, host, port, position, enabled) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(rule_id)
+                .bind(target.host.trim())
+                .bind(target.port as i32)
+                .bind(idx as i32 + 1)
+                .bind(target.enabled)
+                .execute(&mut *tx)
+                .await
+            );
+        }
+
+        if load_balance_strategy != "first" {
+            try_!(
+                tx,
+                sqlx::query("UPDATE forward_rules SET load_balance_strategy = $1 WHERE id = $2")
+                    .bind(load_balance_strategy)
+                    .bind(rule_id)
+                    .execute(&mut *tx)
+                    .await
+            );
+        }
+
+        if upload_limit_mbps != 0 || download_limit_mbps != 0 {
+            try_!(
+                tx,
+                sqlx::query(
+                    "UPDATE forward_rules SET upload_limit_mbps = $1, download_limit_mbps = $2 \
+                     WHERE id = $3",
+                )
+                .bind(upload_limit_mbps)
+                .bind(download_limit_mbps)
+                .bind(rule_id)
+                .execute(&mut *tx)
+                .await
+            );
+        }
+
+        if let Some(pid) = tunnel_profile_id {
+            try_!(
+                tx,
+                sqlx::query("UPDATE forward_rules SET tunnel_profile_id = $1 WHERE id = $2")
+                    .bind(pid)
+                    .bind(rule_id)
+                    .execute(&mut *tx)
+                    .await
+            );
+        }
+
+        tx.commit().await?;
+        Ok(Some(rule_id))
+    }
+
     async fn find_transport_by_id(
         &self,
         id: i64,

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -707,6 +707,265 @@ async fn pg_rule_insert_quota_guarded_port_scoped_by_group() {
     cleanup(&db).await;
 }
 
+/// v1.2 regression (PG mirror of the SQLite test): the same listen_port may be
+/// reused across two different inbound groups. create_rule_full returns the id
+/// straight from RETURNING, so the second rule's targets / LB / rate limits land
+/// on the SECOND rule — never the first.
+#[tokio::test]
+async fn pg_rule_create_full_cross_group_no_crosstalk() {
+    let Some(db) = repo("rule_full_cross_group").await else {
+        return;
+    };
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (1, 'gin', 'in', 'tok-1', 1)")
+        .execute(&db.pool).await.unwrap();
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (2, 'gin2', 'in', 'tok-2', 1)")
+        .execute(&db.pool).await.unwrap();
+
+    // Rule A: group 1, port 10000, ONE target, default LB, no caps.
+    let id_a = db
+        .create_rule_full(
+            "ruleA",
+            1,
+            10000,
+            "tcp_udp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "a.example.com".into(),
+                port: 1001,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("rule A created");
+
+    // Rule B: group 2, SAME port 10000, THREE targets + round_robin + caps.
+    let id_b = db
+        .create_rule_full(
+            "ruleB",
+            1,
+            10000,
+            "tcp_udp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            2,
+            None,
+            "direct",
+            "2.2.2.2",
+            80,
+            &[
+                relay_shared::protocol::RuleTargetRequest {
+                    host: "b1.example.com".into(),
+                    port: 2001,
+                    enabled: true,
+                },
+                relay_shared::protocol::RuleTargetRequest {
+                    host: "b2.example.com".into(),
+                    port: 2002,
+                    enabled: true,
+                },
+                relay_shared::protocol::RuleTargetRequest {
+                    host: "b3.example.com".into(),
+                    port: 2003,
+                    enabled: true,
+                },
+            ],
+            "round_robin",
+            50,
+            100,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("rule B created");
+
+    assert_ne!(id_a, id_b, "two distinct rules must have distinct ids");
+
+    let a = db
+        .find_rule_by_id(id_a, &ResourceScope::All)
+        .await
+        .unwrap()
+        .expect("rule A exists");
+    assert_eq!(a.device_group_in, 1);
+    assert_eq!(a.load_balance_strategy, "first");
+    assert_eq!(a.upload_limit_mbps, 0);
+    assert_eq!(a.download_limit_mbps, 0);
+    let a_targets = db
+        .list_rule_targets(id_a, &ResourceScope::All)
+        .await
+        .unwrap();
+    assert_eq!(a_targets.len(), 1, "rule A keeps exactly its one target");
+    assert_eq!(a_targets[0].host, "a.example.com");
+
+    let b = db
+        .find_rule_by_id(id_b, &ResourceScope::All)
+        .await
+        .unwrap()
+        .expect("rule B exists");
+    assert_eq!(b.device_group_in, 2);
+    assert_eq!(b.load_balance_strategy, "round_robin");
+    assert_eq!(b.upload_limit_mbps, 50);
+    assert_eq!(b.download_limit_mbps, 100);
+    let b_targets = db
+        .list_rule_targets(id_b, &ResourceScope::All)
+        .await
+        .unwrap();
+    assert_eq!(b_targets.len(), 3, "rule B got its three targets");
+    assert_eq!(b_targets[0].host, "b1.example.com");
+    assert_eq!(b_targets[2].host, "b3.example.com");
+    cleanup(&db).await;
+}
+
+/// v1.2 regression (PG): create_rule_full is one transaction, so a bad target
+/// (port=0 violates the CHECK constraint) rolls back the rule-row INSERT.
+#[tokio::test]
+async fn pg_rule_create_full_rollback_on_target_failure() {
+    let Some(db) = repo("rule_full_rollback").await else {
+        return;
+    };
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (1, 'gin', 'in', 'tok-1', 1)")
+        .execute(&db.pool).await.unwrap();
+
+    let err = db
+        .create_rule_full(
+            "doomed",
+            1,
+            30000,
+            "tcp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "bad.example.com".into(),
+                port: 0,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await;
+    assert!(err.is_err(), "the bad target must fail the whole call");
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM forward_rules WHERE uid = 1 AND listen_port = 30000",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 0, "transaction must roll back, leaving no rule row");
+    cleanup(&db).await;
+}
+
+/// v1.2 (PG): create_rule_full reports Ok(None) when the max_rules quota is
+/// exhausted, and crucially writes no row.
+#[tokio::test]
+async fn pg_rule_create_full_quota_exhausted_returns_none() {
+    let Some(db) = repo("rule_full_quota").await else {
+        return;
+    };
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (1, 'gin', 'in', 'tok-1', 1)")
+        .execute(&db.pool).await.unwrap();
+    sqlx::query("UPDATE users SET max_rules = 1 WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    assert!(
+        db.create_rule_full(
+            "r1",
+            1,
+            40000,
+            "tcp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "a.example.com".into(),
+                port: 80,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await
+        .unwrap()
+        .is_some(),
+        "first rule within quota returns Some(id)"
+    );
+    assert_eq!(
+        db.create_rule_full(
+            "r2",
+            1,
+            40001,
+            "tcp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "a.example.com".into(),
+                port: 80,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await
+        .unwrap(),
+        None,
+        "quota exhaustion returns Ok(None)"
+    );
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM forward_rules WHERE uid = 1")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "the over-quota create wrote no row");
+    cleanup(&db).await;
+}
+
 #[tokio::test]
 async fn pg_rule_update_switch_to_direct_clears_device_group_out() {
     // Regression for v0.4.4: switching a rule to "direct" without an
@@ -1762,6 +2021,46 @@ async fn pg_insert_user_from_plan_inherits_quota_and_handles_missing_plan() {
     assert!(
         db.find_by_username("bob").await.unwrap().is_none(),
         "no user for missing plan (PG)"
+    );
+    cleanup(&db).await;
+}
+
+/// v1.2 regression (PG parity): a freshly-registered user has NO usable device
+/// groups by design — all_device_groups stays false, user_device_groups empty,
+/// so a new user cannot forward until a plan/admin grants authorization.
+#[tokio::test]
+async fn pg_new_user_has_no_device_groups_by_default() {
+    let Some(db) = repo("newuser_nogroups").await else {
+        return;
+    };
+    db.insert_user_from_plan("carol", "hash", 1).await.unwrap();
+    let carol = db
+        .find_by_username("carol")
+        .await
+        .unwrap()
+        .expect("carol registered");
+    assert!(!carol.admin);
+    assert!(
+        !carol.all_device_groups,
+        "all_device_groups must default to false (PG)"
+    );
+    assert!(
+        db.list_user_device_groups(carol.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "user_device_groups must be empty for a new user (PG)"
+    );
+    assert!(
+        db.authorized_device_group_ids(carol.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "authorized_device_group_ids must be empty for a new user (PG)"
+    );
+    assert!(
+        db.is_user_restricted(carol.id).await.unwrap(),
+        "a non-admin without all_device_groups is restricted (PG)"
     );
     cleanup(&db).await;
 }

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -300,6 +300,58 @@ pub trait RuleRepository: Send + Sync {
         target_addr: &str,
         target_port: i32,
     ) -> Result<u64, DbError>;
+
+    /// v1.2: create a rule AND write its targets / load-balance strategy /
+    /// rate limits / tunnel profile in ONE transaction, returning the new
+    /// rule's id directly.
+    ///
+    /// This supersedes the old `insert_quota_guarded`-then-`list_rules`-by-
+    /// `listen_port`-lookup dance for `create_rule`. The old lookup keyed only
+    /// on `(owner_uid, listen_port)` and ignored `device_group_in`, so when two
+    /// inbound groups (both legal owners of the same listen_port under the
+    /// per-group partial unique index) reused a port, the lookup returned the
+    /// WRONG rule and the targets/LB/limits were written to it. Returning the
+    /// id from the INSERT itself closes that bug, and putting every write in
+    /// one transaction means a mid-creation failure leaves no half-rule.
+    ///
+    /// Returns:
+    /// - `Ok(Some(id))` — rule created; the id is the freshly inserted row.
+    /// - `Ok(None)` — the owner's max_rules quota is exhausted (the
+    ///   quota-guarded INSERT matched 0 rows); no row was written.
+    /// - `Err(DbError::PortConflict)` — listen_port already occupied on the
+    ///   inbound group by a conflicting socket type.
+    /// - `Err(DbError::UniqueViolation)` — DB-layer backstop (partial unique
+    ///   index) when a concurrent creator won the race.
+    ///
+    /// `load_balance_strategy` is the stable DB string ("first"/"round_robin"/
+    /// "failover"); it is only written when it differs from "first" (mirrors
+    /// the service's existing behaviour, since "first" is the column default).
+    /// `upload_limit_mbps` / `download_limit_mbps` are only written when either
+    /// is non-zero (0 = unlimited = the column default). `tunnel_profile_id` is
+    /// only written when `Some`.
+    #[allow(clippy::too_many_arguments)]
+    async fn create_rule_full(
+        &self,
+        name: &str,
+        uid: i64,
+        listen_port: i32,
+        protocol: &str,
+        public_transport: &str,
+        node_transport: &str,
+        route_mode: &str,
+        entry_transport: &str,
+        ws_path: Option<&str>,
+        device_group_in: i64,
+        device_group_out: Option<i64>,
+        forward_mode: &str,
+        target_addr: &str,
+        target_port: i32,
+        targets: &[RuleTargetRequest],
+        load_balance_strategy: &str,
+        upload_limit_mbps: i32,
+        download_limit_mbps: i32,
+        tunnel_profile_id: Option<i64>,
+    ) -> Result<Option<i64>, DbError>;
     /// Find (protocol, public_transport) for effective-combo validation, scoped.
     async fn find_transport_by_id(
         &self,

--- a/crates/panel/src/db/sqlite_repo/rules.rs
+++ b/crates/panel/src/db/sqlite_repo/rules.rs
@@ -338,6 +338,195 @@ impl RuleRepository for SqliteRepository {
         }
     }
 
+    async fn create_rule_full(
+        &self,
+        name: &str,
+        uid: i64,
+        listen_port: i32,
+        protocol: &str,
+        public_transport: &str,
+        node_transport: &str,
+        route_mode: &str,
+        entry_transport: &str,
+        ws_path: Option<&str>,
+        device_group_in: i64,
+        device_group_out: Option<i64>,
+        forward_mode: &str,
+        target_addr: &str,
+        target_port: i32,
+        targets: &[relay_shared::protocol::RuleTargetRequest],
+        load_balance_strategy: &str,
+        upload_limit_mbps: i32,
+        download_limit_mbps: i32,
+        tunnel_profile_id: Option<i64>,
+    ) -> Result<Option<i64>, DbError> {
+        // v1.2: atomic create. Same BEGIN IMMEDIATE + conflict pre-check +
+        // quota-guarded INSERT shape as insert_quota_guarded, but the INSERT is
+        // followed by the targets / LB / rate-limit / tunnel writes INSIDE the
+        // same transaction, and the new row's id comes from last_insert_rowid()
+        // instead of a post-commit (owner_uid, listen_port) re-lookup (which
+        // was wrong when two inbound groups reused a port — see trait docs).
+
+        let needs_tcp = matches!(protocol, "tcp" | "tcp_udp");
+        let needs_udp = matches!(protocol, "udp" | "tcp_udp");
+
+        let mut conn = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+
+        // Convert any sqlx error into a ROLLBACK + DbError early return, so the
+        // body stays linear (no per-statement match arms). The macro evaluates
+        // to `!` (it always returns), so `try_!(expr)` is well-typed for any
+        // sqlx::Error-producing statement.
+        macro_rules! try_ {
+            ($conn:expr, $expr:expr) => {
+                match $expr {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = sqlx::query("ROLLBACK").execute(&mut *$conn).await;
+                        return Err(DbError::from(e));
+                    }
+                }
+            };
+        }
+
+        // Port-conflict pre-check (socket-type aware, scoped to the group).
+        let conflict: Option<(i64,)> = try_!(
+            conn,
+            sqlx::query_as(
+                "SELECT 1 FROM forward_rules \
+                 WHERE device_group_in = ? AND listen_port = ? \
+                   AND ( (? = 1 AND protocol IN ('tcp', 'tcp_udp')) \
+                      OR (? = 1 AND protocol IN ('udp', 'tcp_udp')) ) \
+                 LIMIT 1",
+            )
+            .bind(device_group_in)
+            .bind(listen_port)
+            .bind(needs_tcp as i32)
+            .bind(needs_udp as i32)
+            .fetch_optional(&mut *conn)
+            .await
+        );
+        if conflict.is_some() {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+            return Err(DbError::PortConflict);
+        }
+
+        // Atomic quota-guarded INSERT. 0 rows affected ⇒ quota exhausted.
+        let result = try_!(
+            conn,
+            sqlx::query(
+                "INSERT INTO forward_rules \
+                   (name, uid, listen_port, protocol, public_transport, node_transport, \
+                    route_mode, entry_transport, ws_path, \
+                    device_group_in, device_group_out, forward_mode, target_addr, target_port) \
+                 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? \
+                 WHERE (SELECT max_rules FROM users WHERE id = ?) = 0 \
+                    OR (SELECT COUNT(*) FROM forward_rules WHERE uid = ?) \
+                       < (SELECT max_rules FROM users WHERE id = ?)",
+            )
+            .bind(name)
+            .bind(uid)
+            .bind(listen_port)
+            .bind(protocol)
+            .bind(public_transport)
+            .bind(node_transport)
+            .bind(route_mode)
+            .bind(entry_transport)
+            .bind(ws_path)
+            .bind(device_group_in)
+            .bind(device_group_out)
+            .bind(forward_mode)
+            .bind(target_addr)
+            .bind(target_port)
+            .bind(uid)
+            .bind(uid)
+            .bind(uid)
+            .execute(&mut *conn)
+            .await
+        );
+
+        if result.rows_affected() == 0 {
+            // Quota exhausted — nothing was inserted. The tx made no writes, so
+            // COMMIT it cleanly and report None to the caller.
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            return Ok(None);
+        }
+        let rule_id = result.last_insert_rowid();
+
+        // Targets: DELETE-then-INSERT keeps the SQL identical to
+        // replace_rule_targets (the row is brand new, so there are none).
+        try_!(
+            conn,
+            sqlx::query("DELETE FROM forward_rule_targets WHERE rule_id = ?")
+                .bind(rule_id)
+                .execute(&mut *conn)
+                .await
+        );
+        for (idx, target) in targets.iter().enumerate() {
+            try_!(
+                conn,
+                sqlx::query(
+                    "INSERT INTO forward_rule_targets (rule_id, host, port, position, enabled) \
+                     VALUES (?, ?, ?, ?, ?)",
+                )
+                .bind(rule_id)
+                .bind(target.host.trim())
+                .bind(target.port as i32)
+                .bind(idx as i32 + 1)
+                .bind(target.enabled)
+                .execute(&mut *conn)
+                .await
+            );
+        }
+
+        // Load-balance strategy: only written when not "first" (the column
+        // default), matching the service's pre-v1.2 conditional.
+        if load_balance_strategy != "first" {
+            try_!(
+                conn,
+                sqlx::query("UPDATE forward_rules SET load_balance_strategy = ? WHERE id = ?")
+                    .bind(load_balance_strategy)
+                    .bind(rule_id)
+                    .execute(&mut *conn)
+                    .await
+            );
+        }
+
+        // Rate limits: only written when either cap is non-zero (0 = unlimited
+        // = the column default).
+        if upload_limit_mbps != 0 || download_limit_mbps != 0 {
+            try_!(
+                conn,
+                sqlx::query(
+                    "UPDATE forward_rules SET upload_limit_mbps = ?, download_limit_mbps = ? \
+                     WHERE id = ?",
+                )
+                .bind(upload_limit_mbps)
+                .bind(download_limit_mbps)
+                .bind(rule_id)
+                .execute(&mut *conn)
+                .await
+            );
+        }
+
+        // Tunnel profile: only written when Some (Raw transport rules never
+        // reach here with a profile — the service rejects that combination
+        // earlier).
+        if let Some(pid) = tunnel_profile_id {
+            try_!(
+                conn,
+                sqlx::query("UPDATE forward_rules SET tunnel_profile_id = ? WHERE id = ?")
+                    .bind(pid)
+                    .bind(rule_id)
+                    .execute(&mut *conn)
+                    .await
+            );
+        }
+
+        sqlx::query("COMMIT").execute(&mut *conn).await?;
+        Ok(Some(rule_id))
+    }
+
     async fn find_transport_by_id(
         &self,
         id: i64,

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -677,6 +677,273 @@ async fn rule_insert_quota_guarded_surfaces_port_unique_violation() {
     }
 }
 
+/// v1.2 regression: the same listen_port may be reused across TWO different
+/// inbound groups (the per-group partial unique index allows it). Before v1.2,
+/// create_rule re-looked-up the new rule by (owner_uid, listen_port) — which
+/// ignores device_group_in — so the second create_rule_full's targets / LB /
+/// rate limits were written to the FIRST (wrong) rule. create_rule_full returns
+/// the id straight from the INSERT, so the side-tables land on the right rule.
+#[tokio::test]
+async fn rule_create_full_cross_group_no_crosstalk() {
+    let db = repo().await; // uid=1 admin seeded
+    seed_group(&db, 1).await; // inbound group 1
+    seed_group(&db, 2).await; // inbound group 2
+
+    // Rule A on group 1, port 10000, ONE target, default LB ("first"), no caps.
+    let id_a = db
+        .create_rule_full(
+            "ruleA",
+            1,
+            10000,
+            "tcp_udp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "a.example.com".into(),
+                port: 1001,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("rule A created");
+
+    // Rule B on group 2, SAME port 10000, THREE distinct targets + round_robin
+    // LB + up/down rate caps. Under the old bug this clobbered rule A.
+    let id_b = db
+        .create_rule_full(
+            "ruleB",
+            1,
+            10000,
+            "tcp_udp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            2,
+            None,
+            "direct",
+            "2.2.2.2",
+            80,
+            &[
+                relay_shared::protocol::RuleTargetRequest {
+                    host: "b1.example.com".into(),
+                    port: 2001,
+                    enabled: true,
+                },
+                relay_shared::protocol::RuleTargetRequest {
+                    host: "b2.example.com".into(),
+                    port: 2002,
+                    enabled: true,
+                },
+                relay_shared::protocol::RuleTargetRequest {
+                    host: "b3.example.com".into(),
+                    port: 2003,
+                    enabled: true,
+                },
+            ],
+            "round_robin",
+            50,
+            100,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("rule B created");
+
+    assert_ne!(id_a, id_b, "two distinct rules must have distinct ids");
+
+    // Rule A is UNTOUCHED: still one target, LB "first", zero caps.
+    let a = db
+        .find_rule_by_id(id_a, &ResourceScope::All)
+        .await
+        .unwrap()
+        .expect("rule A exists");
+    assert_eq!(a.device_group_in, 1);
+    assert_eq!(a.load_balance_strategy, "first");
+    assert_eq!(a.upload_limit_mbps, 0);
+    assert_eq!(a.download_limit_mbps, 0);
+    let a_targets = db
+        .list_rule_targets(id_a, &ResourceScope::All)
+        .await
+        .unwrap();
+    assert_eq!(a_targets.len(), 1, "rule A keeps exactly its one target");
+    assert_eq!(a_targets[0].host, "a.example.com");
+
+    // Rule B got everything: three targets, round_robin, the rate caps.
+    let b = db
+        .find_rule_by_id(id_b, &ResourceScope::All)
+        .await
+        .unwrap()
+        .expect("rule B exists");
+    assert_eq!(b.device_group_in, 2);
+    assert_eq!(b.load_balance_strategy, "round_robin");
+    assert_eq!(b.upload_limit_mbps, 50);
+    assert_eq!(b.download_limit_mbps, 100);
+    let b_targets = db
+        .list_rule_targets(id_b, &ResourceScope::All)
+        .await
+        .unwrap();
+    assert_eq!(b_targets.len(), 3, "rule B got its three targets");
+    assert_eq!(b_targets[0].host, "b1.example.com");
+    assert_eq!(b_targets[2].host, "b3.example.com");
+}
+
+/// v1.2 regression: create_rule_full is one transaction, so a failure in the
+/// targets write (here a port=0 target violates the table's CHECK constraint)
+/// must roll back the rule-row INSERT — no half-rule left behind.
+#[tokio::test]
+async fn rule_create_full_rollback_on_target_failure() {
+    let db = repo().await;
+    seed_group(&db, 1).await;
+
+    // port 0 is a valid u16 but violates forward_rule_targets CHECK (port >= 1),
+    // so the target INSERT inside the transaction fails.
+    let err = db
+        .create_rule_full(
+            "doomed",
+            1,
+            30000,
+            "tcp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "bad.example.com".into(),
+                port: 0,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await;
+    assert!(err.is_err(), "the bad target must fail the whole call");
+
+    // No half-rule residue: zero rows on port 30000 for this owner.
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM forward_rules WHERE uid = 1 AND listen_port = 30000",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 0, "transaction must roll back, leaving no rule row");
+    // And no orphan targets either.
+    let target_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM forward_rule_targets WHERE rule_id IN \
+             (SELECT id FROM forward_rules WHERE uid = 1)",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(target_count, 0, "no orphan target rows");
+}
+
+/// v1.2: create_rule_full reports Ok(None) (not an error, not a row) when the
+/// owner's max_rules quota is exhausted, so the service can map that to a 400.
+#[tokio::test]
+async fn rule_create_full_quota_exhausted_returns_none() {
+    let db = repo().await;
+    seed_group(&db, 1).await;
+    sqlx::query("UPDATE users SET max_rules = 1 WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    // First create succeeds with Some(id).
+    assert!(
+        db.create_rule_full(
+            "r1",
+            1,
+            40000,
+            "tcp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "a.example.com".into(),
+                port: 80,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await
+        .unwrap()
+        .is_some(),
+        "first rule within quota returns Some(id)"
+    );
+
+    // Second create hits the quota guard → Ok(None), and crucially no new row.
+    assert_eq!(
+        db.create_rule_full(
+            "r2",
+            1,
+            40001,
+            "tcp",
+            "raw",
+            "raw",
+            "direct",
+            "raw",
+            None,
+            1,
+            None,
+            "direct",
+            "1.1.1.1",
+            80,
+            &[relay_shared::protocol::RuleTargetRequest {
+                host: "a.example.com".into(),
+                port: 80,
+                enabled: true,
+            }],
+            "first",
+            0,
+            0,
+            None,
+        )
+        .await
+        .unwrap(),
+        None,
+        "quota exhaustion returns Ok(None)"
+    );
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM forward_rules WHERE uid = 1")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "the over-quota create wrote no row");
+}
+
 /// v0.4.11 PR4: a pure-TCP and a pure-UDP rule may share the same port on
 /// the same group; two TCP-bearing (or two UDP-bearing) rules may not.
 #[tokio::test]
@@ -1879,6 +2146,47 @@ async fn insert_user_from_plan_inherits_quota_and_handles_missing_plan() {
     assert!(
         db.find_by_username("bob").await.unwrap().is_none(),
         "no user should be created for a missing plan"
+    );
+}
+
+/// v1.2 regression: a freshly-registered user has NO usable device groups by
+/// product design — `all_device_groups` stays false and `user_device_groups`
+/// stays empty, so a brand-new user cannot forward until a plan/admin grants
+/// authorization. This pins the behaviour so a future change (e.g. auto-grant
+/// on registration) can't silently flip it.
+#[tokio::test]
+async fn new_user_has_no_device_groups_by_default() {
+    let db = repo().await; // plan_id=1 (free) is seeded
+    db.insert_user_from_plan("carol", "hash", 1).await.unwrap();
+    let carol = db
+        .find_by_username("carol")
+        .await
+        .unwrap()
+        .expect("carol registered");
+    assert!(!carol.admin);
+    assert!(
+        !carol.all_device_groups,
+        "all_device_groups must default to false — a new user may not use any group"
+    );
+
+    // No explicit authorization rows either.
+    assert!(
+        db.list_user_device_groups(carol.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "user_device_groups must be empty for a new user"
+    );
+    assert!(
+        db.authorized_device_group_ids(carol.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "authorized_device_group_ids must be empty for a new user"
+    );
+    assert!(
+        db.is_user_restricted(carol.id).await.unwrap(),
+        "a non-admin without all_device_groups is restricted (cannot forward)"
     );
 }
 

--- a/crates/panel/src/service/rules.rs
+++ b/crates/panel/src/service/rules.rs
@@ -9,8 +9,7 @@
 use crate::db::error::DbError;
 use crate::db::repo::{GroupRepository, ProfileScope, Repository, ResourceScope};
 use relay_shared::protocol::{
-    CreateRuleRequest, GroupType, LoadBalanceStrategy, Protocol, PublicTransport,
-    RuleTargetRequest, UpdateRuleRequest,
+    CreateRuleRequest, GroupType, Protocol, PublicTransport, RuleTargetRequest, UpdateRuleRequest,
 };
 
 /// v0.4.20: forward_mode is locked to "direct" at the API boundary
@@ -406,10 +405,22 @@ pub async fn create_rule(
         None
     };
 
+    let lb_db = req.load_balance_strategy.to_db_str();
+    let up_mbps = req.upload_limit_mbps.unwrap_or(0).max(0);
+    let down_mbps = req.download_limit_mbps.unwrap_or(0).max(0);
+
     let mut attempt = 0u32;
     let max_attempts = if req.listen_port.is_some() { 1 } else { 8 };
     let mut last_port: Option<u16> = req.listen_port;
-    let result: Result<u64, DbError> = loop {
+    // v1.2: create_rule_full does the rule INSERT + targets + LB + rate limits
+    // + tunnel profile in ONE transaction and returns the new rule's id
+    // directly (SQLite last_insert_rowid / PG RETURNING id). This replaces the
+    // old insert_quota_guarded-then-list_rules-by-(owner,listen_port)-lookup,
+    // which wrote the side-tables to the WRONG rule when two inbound groups
+    // reused the same listen_port (the per-group unique index makes that legal
+    // but the lookup ignored device_group_in). Atomicity also guarantees a
+    // mid-create failure leaves no half-rule.
+    let result: Result<Option<i64>, DbError> = loop {
         let port = match last_port {
             Some(p) => p,
             None => match auto_assign_port(db, req.device_group_in, protocol_str).await {
@@ -420,7 +431,7 @@ pub async fn create_rule(
         last_port = Some(port);
 
         match db
-            .insert_quota_guarded(
+            .create_rule_full(
                 &req.name,
                 owner_uid,
                 port as i32,
@@ -435,10 +446,15 @@ pub async fn create_rule(
                 &req.forward_mode,
                 &primary_target.host,
                 primary_target.port as i32,
+                &targets,
+                lb_db,
+                up_mbps,
+                down_mbps,
+                req.tunnel_profile_id,
             )
             .await
         {
-            Ok(n) => break Ok(n),
+            Ok(opt) => break Ok(opt),
             Err(DbError::PortConflict | DbError::UniqueViolation)
                 if req.listen_port.is_none() && attempt + 1 < max_attempts =>
             {
@@ -456,76 +472,22 @@ pub async fn create_rule(
         }
     };
 
-    if let Ok(0) = result {
-        let current_count: i64 = db.count_by_uid(owner_uid).await.unwrap_or(0);
-        let max_rules: i32 = db.max_rules_for_uid(owner_uid).await.unwrap_or(0);
-        return Err(CreateRuleError::BadRequest(format!(
-            "Rule limit reached: you have {} rules, max is {}",
-            current_count, max_rules
-        )));
-    }
-
-    if let Err(DbError::PortConflict | DbError::UniqueViolation) = &result {
-        return Err(CreateRuleError::PortConflict(last_port.unwrap_or(0)));
-    }
-
     match result {
-        Ok(_) => {
-            if let Some(rule) = db
-                .list_rules(&owner_scope)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .find(|r| r.listen_port == last_port.unwrap_or(0) as i32)
-            {
-                if let Err(e) = db
-                    .replace_rule_targets(rule.id, &owner_scope, &targets)
-                    .await
-                {
-                    tracing::error!("create_rule: replace_rule_targets failed: {}", e);
-                    return Err(CreateRuleError::Database(e));
-                }
-                if req.load_balance_strategy != LoadBalanceStrategy::First {
-                    if let Err(e) = db
-                        .set_rule_load_balance_strategy(
-                            rule.id,
-                            &owner_scope,
-                            req.load_balance_strategy.to_db_str(),
-                        )
-                        .await
-                    {
-                        tracing::error!(
-                            "create_rule: set_rule_load_balance_strategy failed: {}",
-                            e
-                        );
-                        return Err(CreateRuleError::Database(e));
-                    }
-                }
-                let up_mbps = req.upload_limit_mbps.unwrap_or(0).max(0);
-                let down_mbps = req.download_limit_mbps.unwrap_or(0).max(0);
-                if up_mbps != 0 || down_mbps != 0 {
-                    if let Err(e) = db
-                        .set_rule_rate_limits(rule.id, &owner_scope, up_mbps, down_mbps)
-                        .await
-                    {
-                        tracing::error!("create_rule: set_rule_rate_limits failed: {}", e);
-                        return Err(CreateRuleError::Database(e));
-                    }
-                }
-                if let Some(pid) = req.tunnel_profile_id {
-                    if let Err(e) = db
-                        .set_rule_tunnel_profile(rule.id, &owner_scope, Some(pid))
-                        .await
-                    {
-                        tracing::error!("create_rule: set_rule_tunnel_profile failed: {}", e);
-                        return Err(CreateRuleError::Database(e));
-                    }
-                }
-            }
-            Ok(())
+        Ok(None) => {
+            // Quota exhausted: the guarded INSERT matched 0 rows.
+            let current_count: i64 = db.count_by_uid(owner_uid).await.unwrap_or(0);
+            let max_rules: i32 = db.max_rules_for_uid(owner_uid).await.unwrap_or(0);
+            Err(CreateRuleError::BadRequest(format!(
+                "Rule limit reached: you have {} rules, max is {}",
+                current_count, max_rules
+            )))
+        }
+        Ok(Some(_)) => Ok(()),
+        Err(DbError::PortConflict | DbError::UniqueViolation) => {
+            Err(CreateRuleError::PortConflict(last_port.unwrap_or(0)))
         }
         Err(e) => {
-            tracing::error!("create_rule: insert_quota_guarded failed: {}", e);
+            tracing::error!("create_rule: create_rule_full failed: {}", e);
             Err(CreateRuleError::Database(e))
         }
     }


### PR DESCRIPTION
## 修复

**根因**：`service/rules.rs` 在 `insert_quota_guarded` 返回后，用 `db.list_rules(&owner_scope).find(|r| r.listen_port == port)` 反查新规则 ID。`owner_scope = Owner(uid)` 不含 `device_group_in`，而端口唯一约束是**按入口分组**的——同一 owner 在两个不同入口分组复用同一 listen_port（合法）时，`.find()` 命中第一条（旧规则），targets / 负载策略 / 限速全写进错规则。这些后续写语句还各自独立、不在事务内，中途失败会残留半条规则。

## 改动
- 新增 `Repository::create_rule_full`（trait 声明 + SQLite/PG 实现）：规则主体 INSERT + targets + load_balance_strategy + 上下行限速 + tunnel_profile 放在**同一事务**内，新规则 ID 直接来自 INSERT（SQLite `last_insert_rowid()` / PG `RETURNING id`）。SQLite 沿用 `BEGIN IMMEDIATE` + socket-type 端口冲突预检 + max_rules 配额守卫；PG 沿用 `pg_advisory_xact_lock` + users `FOR UPDATE`。任一步失败完整回滚，零半成品残留。
- `create_rule` 改调 `create_rule_full`，删除旧的 `list_rules`-by-(owner,listen_port) 反查与四段独立写。保留自动分配端口重试循环、`Ok(None)`→配额超限 400、`PortConflict`→409。
- `insert_quota_guarded` 旧方法保留（测试仍用）。

## 回归测试（SQLite + PG 镜像，repo-parity 通过）
- `rule_create_full_cross_group_no_crosstalk`：两入口分组各建 listen_port=10000；第二条带 3 目标+round_robin+限速。断言第一条规则**不被改动**，第二条含全部设定。
- `rule_create_full_rollback_on_target_failure`：注入 port=0 目标（违反 CHECK），断言 `forward_rules` 零行残留。
- `rule_create_full_quota_exhausted_returns_none`：max_rules=1，第二条返回 `Ok(None)` 且不写行。
- `new_user_has_no_device_groups_by_default`：固定新注册用户无设备分组（all_device_groups=false / user_device_groups 空 / is_user_restricted=true）。

## 数据库变化
无 schema 变化。

## 兼容性风险
低。`POST /rules` 对外契约不变。

## 验收
cargo fmt/clippy/test（panel 384 全过）、repo-test-parity 通过。