### PR TITLE
release: v1.1.2 + node-v1.1.2(双轨版本 bump)

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,6 +11,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.1.2] - 2026-07-12
+
+### Fixed
+
+- **UDP forwarding now follows DDNS target IP changes.** A UDP rule's domain
+  target was resolved ONCE when the listener started (rule push / node boot) and
+  the resolved IP was reused forever — so a DDNS target (WireGuard, game relay,
+  DNS forwarding) that changed IP kept getting blackholed to the stale address
+  until the rule or node was manually restarted. New UDP sessions now resolve
+  through the shared 30s DNS cache (same as TCP), so an IP change is picked up
+  within the cache TTL; established sessions age out on the 60s idle timeout and
+  the next datagram opens a fresh session against the current IP. This also
+  removes the old "unresolvable-at-boot kills the listener → restart loop"
+  behavior — a transient DNS failure no longer tears down the UDP listener.
+
 ## [1.1.1] - 2026-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.1.2] - 2026-07-12
+
+### Fixed
+
+- **Auto-assigned listen ports now respect the device group's `port_range`.**
+  When a rule was created with the port left on `auto`, the panel ignored the
+  inbound group's configured `port_range` entirely and always drew from a
+  hardcoded 10000-65535 — so a group set to e.g. `65000-65100` still handed out
+  2xxxx ports. Auto-assignment now draws from the group's `port_range`: an
+  explicit range is honored verbatim (including sub-10000 ports the admin opted
+  into), while the unset/default `1-65535` sentinel maps to the safe 10000-65535
+  pool so a never-customized group never auto-assigns a system port. Manual port
+  entry, per-group/per-socket-type conflict detection, and the frontend's
+  `10000-65535` default display are unchanged.
+- **A full port range now returns a clear error instead of "数据库错误".** When
+  every port in a group's range is taken, rule creation returns a 400 naming the
+  exhausted range (`设备组端口范围 X-Y 已全部占用…`) rather than a generic 500.
+
 ## [1.1.1] - 2026-07-08
 
 ### Changed — panel & node now release on independent tracks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.1.1";
+const COMPILED_APP_VERSION: &str = "1.1.2";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.1}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.2}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -57,7 +57,7 @@ services:
     # v1.2: the node image tag is INDEPENDENT of the panel tag. Override
     # RELAYPANEL_NODE_TAG in .env to pin a node version that differs from the
     # panel version.
-    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.1.1}
+    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.1.2}
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.1.1"
+SCRIPT_VERSION="1.1.2"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
两轨一起发 **1.1.2**,发布 #59 已合入 main 的两个生产修复。

## 内容
- **面板(v1.1.2)**:auto 端口遵守设备组 `port_range`;范围占满改为可读的 400 提示(不再 500「数据库错误」)。
- **节点(node-v1.1.2)**:UDP 域名按会话重解析,跟随 DDNS —— WireGuard / 游戏中转 / DNS 转发的目标换 IP 后不再需要手动重启规则或节点。

## 版本同步位置
`crates/panel/Cargo.toml`、`crates/node/Cargo.toml`、`crates/panel/src/config.rs`(`COMPILED_APP_VERSION`)、`scripts/relay-node-install.sh`(`SCRIPT_VERSION`)、`docker-compose.release.yaml`(两个镜像 tag 默认值)、`Cargo.lock`、`CHANGELOG.md`(panel)、`CHANGELOG-NODE.md`(node)。

## 预检
- `release-check panel 1.1.2`:78 OK / 8 WARN / **0 FAIL**
- `release-check node 1.1.2`:77 OK / 8 WARN / **0 FAIL**
- 8 个 WARN 均为常规项(shared crate 0.1.0 不参与发布同步、README 文案精简提示)。

## 发布顺序(合并后)
1. 先打 `node-v1.1.2` → 走完 node-release 完整流程(draft → verify → promote-latest → publish)。
2. 再打 `v1.1.2` → panel docker-release。
3. 本次**无需桥接**(≤1.1.0 旧节点已在 1.1.1 桥接过,现均为 node-v* 方案)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)