### PR TITLE
fix: auto 端口遵守设备组 port_range + UDP 域名按会话重解析(跟随 DDNS)

### DIFF
--- a/crates/node/src/forwarder/outbound.rs
+++ b/crates/node/src/forwarder/outbound.rs
@@ -297,7 +297,10 @@ fn dns_cache() -> &'static AsyncMutex<HashMap<String, CachedDns>> {
 /// Resolve `target` ("host:port") to socket addresses, caching for
 /// `DNS_CACHE_TTL`. On a resolver error a stale cached entry (if any) is reused
 /// rather than failing the connection outright — DNS blips shouldn't drop links.
-async fn resolve_cached(target: &str) -> std::io::Result<Vec<SocketAddr>> {
+///
+/// `pub(super)` so the UDP forwarder can re-resolve session targets through the
+/// same cache (following DDNS changes) instead of pinning a boot-time IP.
+pub(super) async fn resolve_cached(target: &str) -> std::io::Result<Vec<SocketAddr>> {
     {
         let cache = dns_cache().lock().await;
         if let Some(c) = cache.get(target) {

--- a/crates/node/src/forwarder/udp.rs
+++ b/crates/node/src/forwarder/udp.rs
@@ -63,37 +63,13 @@ pub async fn serve_udp_listener(
 
     let port = listen_addr.port();
 
-    // v0.4.6: resolve targets keeping index alignment with the `targets` list so
-    // the load-balance selector (which returns target INDICES) maps to the right
-    // address. Each target string resolves to its FIRST address; unresolvable
-    // targets become None and are skipped during selection. Async DNS is used so
-    // a slow resolver can't block a runtime worker.
-    let mut resolved: Vec<Option<SocketAddr>> = Vec::with_capacity(targets.len());
-    for t in &targets {
-        if let Ok(addr) = t.parse::<SocketAddr>() {
-            resolved.push(Some(addr));
-            continue;
-        }
-        match tokio::net::lookup_host(t).await {
-            Ok(mut addrs) => resolved.push(addrs.next()),
-            Err(e) => {
-                tracing::warn!(
-                    "UDP listener on {}: failed to resolve {}: {}",
-                    listen_addr,
-                    t,
-                    e
-                );
-                resolved.push(None);
-            }
-        }
-    }
-    if resolved.iter().all(Option::is_none) {
-        tracing::error!(
-            "UDP listener on {}: failed to resolve any target",
-            listen_addr
-        );
-        return Err("no resolvable target".into());
-    }
+    // v1.2.x: targets are resolved LAZILY per new session (see
+    // select_udp_target) rather than once here at listener start. The old
+    // boot-time resolution pinned a DDNS target to whatever IP it had when the
+    // rule was pushed; the IP never refreshed until the rule/node restarted,
+    // silently blackholing UDP (WireGuard / game / DNS-forward) traffic after a
+    // DDNS update. Session-time resolution goes through the shared 30s DNS cache
+    // so new sessions follow IP changes automatically.
 
     // v1.0.9: sharded concurrent map — per-packet lookups take a per-shard lock
     // (keyed by client addr) instead of one listener-wide mutex, so datagrams
@@ -177,15 +153,12 @@ pub async fn serve_udp_listener(
                     continue;
                 }
             };
-            // v0.4.6: pick a target per the rule's load-balance strategy. The
-            // selector yields target indices in priority order; we use the first
-            // that resolved. UDP affinity: this pick happens once per NEW
-            // session, so all datagrams from the same client stay pinned.
-            let target = match selector
-                .order()
-                .into_iter()
-                .find_map(|idx| resolved.get(idx).copied().flatten())
-            {
+            // Pick a target per the rule's load-balance strategy AND resolve it
+            // now, through the 30s DNS cache, so a DDNS target follows IP
+            // changes (see select_udp_target). UDP affinity: this happens once
+            // per NEW session, so all datagrams from the same client stay pinned
+            // to the IP chosen here until the session idles out.
+            let target = match select_udp_target(&targets, &selector, port).await {
                 Some(t) => t,
                 None => {
                     tracing::warn!("UDP port {}: no resolvable target for session", port);
@@ -289,6 +262,42 @@ pub async fn serve_udp_listener(
     }
 }
 
+/// Resolve the outbound target for a NEW UDP session, honoring the rule's
+/// load-balance order and following DNS changes.
+///
+/// v1.2.x: unlike the pre-split code — which resolved every target ONCE at
+/// listener startup and reused those addresses forever — this re-resolves
+/// through the shared DNS cache (`resolve_cached`, 30s TTL) at session-open
+/// time. A DDNS target whose IP changes is picked up by the next new session
+/// within the cache TTL, instead of being pinned to the boot-time IP until the
+/// rule or node restarts. (Established sessions keep their socket and age out on
+/// the 60s idle timeout, after which new datagrams open a fresh session against
+/// the current IP.)
+///
+/// Returns the first target, in selector order, that resolves to at least one
+/// address; None when none resolve.
+async fn select_udp_target(
+    targets: &[String],
+    selector: &TargetSelector,
+    port: u16,
+) -> Option<SocketAddr> {
+    for idx in selector.order() {
+        let Some(t) = targets.get(idx) else { continue };
+        match super::outbound::resolve_cached(t).await {
+            Ok(addrs) => {
+                if let Some(addr) = addrs.into_iter().next() {
+                    return Some(addr);
+                }
+                tracing::debug!("UDP port {}: target {} resolved to no address", port, t);
+            }
+            Err(e) => {
+                tracing::debug!("UDP port {}: failed to resolve target {}: {}", port, t, e);
+            }
+        }
+    }
+    None
+}
+
 /// Classify whether a `recv_from` error is worth retrying (mirrors the TCP
 /// accept classifier). Transient OS-level resource exhaustion clears on its
 /// own; retrying keeps the listener alive. A bad-fd / closed-socket error is
@@ -305,4 +314,52 @@ fn is_transient_recv_error(e: &std::io::Error) -> bool {
         // EMFILE (24) / ENFILE (23) / ENOBUFS (105) / ENOMEM (12).
         matches!(c, 24 | 23 | 105 | 12)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relay_shared::protocol::LoadBalanceStrategy;
+
+    // All targets below are IP literals ("ip:port"), which resolve LOCALLY via
+    // lookup_host with no DNS query — keeping these tests hermetic (no network).
+
+    /// Failover order picks the first (primary) target and resolves it.
+    #[tokio::test]
+    async fn select_udp_target_picks_first_in_order() {
+        let targets = vec!["127.0.0.1:9".to_string(), "127.0.0.2:9".to_string()];
+        let selector = TargetSelector::new(LoadBalanceStrategy::Failover, 2);
+        let got = select_udp_target(&targets, &selector, 5000).await;
+        assert_eq!(got, Some("127.0.0.1:9".parse().unwrap()));
+    }
+
+    /// Round-robin advances the shared cursor across successive new sessions,
+    /// so consecutive sessions pin to different targets.
+    #[tokio::test]
+    async fn select_udp_target_follows_round_robin() {
+        let targets = vec!["127.0.0.1:9".to_string(), "127.0.0.2:9".to_string()];
+        let selector = TargetSelector::new(LoadBalanceStrategy::RoundRobin, 2);
+        let a = select_udp_target(&targets, &selector, 5000).await.unwrap();
+        let b = select_udp_target(&targets, &selector, 5000).await.unwrap();
+        assert_eq!(a, "127.0.0.1:9".parse().unwrap());
+        assert_eq!(b, "127.0.0.2:9".parse().unwrap());
+    }
+
+    /// A target that can't be resolved (no port → immediate parse error, no DNS)
+    /// is skipped, falling through to the next resolvable target in order.
+    #[tokio::test]
+    async fn select_udp_target_skips_unresolvable() {
+        let targets = vec!["nocolon-no-port".to_string(), "127.0.0.1:9".to_string()];
+        let selector = TargetSelector::new(LoadBalanceStrategy::Failover, 2);
+        let got = select_udp_target(&targets, &selector, 5000).await;
+        assert_eq!(got, Some("127.0.0.1:9".parse().unwrap()));
+    }
+
+    /// No targets → None (the caller drops the datagram and warns).
+    #[tokio::test]
+    async fn select_udp_target_none_when_empty() {
+        let targets: Vec<String> = vec![];
+        let selector = TargetSelector::new(LoadBalanceStrategy::RoundRobin, 0);
+        assert!(select_udp_target(&targets, &selector, 5000).await.is_none());
+    }
 }

--- a/crates/panel/src/db/pg_repo/rules.rs
+++ b/crates/panel/src/db/pg_repo/rules.rs
@@ -215,6 +215,17 @@ impl RuleRepository for PgRepository {
         Ok(rows)
     }
 
+    async fn group_port_range(&self, group_id: i64) -> Result<Option<String>, DbError> {
+        // port_range is TEXT NOT NULL, so the Option here reflects row existence
+        // (missing group -> None), not a null column.
+        let range: Option<String> =
+            sqlx::query_scalar("SELECT port_range FROM device_groups WHERE id = $1")
+                .bind(group_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(range)
+    }
+
     async fn count_by_uid(&self, uid: i64) -> Result<i64, DbError> {
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM forward_rules WHERE uid = $1")
             .bind(uid)

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -707,6 +707,118 @@ async fn pg_rule_insert_quota_guarded_port_scoped_by_group() {
     cleanup(&db).await;
 }
 
+// ── v1.2.x (PG parity): auto_assign_port honors the group's port_range ──
+
+/// Seed an inbound device_group with an explicit `port_range` (the auto-assign
+/// pool). PG mirror of the SQLite `seed_group_with_range` helper.
+async fn seed_group_with_range(db: &PgRepository, gid: i64, range: &str) {
+    sqlx::query(
+        "INSERT INTO device_groups (id, name, group_type, token, uid, port_range) \
+         VALUES ($1, 'gin', 'in', $2, 1, $3)",
+    )
+    .bind(gid)
+    .bind(format!("tok-{gid}"))
+    .bind(range)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+}
+
+/// PG mirror: an explicit narrow range confines every auto-assigned port.
+#[tokio::test]
+async fn pg_auto_assign_port_stays_within_explicit_group_range() {
+    use crate::service::rules::auto_assign_port;
+    let Some(db) = repo("auto_port_explicit_range").await else {
+        return;
+    };
+    seed_group_with_range(&db, 1, "65000-65100").await;
+    for _ in 0..30 {
+        let p = auto_assign_port(&db, 1, "tcp").await.unwrap();
+        assert!(
+            (65000..=65100).contains(&p),
+            "auto port {} escaped the configured 65000-65100 range",
+            p
+        );
+    }
+    cleanup(&db).await;
+}
+
+/// PG mirror: the `1-65535` sentinel maps to the 10000-65535 default pool.
+#[tokio::test]
+async fn pg_auto_assign_port_sentinel_uses_default_pool() {
+    use crate::service::rules::auto_assign_port;
+    let Some(db) = repo("auto_port_sentinel").await else {
+        return;
+    };
+    // No port_range column → PG schema default '1-65535' (the sentinel).
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (1, 'gin', 'in', 'tok-1', 1)")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    for _ in 0..30 {
+        let p = auto_assign_port(&db, 1, "tcp").await.unwrap();
+        assert!(
+            (10000..=65535).contains(&p),
+            "sentinel must map to 10000-65535, got {}",
+            p
+        );
+    }
+    cleanup(&db).await;
+}
+
+/// PG mirror: a full range errors (naming the range), socket-type scoped.
+#[tokio::test]
+async fn pg_auto_assign_port_errors_when_range_full() {
+    use crate::service::rules::auto_assign_port;
+    let Some(db) = repo("auto_port_full").await else {
+        return;
+    };
+    seed_group_with_range(&db, 1, "50000-50000").await;
+    db.insert_quota_guarded(
+        "r1",
+        1,
+        50000,
+        "tcp",
+        "raw",
+        "raw",
+        "direct",
+        "raw",
+        None,
+        1,
+        None,
+        "direct",
+        "127.0.0.1",
+        80,
+    )
+    .await
+    .unwrap();
+    let err = auto_assign_port(&db, 1, "tcp").await.unwrap_err();
+    assert!(
+        err.contains("50000-50000"),
+        "error must name the exhausted range, got {:?}",
+        err
+    );
+    let p = auto_assign_port(&db, 1, "udp").await.unwrap();
+    assert_eq!(p, 50000, "udp must reuse the port held only by tcp");
+    cleanup(&db).await;
+}
+
+/// PG mirror: a non-existent group id falls back to the default pool.
+#[tokio::test]
+async fn pg_auto_assign_port_missing_group_uses_default_pool() {
+    use crate::service::rules::auto_assign_port;
+    let Some(db) = repo("auto_port_missing_group").await else {
+        return;
+    };
+    let p = auto_assign_port(&db, 999, "tcp").await.unwrap();
+    assert!(
+        (10000..=65535).contains(&p),
+        "missing group must use the default pool, got {}",
+        p
+    );
+    cleanup(&db).await;
+}
+
 /// v1.2 regression (PG mirror of the SQLite test): the same listen_port may be
 /// reused across two different inbound groups. create_rule_full returns the id
 /// straight from RETURNING, so the second rule's targets / LB / rate limits land

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -264,6 +264,11 @@ pub trait RuleRepository: Send + Sync {
         &self,
         device_group_in: i64,
     ) -> Result<Vec<(i32, String)>, DbError>;
+    /// v1.2.x: the auto-assign port pool configured on a device group
+    /// (`device_groups.port_range`, e.g. "10000-65535"). `auto_assign_port`
+    /// parses this to bound its search. Returns `None` when the group id
+    /// doesn't exist (the caller falls back to the default pool).
+    async fn group_port_range(&self, group_id: i64) -> Result<Option<String>, DbError>;
     /// Count rules for a user (quota reporting).
     async fn count_by_uid(&self, uid: i64) -> Result<i64, DbError>;
     /// Get max_rules for a user (quota ceiling; 0 = unlimited).

--- a/crates/panel/src/db/sqlite_repo/rules.rs
+++ b/crates/panel/src/db/sqlite_repo/rules.rs
@@ -215,6 +215,17 @@ impl RuleRepository for SqliteRepository {
         Ok(rows)
     }
 
+    async fn group_port_range(&self, group_id: i64) -> Result<Option<String>, DbError> {
+        // port_range is TEXT NOT NULL, so the Option here reflects row existence
+        // (missing group -> None), not a null column.
+        let range: Option<String> =
+            sqlx::query_scalar("SELECT port_range FROM device_groups WHERE id = ?")
+                .bind(group_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(range)
+    }
+
     async fn count_by_uid(&self, uid: i64) -> Result<i64, DbError> {
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM forward_rules WHERE uid = ?")
             .bind(uid)

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -1098,8 +1098,20 @@ async fn auto_assign_port_errors_when_range_full() {
     seed_group_with_range(&db, 1, "50000-50000").await;
     // Occupy the pool's only port with a TCP rule on this group.
     db.insert_quota_guarded(
-        "r1", 1, 50000, "tcp", "raw", "raw", "direct", "raw", None, 1, None, "direct",
-        "127.0.0.1", 80,
+        "r1",
+        1,
+        50000,
+        "tcp",
+        "raw",
+        "raw",
+        "direct",
+        "raw",
+        None,
+        1,
+        None,
+        "direct",
+        "127.0.0.1",
+        80,
     )
     .await
     .unwrap();

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -42,6 +42,21 @@ async fn seed_group(db: &SqliteRepository, gid: i64) {
     .unwrap();
 }
 
+/// Seed an inbound device_group with an explicit `port_range` (the auto-assign
+/// pool). Mirrors `seed_group` but lets a test pin the range under test.
+async fn seed_group_with_range(db: &SqliteRepository, gid: i64, range: &str) {
+    sqlx::query(
+        "INSERT INTO device_groups (id, name, group_type, token, uid, port_range) \
+         VALUES (?, 'gin', 'in', ?, 1, ?)",
+    )
+    .bind(gid)
+    .bind(format!("tok-{gid}"))
+    .bind(range)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+}
+
 /// Insert a user row with the given id + admin flag (FK target for groups).
 async fn seed_user(db: &SqliteRepository, id: i64, admin: bool) {
     sqlx::query("INSERT INTO users (id, username, password, admin) VALUES (?, ?, 'x', ?)")
@@ -1035,6 +1050,82 @@ async fn rule_insert_quota_guarded_port_scoped_by_group() {
             other
         ),
     }
+}
+
+// ── v1.2.x: auto_assign_port honors the group's port_range ──
+
+/// An explicit narrow range confines every auto-assigned port to that range.
+#[tokio::test]
+async fn auto_assign_port_stays_within_explicit_group_range() {
+    use crate::service::rules::auto_assign_port;
+    let db = repo().await;
+    seed_group_with_range(&db, 1, "65000-65100").await;
+    // Nothing is occupied, so every draw is valid — assert it stays in-range
+    // across many random starts (the ring scan starts at a random offset).
+    for _ in 0..30 {
+        let p = auto_assign_port(&db, 1, "tcp").await.unwrap();
+        assert!(
+            (65000..=65100).contains(&p),
+            "auto port {} escaped the configured 65000-65100 range",
+            p
+        );
+    }
+}
+
+/// The `1-65535` schema default (seed_group leaves it unset → default) is the
+/// "全可转发" sentinel and maps to the 10000-65535 pool, never a system port.
+#[tokio::test]
+async fn auto_assign_port_sentinel_uses_default_pool() {
+    use crate::service::rules::auto_assign_port;
+    let db = repo().await;
+    seed_group(&db, 1).await; // port_range defaults to '1-65535'
+    for _ in 0..30 {
+        let p = auto_assign_port(&db, 1, "tcp").await.unwrap();
+        assert!(
+            (10000..=65535).contains(&p),
+            "sentinel must map to 10000-65535, got {}",
+            p
+        );
+    }
+}
+
+/// A full range errors (naming the real range) instead of spilling outside it —
+/// and the fullness is socket-type scoped: a TCP occupant doesn't block UDP.
+#[tokio::test]
+async fn auto_assign_port_errors_when_range_full() {
+    use crate::service::rules::auto_assign_port;
+    let db = repo().await;
+    seed_group_with_range(&db, 1, "50000-50000").await;
+    // Occupy the pool's only port with a TCP rule on this group.
+    db.insert_quota_guarded(
+        "r1", 1, 50000, "tcp", "raw", "raw", "direct", "raw", None, 1, None, "direct",
+        "127.0.0.1", 80,
+    )
+    .await
+    .unwrap();
+    let err = auto_assign_port(&db, 1, "tcp").await.unwrap_err();
+    assert!(
+        err.contains("50000-50000"),
+        "error must name the exhausted range, got {:?}",
+        err
+    );
+    // A UDP-bearing rule doesn't conflict with the TCP occupant → still fits.
+    let p = auto_assign_port(&db, 1, "udp").await.unwrap();
+    assert_eq!(p, 50000, "udp must reuse the port held only by tcp");
+}
+
+/// A non-existent group id (None port_range) falls back to the default pool
+/// rather than erroring.
+#[tokio::test]
+async fn auto_assign_port_missing_group_uses_default_pool() {
+    use crate::service::rules::auto_assign_port;
+    let db = repo().await;
+    let p = auto_assign_port(&db, 999, "tcp").await.unwrap();
+    assert!(
+        (10000..=65535).contains(&p),
+        "missing group must use the default pool, got {}",
+        p
+    );
 }
 
 #[tokio::test]

--- a/crates/panel/src/service/rules.rs
+++ b/crates/panel/src/service/rules.rs
@@ -132,8 +132,61 @@ pub fn group_type_to_str(gt: &GroupType) -> &'static str {
     }
 }
 
-/// Auto-assign a free listen port from 10000-65535, scoped to the rule's
-/// inbound group and socket type.
+/// The default auto-assign pool used when a group's `port_range` is unset, is
+/// the "全可转发" sentinel `1-65535`, or is unparseable. Deliberately excludes
+/// system ports (<10000) — matching the historical hardcoded behavior — so a
+/// brand-new / never-customized group never auto-assigns 22/80/443 etc.
+const DEFAULT_AUTO_PORT_LO: u16 = 10000;
+const DEFAULT_AUTO_PORT_HI: u16 = 65535;
+
+/// Resolve a group's stored `port_range` string into the inclusive `[lo, hi]`
+/// pool that auto-assignment draws from.
+///
+/// * empty / `"1-65535"` (the schema default, i.e. "全可转发" — nobody narrowed
+///   it) / unparseable → the default 10000-65535 pool (never system ports);
+/// * an explicit `"start-end"` with `1 <= start <= end <= 65535` → used
+///   verbatim, INCLUDING sub-10000 ports when the admin asked for them
+///   (`"5000-65535"` really does hand out 5000-9999 — an explicit choice wins
+///   over the default-avoidance). Only the exact `1-65535` string is treated as
+///   the sentinel, so `2-65535` or `1-65534` are honored as narrowings.
+pub fn resolve_auto_port_range(raw: &str) -> (u16, u16) {
+    const DEFAULT: (u16, u16) = (DEFAULT_AUTO_PORT_LO, DEFAULT_AUTO_PORT_HI);
+    let s = raw.trim();
+    if s.is_empty() || s == "1-65535" {
+        return DEFAULT;
+    }
+    let Some((a, b)) = s.split_once('-') else {
+        return DEFAULT;
+    };
+    let (Ok(start), Ok(end)) = (a.trim().parse::<u32>(), b.trim().parse::<u32>()) else {
+        return DEFAULT;
+    };
+    if start < 1 || end > 65535 || start > end {
+        return DEFAULT;
+    }
+    (start as u16, end as u16)
+}
+
+/// A cheap, dependency-free pseudo-random offset in `[0, span)`, seeded from the
+/// wall clock so successive auto-assignments on the same group spread across the
+/// pool instead of clustering at its low end. `span` is always `>= 1`.
+fn pseudo_random_offset(span: u32) -> u32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    nanos % span
+}
+
+/// Auto-assign a free listen port from the rule's inbound group's configured
+/// `port_range`, scoped to that group and socket type.
+///
+/// v1.2.x: the search pool is the group's `port_range` (resolved via
+/// [`resolve_auto_port_range`]) instead of a hardcoded 10000-65535. When the
+/// pool is exhausted this returns an error naming the real range so the panel
+/// can tell the operator the range is full — it never silently spills outside
+/// the configured range.
 ///
 /// v0.4.11 PR4: port occupancy is per (device_group_in, port, socket type).
 /// We only need to avoid ports already used ON THIS GROUP that conflict with
@@ -149,6 +202,16 @@ pub async fn auto_assign_port(
 ) -> Result<u16, String> {
     let needs_tcp = matches!(protocol, "tcp" | "tcp_udp");
     let needs_udp = matches!(protocol, "udp" | "tcp_udp");
+
+    // The pool to draw from = this group's configured port_range, with the
+    // unset / "1-65535" sentinel mapped to the safe 10000-65535 default. A
+    // missing group (None) also falls back to the default pool.
+    let range_raw = db
+        .group_port_range(device_group_in)
+        .await
+        .map_err(|e| e.to_string())?
+        .unwrap_or_default();
+    let (lo, hi) = resolve_auto_port_range(&range_raw);
 
     // (port, protocol) pairs already in use on this group.
     let group_ports: Vec<(i32, String)> = db
@@ -172,22 +235,26 @@ pub async fn auto_assign_port(
         })
         .collect();
 
-    // Try pseudo-random ports in the 10000-65535 range
-    let mut rng = 10000u16;
-    for _ in 0..1000 {
-        let candidate = rng.wrapping_add(7919).wrapping_rem(55535) + 10000;
+    // Ring scan over [lo, hi] starting from a pseudo-random offset: visits every
+    // port in the pool exactly once, returning the first that doesn't conflict.
+    // The random start spreads assignments across the range rather than always
+    // taking the lowest free port. If every port is taken, the range is full.
+    let span = (hi as u32) - (lo as u32) + 1;
+    let start_offset = pseudo_random_offset(span);
+    for i in 0..span {
+        // lo + offset <= hi <= 65535, so the u16 cast never truncates.
+        let candidate = (lo as u32 + (start_offset + i) % span) as u16;
         if !used.contains(&candidate) {
             return Ok(candidate);
         }
-        rng = candidate;
     }
-    // Fallback: linear scan
-    for p in 10000u16..=65535 {
-        if !used.contains(&p) {
-            return Ok(p);
-        }
-    }
-    Err("No free port available in 10000-65535".into())
+    // Actionable, user-facing: this surfaces as a 400 (CreateRuleError::BadRequest)
+    // so the operator knows to widen the group's port range or free a rule —
+    // NOT a generic 500 "数据库错误".
+    Err(format!(
+        "设备组端口范围 {}-{} 已全部占用,请扩大该组端口范围或删除已有规则后重试",
+        lo, hi
+    ))
 }
 
 #[derive(Debug)]
@@ -425,7 +492,10 @@ pub async fn create_rule(
             Some(p) => p,
             None => match auto_assign_port(db, req.device_group_in, protocol_str).await {
                 Ok(p) => p,
-                Err(e) => break Err(DbError::Other(sqlx::Error::Configuration(e.into()))),
+                // A full/unassignable range is a client-fixable condition, not a
+                // DB fault — surface the actionable message as a 400, not a
+                // generic 500 "数据库错误".
+                Err(e) => return Err(CreateRuleError::BadRequest(e)),
             },
         };
         last_port = Some(port);
@@ -927,5 +997,49 @@ mod tests {
             enabled: true,
         }];
         assert!(normalize_rule_targets(Some(bad), "x", 1).is_err());
+    }
+
+    /// v1.2.x: the unset / "全可转发" sentinel and any garbage fall back to the
+    /// default 10000-65535 pool, so a never-customized group never auto-assigns
+    /// a system port.
+    #[test]
+    fn resolve_auto_port_range_sentinel_and_default() {
+        let def = (DEFAULT_AUTO_PORT_LO, DEFAULT_AUTO_PORT_HI);
+        assert_eq!(resolve_auto_port_range("1-65535"), def, "全可转发 sentinel");
+        assert_eq!(resolve_auto_port_range(""), def, "empty");
+        assert_eq!(resolve_auto_port_range("   "), def, "whitespace");
+        assert_eq!(resolve_auto_port_range("garbage"), def, "no dash");
+        assert_eq!(resolve_auto_port_range("10000"), def, "single number");
+        assert_eq!(resolve_auto_port_range("abc-def"), def, "non-numeric");
+        assert_eq!(resolve_auto_port_range("65000-100"), def, "start > end");
+        assert_eq!(resolve_auto_port_range("0-100"), def, "start < 1");
+        assert_eq!(resolve_auto_port_range("1-70000"), def, "end > 65535");
+    }
+
+    /// An explicit narrowing is honored verbatim — including sub-10000 ports the
+    /// admin deliberately opted into, and including exact-boundary narrowings
+    /// that are NOT the `1-65535` sentinel.
+    #[test]
+    fn resolve_auto_port_range_explicit_is_honored() {
+        assert_eq!(resolve_auto_port_range("65000-65100"), (65000, 65100));
+        // "5000-65535" is an explicit choice → really hands out 5000-9999.
+        assert_eq!(resolve_auto_port_range("5000-65535"), (5000, 65535));
+        // A one-off narrowing of either bound is NOT the sentinel.
+        assert_eq!(resolve_auto_port_range("2-65535"), (2, 65535));
+        assert_eq!(resolve_auto_port_range("1-65534"), (1, 65534));
+        // Single-port pool.
+        assert_eq!(resolve_auto_port_range("40000-40000"), (40000, 40000));
+        // Surrounding whitespace is trimmed on both the whole string and parts.
+        assert_eq!(resolve_auto_port_range("  5000 - 6000  "), (5000, 6000));
+    }
+
+    /// The ring-scan offset is always inside the pool span, so `lo + offset`
+    /// can never exceed `hi` (guards the u16 cast in auto_assign_port).
+    #[test]
+    fn pseudo_random_offset_within_span() {
+        for span in [1u32, 2, 101, 55536, 65535] {
+            let off = pseudo_random_offset(span);
+            assert!(off < span, "offset {} must be < span {}", off, span);
+        }
     }
 }


### PR DESCRIPTION
## 背景
两个生产问题反馈:
1. **UDP 场景域名只解析一次**:域名在规则下发/节点启动那一刻解析一次,之后 IP 变了也不重解析。DDNS 目标(WireGuard/游戏/DNS 转发)走 UDP 时,IP 变更后转发一直指向旧 IP,必须手动重启规则或节点。
2. **添加设备组设了端口范围(如 65000-65100),auto 建规则却分配出 2xxxx 端口** —— auto 分配完全无视设备组的 `port_range`。

## 修复

### 问题二(面板)auto 端口遵守 port_range
- `auto_assign_port` 之前硬编码 `10000-65535`,从不读 `port_range`(该字段一直纯写不读)。现读取该组 `port_range`,范围内环形扫描(随机起点、每端口恰好一次)分配,满了报错。
- 哨兵 `resolve_auto_port_range`:空/非法/精确 `1-65535`(全可转发默认)→ 回退 `10000-65535`(避开系统端口);显式范围(含 `5000-65535` 这类低端口)完全按管理员意图使用。
- 范围占满不再包成 500「数据库错误」,改走 **400** 可读提示「设备组端口范围 X-Y 已全部占用,请扩大…」。
- 新增轻量 repo 方法 `group_port_range(id)`(sqlite + pg)。
- 手动端口、冲突检测、前端默认显示 `10000-65535` 均已满足,未改。

### 问题一(节点)UDP 域名按会话重解析
- `serve_udp_listener` 改为新会话经共享 30s DNS 缓存 `resolve_cached` 惰性解析(与 TCP 一致),删除启动时一次性解析。
- DDNS 换 IP 后新会话 ≤30s 跟上,旧会话 60s 空闲超时后自然切换,无需重启。顺带消除了"启动时暂时解析失败→监听任务立即结束→被拉起→再结束"的重启循环。

## 验证
- panel **402** + node **94+4** 测试全过;两 crate `clippy -D warnings` 干净。
- 新增单测:`resolve_auto_port_range` 哨兵/显式、`pseudo_random_offset`、`select_udp_target`(failover/轮询/跳过不可解析/空)。
- 新增真 sqlite 集成测试:范围内/哨兵回退/满了报错(协议隔离)/缺组回退。
- **本地起后端 HTTP 实测**(问题二):自定义 65000-65100 全落范围内;哨兵 1-65535 全 ≥10000;50000-50000 占满后 c2 返回干净 400,udp 仍复用 50000。

## 不含
- 版本号 bump / changelog / 发布 —— 按攒批流程,后续统一处理。
- WS/TLS 传输的出站加固缺口(keepalive/nodelay/源绑定)—— 已知,本轮不处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)