### PR TITLE
release: v1.1.3 (panel) — install_method 修复 + 面板 arm64 + README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.1.3] - 2026-07-16
+
+### Fixed
+
+- **systemd-managed nodes are no longer wrongly shown as "手动运行" (manual) in
+  node status, and their one-click upgrade button now appears.** The node
+  correctly reported its `install_method` ("systemd" | "docker" | "manual"), but
+  the panel's status-report handler dropped the field when persisting the node
+  status, so the frontend always saw it as unset and resolved every node to the
+  "manual" upgrade state — showing "手动运行：不支持一键升级（退出后无人拉起）"
+  and hiding the upgrade action on legitimately systemd-managed nodes. The panel
+  now persists `install_method`; no node re-install is needed — an already
+  running node surfaces the correct state on its next status report.
+
+### Changed
+
+- **The panel Docker image is now multi-arch (`linux/amd64` + `linux/arm64`).**
+  ARM64 servers can pull and run the panel image directly. Each architecture is
+  compiled natively on its own GitHub-hosted runner (no QEMU / cross-toolchain);
+  the two per-arch images are merged into one manifest and the release verifies
+  both architectures are present. Node binaries already supported amd64/arm64.
+
 ## [1.1.2] - 2026-07-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/README.en.md
+++ b/README.en.md
@@ -72,7 +72,7 @@ curl -fsSL https://raw.githubusercontent.com/MoeShinX/relay-panel/main/install.s
 
 > 🔑 **Default login `admin` / `admin123` — first login forces a password change.**
 
-> 🖥️ **Platform**: the panel image is currently **amd64-only** (arm hosts not yet supported — multi-arch is planned); the **node supports amd64 / arm64**, and its install script auto-detects the arch via `uname -m` — no manual selection needed.
+> 🖥️ **Platform**: both the panel image and the node support **amd64 / arm64**, so ARM servers can deploy directly. The panel image is a multi-arch manifest (`docker pull` picks the right arch automatically) and the node install script auto-detects the arch via `uname -m` — no manual selection needed.
 
 📖 Full guide: **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)**
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ curl -fsSL https://raw.githubusercontent.com/MoeShinX/relay-panel/main/install.s
 
 > 🔑 **默认账号 `admin` / `admin123`，首次登录强制修改密码。**
 
-> 🖥️ **平台支持**：面板镜像目前仅 **amd64**，arm 主机暂不支持（多架构后续跟进）；**节点支持 amd64 / arm64**，安装脚本 `uname -m` 自动适配，无需手动指定。
+> 🖥️ **平台支持**：面板镜像与节点均支持 **amd64 / arm64**，ARM 服务器可直接部署；面板镜像为多架构 manifest，`docker pull` 自动选对架构，节点安装脚本 `uname -m` 自动适配，均无需手动指定。
 
 📖 完整指南：**[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)**
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.1.2";
+const COMPILED_APP_VERSION: &str = "1.1.3";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.2}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.3}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)


### PR DESCRIPTION
## v1.1.3(面板)

打包两个已合并到 main 的改动 + 版本号提升 + README 平台说明更新。

### 内容

- **fix(nodes) (#62)**：面板此前丢弃了节点上报的 `install_method`，导致所有 systemd 节点在节点状态里被误判为"手动运行"、隐藏一键升级按钮。已修复并持久化该字段。**节点无需重装**——面板升级后节点下次心跳即恢复正常。
- **feat(panel) (#63)**：面板 Docker 镜像改为多架构 manifest（`linux/amd64` + `linux/arm64`），ARM 服务器可直接部署面板。各架构在各自原生 runner 上编译（无 QEMU / 交叉工具链），发布时验证两架构均存在。
- **README**：更新平台支持说明（面板镜像现为多架构，不再是"仅 amd64"）。

### 版本号（panel 轨道，1.1.2 → 1.1.3）

`crates/panel/Cargo.toml` / `config.rs` `COMPILED_APP_VERSION` / `docker-compose.release.yaml` 面板 tag / `CHANGELOG.md` / `Cargo.lock`。**node 轨道不动**（仍 1.1.2）。

### DB 变化

无（node status 存 kvs JSON blob，非 SQL schema）。

### 兼容性风险

- 纯面板发布，node 镜像 / node 二进制 / `relay-panel-node:latest` 均不受影响。
- SQLite / PostgreSQL 一致（本次不触及 repo 层）。

### 测试结果

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ 无告警
- `cargo test --workspace` ✅ node 94 / cli 4 / panel 407 / shared 16，全 0 failed
- 前端 `typecheck` / `lint` / `test`(159) / `build` ✅
- `scripts/release-check.sh panel 1.1.3` ✅ 78 OK / 8 WARN / **0 FAIL**（WARN 均为非阻断的 README 措辞项）

### 未决项 / 发布后

- 合并 main 后，**打 `v1.1.3` tag** 才会触发 docker-release.yml 构建多架构镜像 + 建 GitHub Release。
- ⚠️ **arm64 多架构编译只有打 tag 时才真正跑**（PR CI 不含 Docker Release workflow）。发布后需确认 docker-release 的 `build-and-push`(amd64 + arm64 两腿)与 `verify`(manifest 含双架构)全绿。
