### PR TITLE
release: v1.1.1 + node-v1.1.1(两轨版本 bump)

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
-## [Unreleased]
+## [1.1.1] - 2026-07-08
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
-## [Unreleased]
+## [1.1.1] - 2026-07-08
 
 ### Changed — panel & node now release on independent tracks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.1.0";
+const COMPILED_APP_VERSION: &str = "1.1.1";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.0}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.1}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -57,7 +57,7 @@ services:
     # v1.2: the node image tag is INDEPENDENT of the panel tag. Override
     # RELAYPANEL_NODE_TAG in .env to pin a node version that differs from the
     # panel version.
-    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.1.0}
+    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.1.1}
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.1.0"
+SCRIPT_VERSION="1.1.1"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
把 panel 与 node 两条轨都 bump 到 **1.1.1**,并把各自 changelog 的 `[Unreleased]` 落成 `[1.1.1] - 2026-07-08`。

## Panel(tag `v1.1.1`)
- `crates/panel/Cargo.toml`、`config.rs` 的 `COMPILED_APP_VERSION`、`docker-compose.release.yaml` 的 `RELAYPANEL_PANEL_TAG`、`Cargo.lock`
- `CHANGELOG.md` [1.1.1]:独立发布轨、密码规则+安全头、规则创建原子性、导入导出加固、移动端/懒加载/a11y/antd v6 清理等

## Node(tag `node-v1.1.1`)
- `crates/node/Cargo.toml`、`relay-node-install.sh` 的 `SCRIPT_VERSION`、`docker-compose.release.yaml` 的 `RELAYPANEL_NODE_TAG`、`Cargo.lock`
- `CHANGELOG-NODE.md` [1.1.1]:fd 耗尽修复(keepalive 回收半开连接 + 抬高 RLIMIT_NOFILE + docker ulimits)

## 验证
- `release-check.sh panel 1.1.1` 与 `node 1.1.1` 均 **0 FAIL**
- `cargo check` 更新 Cargo.lock、`cargo fmt --check` 干净

合并后按顺序打 tag:`v1.1.1` → 等 docker-release 绿 → `node-v1.1.1` → 等 node-release 全绿 → 跑 `bridge-node-asset.yml -f version=1.1.1`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)