### PR TITLE
fix(ci): 桥接 workflow 设置 GH_REPO(gh 无法解析仓库导致 release not found)

### DIFF
--- a/.github/workflows/bridge-node-asset.yml
+++ b/.github/workflows/bridge-node-asset.yml
@@ -42,6 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      # No `actions/checkout` in this job, so `gh` has no local git remote to
+      # infer the repo from — point it explicitly, or every `gh release` call
+      # fails to resolve the repository and reports "release not found".
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Resolve + validate tags
         id: t


### PR DESCRIPTION
桥接 job 没有 `actions/checkout`,runner 里 `gh` 没有本地 git remote 可推断仓库,导致 `gh release view node-v1.1.1` 解析不到仓库、误报 "release not found",桥接第一步就失败。

在 job 级加 `GH_REPO: ${{ github.repository }}`,所有 `gh` 调用即可正确定位仓库。逻辑与安全门槛(published 检查、sha256 复验)不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)