### PR TITLE
feat(node): enforce per-rule connection cap + handle restart_rule

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,6 +11,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`restart_rule` control message.** The panel can ask the node to drop one
+  rule's connections and rebuild its listeners. The node re-creates listeners
+  from its OWN cached config (`ForwarderManager::last_config`), never from
+  anything in the message, so a restart cannot be used to inject listener
+  config. `node_id` is re-checked on arrival as defence in depth even though
+  `send_node` already routed it.
+
+  The WS dispatch arm for this MUST stay above the diagnose arm and MUST check
+  `type`: `DiagnoseRuleMessage` defaults its `challenge` field and ignores
+  unknown fields, so a `restart_rule` payload deserializes into it cleanly
+  (`rule_id` + `request_id` are both present). Ordered after diagnose, every
+  restart would silently become a target probe instead. A test in
+  `relay-shared` pins the ambiguity.
+
+- **Per-rule concurrent TCP connection cap** (`ListenerConfig.max_connections`,
+  None = unlimited). Admission happens in the accept loop, not in the spawned
+  connection task: the accept loop is sequential, so check-then-increment there
+  is exact, whereas incrementing inside the task would let an unbounded number
+  of accepts through before the first increment landed — precisely the
+  connection-flood case the cap exists for. Over the cap, the socket is dropped
+  immediately (the "at cap" warning is rate-limited to once per 60s per
+  listener; a rule sitting at its cap rejects on every accept, and an
+  unthrottled warn would itself become the outage).
+
+  The counter lives per RULE, not per listener: a dual-stack rule runs two
+  accept loops (IPv4 + IPv6), and a per-listener counter would silently grant
+  double the configured cap.
+
+### Fixed
+
+- **Aborting a listener no longer leaves its connections forwarding.**
+  Connections run on detached `tokio::spawn` tasks, so an aborted accept loop
+  stopped new accepts while every established connection kept relaying —
+  verified: a post-abort read/write round-trips fine. Connections now select on
+  a per-rule cancellation channel (`forwarder::gate`). Consequences:
+  - an explicit `restart_rule` genuinely sheds connections rather than just
+    re-binding the port;
+  - a rule removed from the node's config now stops forwarding, instead of
+    relaying bytes for a rule whose traffic counters `apply_config` already
+    pruned.
+
+  `apply_config`'s fingerprint-driven restart (changed targets / rate caps) does
+  NOT cancel: editing a rule must not kick everyone off, which has been the
+  behaviour since v0.3.6.
+
+### Compatibility
+
+- Requires panel **1.2.0+** to be sent `restart_rule` or a connection cap. Both
+  additions are backward compatible on the wire (`#[serde(default)]`), so a
+  1.2.0 node runs against an older panel unchanged — it simply never receives
+  either.
+
 ## [1.1.2] - 2026-07-12
 
 ### Fixed

--- a/crates/node/src/forwarder/gate.rs
+++ b/crates/node/src/forwarder/gate.rs
@@ -1,0 +1,271 @@
+//! v1.2.0: per-rule runtime controls — the concurrent-connection cap and the
+//! restart cancellation channel.
+//!
+//! ## Why this state lives per RULE, not per listener
+//!
+//! A single TCP rule binds up to TWO listeners (IPv4 and IPv6, see the
+//! `(Protocol::Tcp, NodeTransport::Raw)` arm in `manager::apply_config`). If the
+//! live-connection counter were owned by a listener, a dual-stack rule would
+//! admit `max_connections` on v4 PLUS `max_connections` on v6 — silently double
+//! the configured cap. The counter therefore hangs off the rule and both
+//! listeners share one `Arc`, exactly like the rule's rate limiter.
+//!
+//! ## Why a cancellation channel is needed at all
+//!
+//! Each accepted connection is driven by a DETACHED `tokio::spawn` task.
+//! Aborting the accept-loop task does NOT cascade to those children: the
+//! listener stops accepting, but every established connection keeps forwarding
+//! (verified empirically — a post-abort read/write round-trips fine). So
+//! "restart a rule" cannot be implemented as abort-and-rebind; that would only
+//! re-bind the port and shed nothing, which is the entire point of the feature.
+//!
+//! Instead every connection task selects on `RuleGate::cancel`. Bumping the
+//! generation via `RuleRuntime::cancel_all` wakes them all, they drop their
+//! sockets, and the peers see the connection close.
+//!
+//! ## Why cancellation is NOT wired into `apply_config`
+//!
+//! A fingerprint change (new targets, new rate cap) tears the listener down and
+//! rebuilds it, but deliberately leaves live connections alone — that has been
+//! the behaviour since v0.3.6 and users rely on editing a rule without kicking
+//! everyone off. Only an EXPLICIT restart cancels. The two paths are separate on
+//! purpose: `apply_config` never touches the generation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// The half of a rule's runtime state handed to its listeners. Cheap to clone;
+/// a rule's v4 and v6 listeners each hold one and they share the same counter
+/// and cancellation channel.
+#[derive(Clone)]
+pub struct RuleGate {
+    /// Concurrent TCP connections allowed for this rule ON THIS NODE. `None` =
+    /// unlimited (the default, and every pre-v1.2 rule after migration).
+    pub max_connections: Option<u32>,
+    /// Live TCP connections for this rule right now. Incremented by
+    /// [`RuleGate::admit`], decremented when the returned guard drops.
+    live: Arc<AtomicU64>,
+    /// Restart signal. The value is a generation counter; any change means
+    /// "drop the connection you are driving".
+    cancel: watch::Receiver<u64>,
+}
+
+impl RuleGate {
+    /// Try to admit one new connection.
+    ///
+    /// Returns `None` when the rule is at its cap — the caller must drop the
+    /// accepted socket immediately. Returns a guard otherwise; hold it for the
+    /// connection's lifetime, and the count decrements however the task ends
+    /// (clean close, error, panic, or restart cancellation).
+    ///
+    /// MUST be called from the accept loop rather than from inside the spawned
+    /// connection task. The accept loop is sequential, so check-then-increment
+    /// here is atomic with respect to other accepts on the same listener; doing
+    /// it inside the task would let an unbounded number of accepts slip through
+    /// before the first increment lands — precisely the connection-flood case
+    /// this cap exists for. (The v4 and v6 accept loops do race each other, but
+    /// `fetch_add`-then-compare below makes the counter exact regardless.)
+    pub fn admit(&self) -> Option<ConnGuard> {
+        let guard = ConnGuard {
+            live: self.live.clone(),
+        };
+        // Increment FIRST, then compare, so two accept loops (v4 + v6) racing on
+        // the same rule can never both observe "one slot left" and both take it.
+        // The guard is already constructed, so an over-cap increment is undone
+        // by dropping it on the reject path.
+        let now = self.live.fetch_add(1, Ordering::AcqRel) + 1;
+        match self.max_connections {
+            Some(cap) if now > cap as u64 => None, // `guard` drops → decrements
+            _ => Some(guard),
+        }
+    }
+
+    /// Live connection count for this rule on this node.
+    pub fn live(&self) -> u64 {
+        self.live.load(Ordering::Relaxed)
+    }
+
+    /// Resolves when this rule is restarted. Connection tasks select on it and
+    /// drop their sockets when it fires.
+    ///
+    /// Also resolves if the sender is gone (the rule was deleted from the
+    /// node's config), which is the right outcome: a deleted rule's traffic can
+    /// no longer be attributed or billed, so its connections must not outlive
+    /// it.
+    pub async fn cancelled(&mut self) {
+        // `changed()` errors only when the sender dropped; treat that as a
+        // cancel rather than parking forever on a dead channel.
+        let _ = self.cancel.changed().await;
+    }
+}
+
+/// A rule's runtime state as the manager owns it. Dropping this cancels every
+/// connection task belonging to the rule (the `watch::Sender` goes away and each
+/// task's `cancelled()` resolves).
+pub struct RuleRuntime {
+    live: Arc<AtomicU64>,
+    cancel: watch::Sender<u64>,
+}
+
+impl RuleRuntime {
+    pub fn new() -> Self {
+        let (cancel, _) = watch::channel(0);
+        Self {
+            live: Arc::new(AtomicU64::new(0)),
+            cancel,
+        }
+    }
+
+    /// Build the listener-side handle. `max_connections` is passed per-spawn
+    /// rather than stored, because it comes from the config being applied and
+    /// changing it restarts the listener anyway (it is part of the fingerprint).
+    pub fn gate(&self, max_connections: Option<u32>) -> RuleGate {
+        RuleGate {
+            max_connections,
+            live: self.live.clone(),
+            cancel: self.cancel.subscribe(),
+        }
+    }
+
+    /// Drop every in-flight connection of this rule. Returns the number of
+    /// connections that were live at the moment of cancellation — they tear
+    /// down asynchronously, so the counter drains shortly after this returns
+    /// rather than being 0 immediately.
+    pub fn cancel_all(&self) -> u64 {
+        let live = self.live.load(Ordering::Relaxed);
+        // send_modify notifies every receiver even with no listeners attached,
+        // and bumping the generation guarantees a value CHANGE (send_if_modified
+        // with an equal value would not wake anyone).
+        self.cancel.send_modify(|generation| *generation += 1);
+        live
+    }
+}
+
+impl Default for RuleRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII: decrements the rule's live-connection count when the connection task
+/// ends, however it ends.
+pub struct ConnGuard {
+    live: Arc<AtomicU64>,
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.live.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The cap admits exactly `max_connections` and rejects the next one; a
+    /// closed connection frees its slot.
+    #[test]
+    fn admit_enforces_cap_and_guard_frees_slot() {
+        let rt = RuleRuntime::new();
+        let gate = rt.gate(Some(2));
+
+        let g1 = gate.admit().expect("1st under cap");
+        let g2 = gate.admit().expect("2nd hits cap exactly, still admitted");
+        assert_eq!(gate.live(), 2);
+
+        assert!(gate.admit().is_none(), "3rd must be rejected at cap 2");
+        // The rejected admit must NOT leak a slot — the count is still 2, not 3.
+        assert_eq!(
+            gate.live(),
+            2,
+            "a rejected admit must not inflate the count"
+        );
+
+        drop(g1);
+        assert_eq!(gate.live(), 1);
+        let _g3 = gate.admit().expect("slot freed by the closed connection");
+        assert_eq!(gate.live(), 2);
+        drop(g2);
+    }
+
+    /// `None` = unlimited. This is the migration default for every existing
+    /// rule, so getting it wrong would cap the whole fleet at zero on upgrade.
+    #[test]
+    fn no_cap_admits_freely() {
+        let rt = RuleRuntime::new();
+        let gate = rt.gate(None);
+        let guards: Vec<_> = (0..1000)
+            .map(|_| gate.admit().expect("unlimited"))
+            .collect();
+        assert_eq!(gate.live(), 1000);
+        drop(guards);
+        assert_eq!(gate.live(), 0);
+    }
+
+    /// The v4 and v6 listeners of one rule share a counter, so a dual-stack
+    /// rule admits `max_connections` IN TOTAL — not that many per family.
+    #[test]
+    fn dual_stack_listeners_share_one_budget() {
+        let rt = RuleRuntime::new();
+        let v4 = rt.gate(Some(3));
+        let v6 = rt.gate(Some(3));
+
+        let _a = v4.admit().expect("v4 #1");
+        let _b = v6.admit().expect("v6 #1");
+        let _c = v4.admit().expect("v4 #2 — 3 total");
+        assert!(
+            v6.admit().is_none(),
+            "the 4th connection must be rejected regardless of family"
+        );
+        assert_eq!(v4.live(), 3);
+    }
+
+    /// cancel_all wakes a task parked on `cancelled()`. This is what makes a
+    /// restart actually shed connections instead of only rebinding the port.
+    #[tokio::test]
+    async fn cancel_all_wakes_connection_tasks() {
+        let rt = RuleRuntime::new();
+        let mut gate = rt.gate(None);
+        let _g = gate.admit().unwrap();
+
+        let waiter = tokio::spawn(async move {
+            gate.cancelled().await;
+            "cancelled"
+        });
+
+        // Nothing has cancelled yet — the task must still be parked.
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished(), "must not fire before cancel_all");
+
+        assert_eq!(rt.cancel_all(), 1, "reports the connections it is dropping");
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("cancelled() must resolve promptly")
+                .unwrap(),
+            "cancelled"
+        );
+    }
+
+    /// A deleted rule (manager drops its RuleRuntime) must also drop its
+    /// connections, not leave them forwarding for a rule that no longer exists.
+    #[tokio::test]
+    async fn dropping_runtime_cancels_connections() {
+        let rt = RuleRuntime::new();
+        let mut gate = rt.gate(None);
+
+        let waiter = tokio::spawn(async move {
+            gate.cancelled().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(rt);
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("a dropped RuleRuntime must cancel its connections")
+            .unwrap();
+    }
+}

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -1,3 +1,4 @@
+use super::gate::RuleRuntime;
 use super::limiter::RateLimit;
 use super::selector::TargetSelector;
 use super::tcp;
@@ -63,6 +64,15 @@ struct ListenerFingerprint {
     /// takes effect without a node restart.
     upload_limit_bps: Option<u64>,
     download_limit_bps: Option<u64>,
+    /// v1.2.0: concurrent-connection cap (None = unlimited). The accept loop
+    /// captures this when it spawns, so a change must restart the listener for
+    /// the new cap to apply — same reasoning as the rate caps above.
+    ///
+    /// Note this restart does NOT drop live connections (only an explicit
+    /// `restart_rule` does that), so editing the cap on a busy rule is safe:
+    /// existing connections keep running and the new cap governs admissions
+    /// from that point on. A lowered cap takes effect by attrition.
+    max_connections: Option<u32>,
 }
 
 impl ListenerFingerprint {
@@ -75,6 +85,7 @@ impl ListenerFingerprint {
             node_transport: l.node_transport,
             upload_limit_bps: l.upload_limit_bps,
             download_limit_bps: l.download_limit_bps,
+            max_connections: l.max_connections,
         }
     }
 }
@@ -98,6 +109,20 @@ pub struct ListenerInfo {
 
 pub struct ForwarderManager {
     listeners: HashMap<ListenerKey, ManagedListener>,
+    /// v1.2.0: per-rule runtime state (live-connection counter + restart
+    /// cancellation), keyed by rule_id. Lives HERE rather than in the listener
+    /// because a rule's IPv4 and IPv6 listeners must share one connection
+    /// budget, and because it has to survive the listener being torn down and
+    /// rebuilt by `apply_config` (a config edit must not reset the count while
+    /// the connections it counted are still alive). Entries are dropped when the
+    /// rule leaves the config, which cancels its connections — see `gate.rs`.
+    rule_runtime: HashMap<i64, RuleRuntime>,
+    /// v1.2.0: the most recent config, kept so `restart_rule` can rebuild a
+    /// rule's listeners without asking the panel for the config again. A restart
+    /// must be able to run while the control channel is busy, and re-fetching
+    /// would also let a config change ride in on what the operator asked to be a
+    /// pure restart.
+    last_config: Option<NodeConfigResponse>,
     counter: Arc<TrafficCounter>,
     connections: Arc<ConnectionTracker>,
     /// Bind/runtime errors captured from spawned listener tasks since the last
@@ -118,6 +143,8 @@ impl ForwarderManager {
     pub fn new(counter: Arc<TrafficCounter>, connections: Arc<ConnectionTracker>) -> Self {
         Self {
             listeners: HashMap::new(),
+            rule_runtime: HashMap::new(),
+            last_config: None,
             counter,
             connections,
             listener_errors: Arc::new(Mutex::new(Vec::new())),
@@ -474,6 +501,15 @@ impl ForwarderManager {
                     let cn = connections.clone();
                     let rid = rule_id;
                     let ipv4_src = src_ipv4;
+                    // v1.2.0: both families get a gate cloned from the SAME
+                    // RuleRuntime, so `max_connections` is a per-rule total
+                    // rather than a per-family allowance.
+                    let gate4 = self
+                        .rule_runtime
+                        .entry(rule_id)
+                        .or_default()
+                        .gate(listener.max_connections);
+                    let gate6 = gate4.clone();
                     tokio::spawn(async move {
                         type SrvResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
                         let (tgt4, sel4, rl4, ctr4, cn4) = (
@@ -486,7 +522,7 @@ impl ForwarderManager {
                         let v4_fut = async move {
                             if let Some(l) = v4_listener {
                                 tcp::serve_tcp_listener(
-                                    l, tgt4, sel4, rl4, ctr4, cn4, rid, ipv4_src,
+                                    l, tgt4, sel4, rl4, ctr4, cn4, rid, ipv4_src, gate4,
                                 )
                                 .await
                             } else {
@@ -495,8 +531,10 @@ impl ForwarderManager {
                         };
                         let v6_fut = async move {
                             if let Some(l) = v6_listener {
-                                tcp::serve_tcp_listener(l, tgt, sel, rl, ctr, cn, rid, ipv4_src)
-                                    .await
+                                tcp::serve_tcp_listener(
+                                    l, tgt, sel, rl, ctr, cn, rid, ipv4_src, gate6,
+                                )
+                                .await
                             } else {
                                 std::future::pending::<SrvResult>().await
                             }
@@ -695,6 +733,93 @@ impl ForwarderManager {
                 },
             );
         }
+
+        // ── Step 5: forget rules that are gone ──
+        // v1.2.0: dropping a rule's RuleRuntime drops its watch::Sender, which
+        // cancels any connection still forwarding for it. That is deliberate: a
+        // rule removed from the config can no longer have its traffic attributed
+        // or billed (step 2/3 already pruned its counters), so letting its
+        // connections outlive it would forward bytes nobody accounts for.
+        self.rule_runtime
+            .retain(|rule_id, _| desired_rule_ids.contains(rule_id));
+
+        // v1.2.0: remember the applied config so restart_rule can rebuild a
+        // rule's listeners from it without a round-trip to the panel.
+        self.last_config = Some(config.clone());
+    }
+
+    /// v1.2.0: restart ONE rule — drop every connection it is currently
+    /// forwarding, then rebuild its listeners from the last applied config.
+    ///
+    /// Returns `(connections_dropped, listeners_restarted)`. A rule with no
+    /// listeners on this node returns `(0, 0)`; the caller reports that as
+    /// "nothing to do here" rather than an error, because a rule legitimately
+    /// spans only some of a group's nodes.
+    ///
+    /// Order matters. Connections are cancelled BEFORE the listeners are torn
+    /// down and rebuilt: the connection tasks are detached, so tearing the
+    /// listener down first would rebind the port while the old connections kept
+    /// forwarding — the exact no-op this command exists to avoid.
+    ///
+    /// The rule's `paused` state is never consulted or written here. A restart
+    /// is not a state transition: it re-creates whatever the current config
+    /// says should be running. If the panel has paused the rule, the config
+    /// carries no listener for it and this is a no-op.
+    pub async fn restart_rule(&mut self, rule_id: i64) -> (u64, usize) {
+        // Cancel first — see the ordering note above.
+        let dropped = match self.rule_runtime.get(&rule_id) {
+            Some(rt) => rt.cancel_all(),
+            // No runtime → the rule has never had a listener here. Nothing to
+            // restart; don't fabricate an empty runtime for it.
+            None => return (0, 0),
+        };
+
+        let keys: Vec<ListenerKey> = self
+            .listeners
+            .iter()
+            .filter(|(_, m)| m.fingerprint.rule_id == rule_id)
+            .map(|(k, _)| *k)
+            .collect();
+
+        for key in &keys {
+            if let Some(m) = self.listeners.remove(key) {
+                let handle = m.handle;
+                handle.abort();
+                // Await the aborted task so the OS releases the listen socket
+                // before the rebuild re-binds the same port — without this the
+                // bind races teardown and fails with "address already in use".
+                // (Same reason as the equivalent await in apply_config.)
+                let _ = (&mut { handle }).await;
+            }
+        }
+
+        let restarted = keys.len();
+        if restarted > 0 {
+            // Rebuild from the cached config. apply_config re-creates exactly
+            // the listeners we just removed (every other listener still matches
+            // its fingerprint and is skipped), and it reuses this rule's
+            // existing RuleRuntime, so the live counter stays consistent with
+            // the connections that survive — there are none, we just cancelled
+            // them all.
+            if let Some(cfg) = self.last_config.clone() {
+                self.apply_config(&cfg).await;
+            } else {
+                tracing::warn!(
+                    "rule {}: restart tore down {} listener(s) but no cached config exists \
+                     to rebuild from; the next config push will restore them",
+                    rule_id,
+                    restarted
+                );
+            }
+        }
+
+        tracing::info!(
+            "rule {}: restarted — dropped {} connection(s), rebuilt {} listener(s)",
+            rule_id,
+            dropped,
+            restarted
+        );
+        (dropped, restarted)
     }
 }
 
@@ -704,6 +829,7 @@ mod tests {
     use crate::reporter::{ConnectionTracker, TrafficCounter};
     use relay_shared::protocol::{ListenerConfig, NodeConfigResponse, NodeTransport, Protocol};
     use std::sync::Arc;
+    use std::time::Duration;
 
     impl ForwarderManager {
         /// Test-only accessor: the set of listener keys currently registered.
@@ -791,6 +917,169 @@ mod tests {
         let down_limited = ListenerFingerprint::from_listener(&l);
         assert_ne!(up_limited, down_limited);
         assert_ne!(unlimited, down_limited);
+    }
+
+    /// v1.2.0: a connection-cap change must restart the listener, for the same
+    /// reason a rate-limit change must — the accept loop captures the cap when
+    /// it spawns.
+    #[test]
+    fn max_connections_change_alters_fingerprint() {
+        let mut l = one_rule(40051, Protocol::Tcp, NodeTransport::Raw)
+            .listeners
+            .pop()
+            .unwrap();
+        let uncapped = ListenerFingerprint::from_listener(&l);
+
+        l.max_connections = Some(100);
+        let capped = ListenerFingerprint::from_listener(&l);
+        assert_ne!(
+            uncapped, capped,
+            "setting a connection cap must change the fingerprint"
+        );
+
+        l.max_connections = Some(200);
+        assert_ne!(
+            capped,
+            ListenerFingerprint::from_listener(&l),
+            "raising the cap must also change the fingerprint"
+        );
+    }
+
+    /// Spawn an echo server and return its address. Used by the restart tests to
+    /// prove a forwarded connection is really carrying data.
+    async fn echo_target() -> SocketAddr {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = l.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut s, _)) = l.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut b = [0u8; 256];
+                    loop {
+                        match s.read(&mut b).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => {
+                                if s.write_all(&b[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    /// THE test for the restart feature: a live connection must actually be
+    /// dropped, and the listener must come back up.
+    ///
+    /// This is not a formality. Connection tasks are detached `tokio::spawn`s,
+    /// so the intuitive implementation (abort the listener, re-bind) leaves
+    /// every established connection forwarding — the port gets rebound and not
+    /// one connection is shed, which is the whole point of the feature. If this
+    /// test regresses to "connection still alive", the restart is a placebo.
+    #[tokio::test]
+    async fn restart_rule_drops_live_connections_and_rebuilds_listener() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let target = echo_target().await;
+        let mut mgr = fresh_mgr();
+        mgr.listen_ipv6 = String::new(); // IPv4-only keeps the assertions simple.
+        let port = 40561;
+        let c = cfg(
+            port,
+            Protocol::Tcp,
+            NodeTransport::Raw,
+            vec![&target.to_string()],
+            None,
+        );
+        mgr.apply_config(&c).await;
+
+        // Establish a connection and prove it forwards.
+        let mut client = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("listener must be up");
+        client.write_all(b"before").await.unwrap();
+        let mut buf = [0u8; 64];
+        let n = client.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"before", "the rule must forward before restart");
+
+        let (dropped, restarted) = mgr.restart_rule(1).await;
+        assert_eq!(dropped, 1, "the one live connection must be counted");
+        assert_eq!(restarted, 1, "the rule's single TCP listener must rebuild");
+
+        // The OLD connection must now be dead. Read returns EOF (or errors) —
+        // anything that echoes here means the restart shed nothing.
+        let r = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf)).await;
+        match r {
+            Ok(Ok(0)) | Ok(Err(_)) => {}
+            Ok(Ok(n)) => panic!(
+                "restart did NOT drop the connection — it echoed {:?}",
+                String::from_utf8_lossy(&buf[..n])
+            ),
+            Err(_) => panic!("restart did NOT drop the connection — the read is still hanging"),
+        }
+
+        // ...and the listener must be serving again, on the same port.
+        let mut fresh = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("listener must be re-bound after restart");
+        fresh.write_all(b"after").await.unwrap();
+        let n = fresh.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"after", "the rebuilt listener must forward");
+    }
+
+    /// Restarting a rule this node doesn't serve is a no-op, not a panic or a
+    /// fabricated runtime entry — a rule legitimately spans only some nodes.
+    #[tokio::test]
+    async fn restart_unknown_rule_is_a_noop() {
+        let mut mgr = fresh_mgr();
+        assert_eq!(mgr.restart_rule(999).await, (0, 0));
+        assert!(
+            mgr.rule_runtime.is_empty(),
+            "must not create runtime state for a rule that isn't here"
+        );
+    }
+
+    /// The cap must survive an unrelated config push. apply_config rebuilds its
+    /// local limiter map each run; if the connection counter were rebuilt the
+    /// same way, every config edit would reset the count to 0 while the counted
+    /// connections were still alive, and the cap would over-admit.
+    #[tokio::test]
+    async fn rule_runtime_survives_apply_and_is_dropped_with_the_rule() {
+        let mut mgr = fresh_mgr();
+        mgr.listen_ipv6 = String::new();
+        let c = cfg(
+            40562,
+            Protocol::Tcp,
+            NodeTransport::Raw,
+            vec!["127.0.0.1:1"],
+            None,
+        );
+        mgr.apply_config(&c).await;
+        assert!(
+            mgr.rule_runtime.contains_key(&1),
+            "runtime created on apply"
+        );
+
+        // Re-applying the identical config must not disturb the runtime.
+        mgr.apply_config(&c).await;
+        assert!(
+            mgr.rule_runtime.contains_key(&1),
+            "an unchanged apply must keep the rule's runtime"
+        );
+
+        // Removing the rule drops its runtime (which cancels its connections).
+        mgr.apply_config(&NodeConfigResponse { listeners: vec![] })
+            .await;
+        assert!(
+            !mgr.rule_runtime.contains_key(&1),
+            "a removed rule must not leak its runtime"
+        );
     }
 
     #[tokio::test]
@@ -1217,6 +1506,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );
@@ -1276,6 +1566,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );
@@ -1291,6 +1582,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );
@@ -1329,6 +1621,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );

--- a/crates/node/src/forwarder/mod.rs
+++ b/crates/node/src/forwarder/mod.rs
@@ -1,4 +1,5 @@
 pub mod cert_reloader;
+pub mod gate;
 pub mod limiter;
 pub mod manager;
 pub mod outbound;

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -4,13 +4,24 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
+use super::gate::RuleGate;
 use super::limiter::RateLimit;
 use super::selector::TargetSelector;
 use crate::reporter::{ConnectionTracker, TrafficCounter};
 
+/// v1.2.0: how often the "rule is at its connection cap" warning may be logged
+/// per listener. A rule sitting at its cap rejects on EVERY accept, so an
+/// unthrottled warn! here would itself become the outage (disk + CPU) that the
+/// cap exists to prevent.
+const CAP_WARN_INTERVAL: Duration = Duration::from_secs(60);
+
 /// v1.0.4: serve an ALREADY-BOUND TcpListener. Binding happens in the manager
 /// (synchronously, so errors surface immediately and per-family success is
 /// known). This function only runs the accept loop.
+///
+/// v1.2.0: `gate` carries the rule's connection cap and its restart
+/// cancellation. It is cloned from the rule's `RuleRuntime`, so the rule's IPv4
+/// and IPv6 listeners share one connection budget and one cancel signal.
 #[allow(clippy::too_many_arguments)]
 pub async fn serve_tcp_listener(
     listener: TcpListener,
@@ -21,6 +32,7 @@ pub async fn serve_tcp_listener(
     connections: Arc<ConnectionTracker>,
     rule_id: i64,
     source_ipv4: Option<Ipv4Addr>,
+    gate: RuleGate,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let listen_addr = listener
         .local_addr()
@@ -32,9 +44,37 @@ pub async fn serve_tcp_listener(
     // whole listener task, leaving the port dead until node restart. Now we
     // classify the error: transient -> back off and retry; the listener stays
     // up. A non-transient error (e.g. the listener was closed) ends the task.
+    let mut last_cap_warn: Option<std::time::Instant> = None;
     loop {
         match listener.accept().await {
             Ok((inbound, client_addr)) => {
+                // v1.2.0: admit against the rule's connection cap BEFORE doing
+                // any further work. `admit` is called here, in the sequential
+                // accept loop, rather than inside the spawned task below — if the
+                // count were incremented in the task, an inbound flood would let
+                // an unbounded number of accepts through before the first
+                // increment landed, which is exactly the case the cap is for.
+                let Some(conn_guard) = gate.admit() else {
+                    // At cap: close immediately. We accept-then-drop rather than
+                    // stop accepting, because leaving connections in the kernel's
+                    // backlog would stall the queue and make the client hang
+                    // instead of failing fast and retrying elsewhere.
+                    drop(inbound);
+                    let now = std::time::Instant::now();
+                    if last_cap_warn.is_none_or(|t| now.duration_since(t) >= CAP_WARN_INTERVAL) {
+                        last_cap_warn = Some(now);
+                        tracing::warn!(
+                            "TCP rule {}: at connection cap ({} live / {} max), rejecting new \
+                             connections (latest from {}); rate-limited to once per {}s",
+                            rule_id,
+                            gate.live(),
+                            gate.max_connections.unwrap_or(0),
+                            client_addr,
+                            CAP_WARN_INTERVAL.as_secs()
+                        );
+                    }
+                    continue;
+                };
                 // v1.0.8: disable Nagle on the accepted (client-facing) socket.
                 // See the note in outbound::tcp_connect — a relay MUST set
                 // TCP_NODELAY on both ends or small packets get buffered ~40ms
@@ -56,25 +96,45 @@ pub async fn serve_tcp_listener(
                 let rate_limit = rate_limit.clone();
                 let counter = counter.clone();
                 let connections = connections.clone();
+                let mut gate = gate.clone();
 
                 tokio::spawn(async move {
                     // RAII guard: increments the active-TCP count on create,
                     // decrements on drop (end of task — normal close, error, or
                     // panic). Guarantees the count is correct even on abrupt close.
                     let _guard = connections.tcp_handle();
-                    if let Err(e) = handle_tcp_connection(
-                        inbound,
-                        client_addr,
-                        targets,
-                        selector,
-                        rate_limit,
-                        counter,
-                        rule_id,
-                        source_ipv4,
-                    )
-                    .await
-                    {
-                        tracing::debug!("TCP connection error: {}", e);
+                    // v1.2.0: holds this connection's slot in the rule's cap;
+                    // drops with the task however it ends, including when the
+                    // select! below takes the cancellation branch.
+                    let _conn_guard = conn_guard;
+                    // v1.2.0: this task is DETACHED — aborting the accept loop
+                    // does not stop it (verified: an established connection keeps
+                    // forwarding after the listener task is aborted). So a rule
+                    // restart cannot work by killing the listener; it fires this
+                    // cancellation instead, and dropping the handle_tcp_connection
+                    // future here closes both sockets.
+                    tokio::select! {
+                        _ = gate.cancelled() => {
+                            tracing::debug!(
+                                "TCP rule {}: dropping connection from {} (rule restarted)",
+                                rule_id,
+                                client_addr
+                            );
+                        }
+                        r = handle_tcp_connection(
+                            inbound,
+                            client_addr,
+                            targets,
+                            selector,
+                            rate_limit,
+                            counter,
+                            rule_id,
+                            source_ipv4,
+                        ) => {
+                            if let Err(e) = r {
+                                tracing::debug!("TCP connection error: {}", e);
+                            }
+                        }
                     }
                 });
             }
@@ -303,6 +363,7 @@ mod tests {
         let selector = Arc::new(TargetSelector::new(LoadBalanceStrategy::First, 1));
         let counter = Arc::new(TrafficCounter::new());
         let connections = Arc::new(ConnectionTracker::new());
+        let runtime = crate::forwarder::gate::RuleRuntime::new();
         tokio::spawn(serve_tcp_listener(
             listener,
             vec![target_addr.to_string()],
@@ -312,7 +373,11 @@ mod tests {
             connections,
             1,
             None,
+            runtime.gate(None),
         ));
+        // Keep the runtime alive for the duration of the test: dropping it would
+        // cancel the connection we are about to make.
+        let _runtime = runtime;
 
         // Client connects to the relay and round-trips through to the echo.
         let mut client = TcpStream::connect(listen_addr).await.unwrap();
@@ -327,5 +392,91 @@ mod tests {
             b"ping-through-relay",
             "relay must echo the target"
         );
+    }
+
+    /// v1.2.0: the cap is enforced at accept. Connections up to the cap forward
+    /// normally; the one over it is closed immediately rather than queued, so a
+    /// client fails fast instead of hanging.
+    #[tokio::test]
+    async fn accept_loop_rejects_over_the_connection_cap() {
+        // Echo target that serves many connections concurrently.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut s, _)) = target.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut b = [0u8; 64];
+                    loop {
+                        match s.read(&mut b).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => {
+                                if s.write_all(&b[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        let listener = bind_tcp_listener(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+        let runtime = crate::forwarder::gate::RuleRuntime::new();
+        tokio::spawn(serve_tcp_listener(
+            listener,
+            vec![target_addr.to_string()],
+            Arc::new(TargetSelector::new(LoadBalanceStrategy::First, 1)),
+            RateLimit::Unlimited,
+            Arc::new(TrafficCounter::new()),
+            Arc::new(ConnectionTracker::new()),
+            1,
+            None,
+            runtime.gate(Some(2)),
+        ));
+        let _runtime = runtime;
+
+        // Two connections fit under the cap and must both forward.
+        let mut a = TcpStream::connect(listen_addr).await.unwrap();
+        a.write_all(b"a").await.unwrap();
+        let mut buf = [0u8; 16];
+        assert_eq!(a.read(&mut buf).await.unwrap(), 1, "conn 1 must forward");
+
+        let mut b = TcpStream::connect(listen_addr).await.unwrap();
+        b.write_all(b"b").await.unwrap();
+        assert_eq!(b.read(&mut buf).await.unwrap(), 1, "conn 2 must forward");
+
+        // The third is over the cap. The TCP handshake still completes (the
+        // kernel accepts it, then we close), so the rejection shows up as EOF on
+        // read rather than a connect error.
+        let mut c = TcpStream::connect(listen_addr).await.unwrap();
+        let _ = c.write_all(b"c").await;
+        match tokio::time::timeout(Duration::from_secs(2), c.read(&mut buf)).await {
+            Ok(Ok(0)) | Ok(Err(_)) => {}
+            Ok(Ok(n)) => panic!(
+                "over-cap connection was served — echoed {:?}",
+                String::from_utf8_lossy(&buf[..n])
+            ),
+            Err(_) => panic!("over-cap connection hung instead of being closed"),
+        }
+
+        // Closing one frees its slot, and a new connection is admitted again.
+        drop(a);
+        // Give the closed connection's task a moment to drop its guard.
+        for _ in 0..50 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let mut d = TcpStream::connect(listen_addr).await.unwrap();
+            if d.write_all(b"d").await.is_ok() {
+                if let Ok(Ok(1)) =
+                    tokio::time::timeout(Duration::from_millis(200), d.read(&mut buf)).await
+                {
+                    return; // slot was freed and reused — done.
+                }
+            }
+        }
+        panic!("a freed slot was never reused — the guard did not release the cap");
     }
 }

--- a/crates/node/src/ws_client.rs
+++ b/crates/node/src/ws_client.rs
@@ -266,6 +266,51 @@ async fn connect_and_run(
                                 }
                             }
                             return WsExit::ConfigChanged;
+                        } else if let Some(rm) =
+                            serde_json::from_str::<relay_shared::protocol::RestartRuleMessage>(&text)
+                                .ok()
+                                .filter(|rm| rm.msg_type == "restart_rule")
+                        {
+                            // v1.2.0: restart ONE rule's listeners and drop its
+                            // connections.
+                            //
+                            // This arm MUST stay ABOVE the diagnose arm, and MUST
+                            // check msg_type. DiagnoseRuleMessage defaults its
+                            // `challenge` field and ignores unknown fields, so a
+                            // restart_rule payload deserializes into it cleanly
+                            // (rule_id + request_id are both present) — order it
+                            // after diagnose and every restart silently becomes a
+                            // target probe instead.
+                            //
+                            // send_node already routed this to us; re-check as
+                            // defence in depth (same as upgrade_node below).
+                            if rm.node_id != node_id {
+                                tracing::warn!(
+                                    "websocket: ignoring restart of rule {} for node {} (I am {})",
+                                    rm.rule_id,
+                                    rm.node_id,
+                                    node_id
+                                );
+                            } else {
+                                tracing::info!(
+                                    "websocket: restart_rule request_id={} rule_id={}",
+                                    rm.request_id,
+                                    rm.rule_id
+                                );
+                                // Held across the restart: apply_config takes the
+                                // same lock, so a concurrent config push cannot
+                                // interleave with the teardown/rebuild.
+                                let mut mgr = manager.lock().await;
+                                let (dropped, restarted) = mgr.restart_rule(rm.rule_id).await;
+                                tracing::info!(
+                                    "websocket: restart_rule request_id={} rule_id={} done \
+                                     ({} connection(s) dropped, {} listener(s) rebuilt)",
+                                    rm.request_id,
+                                    rm.rule_id,
+                                    dropped,
+                                    restarted
+                                );
+                            }
                         } else if let Ok(dm) =
                             serde_json::from_str::<relay_shared::protocol::DiagnoseRuleMessage>(&text)
                         {


### PR DESCRIPTION
> **Stacked on #65** —— base 是 `feat/rule-conn-controls-schema`,#65 合并后 GitHub 会自动把 base 改成 `main`。请先合 #65。

第 2/4 个 PR:节点侧执行。#65 已经把字段和 `restart_rule` 消息定义好了(但没人用),这个 PR 让节点真正**执行连接数上限**并**处理重启指令**。

## ⚠️ 一个关键发现:abort listener 根本断不掉连接

设计重启功能时,直觉实现是「abort 掉 listener 任务,再重新绑定端口」。我写了个最小复现验证这个假设,结果是:

```
before abort: echo works, got "hello"
RESULT: connection STILL ALIVE — echoed "after" after abort
```

**已建立的连接在 abort 之后照样收发。** 因为每条连接是 `tokio::spawn` 出去的**独立任务**,abort 父任务不会级联到子任务。

也就是说,直觉实现只会重新绑定端口,**一条连接都断不掉** —— 功能完全落空,而且从外部看不出来(端口是通的、面板报告成功)。

所以连接任务必须显式 select 在一个 per-rule 取消通道上。`restart_rule_drops_live_connections_and_rebuilds_listener` 这个端到端测试钉死了它:建真连接 → 确认转发 → 重启 → **断言老连接已死** → 断言新连接能通。测试注释里写明了如果它退化成"连接还活着",重启就是个安慰剂。

### 顺带修了一个现存 bug

同一个根因:规则从节点配置里删掉后,**老连接还在转发** —— 而 `apply_config` 早就把它的流量计数器清理了,等于在转发没人记账的流量。现在删规则会一并取消其连接。

**取消只接在显式重启上。** `apply_config` 因指纹变化重建 listener(改目标、改限速)**仍然不动现有连接** —— 这是 v0.3.6 以来的行为,改个规则不该把人全踢下线。

## 连接数上限

**准入判断放在 accept 循环里,不放在 spawn 出去的任务里。** accept 循环是顺序的,所以"检查+自增"在这里是精确的;放进任务里的话,连接洪水会在第一次自增落地前放行任意多条 —— 而这恰恰就是上限要防的场景。

超限后 accept 然后立刻关闭,客户端**快速失败**而不是卡在内核 backlog 里干等。

**计数器挂在规则上,不挂在 listener 上。** 双栈规则跑两个 accept 循环(v4 + v6),per-listener 计数会**静默给出双倍上限**。`dual_stack_listeners_share_one_budget` 钉住这点。

"到达上限"的告警**限频 60 秒/listener**:规则卡在上限时每次 accept 都会拒绝,不限频的话日志本身就成了故障。

## restart_rule 消息分发有个坑

`DiagnoseRuleMessage.challenge` 带 `#[serde(default)]`,而节点是**按顺序试 struct 解析**来分发消息的。restart 的 JSON(有 `rule_id`、`request_id`,多余字段被忽略)能**干净地解析成 diagnose**。

所以 restart 分支必须排在 diagnose **前面**并强制校验 `type` —— 否则每次重启都会静默变成一次目标探测。`restart_payload_is_ambiguous_with_diagnose_so_msg_type_must_gate` 把这个歧义钉死了,顺序不能动。

节点重建 listener 用的是**自己缓存的配置**,不是消息里的任何内容 —— 重启不能被用来注入 listener 配置。

## 验证

- `cargo fmt --check` / `clippy --workspace --all-targets -- -D warnings` 零告警
- 全量 540 测试通过,其中新增关键测试:
  - `restart_rule_drops_live_connections_and_rebuilds_listener` — 端到端证明真断连+真重建
  - `accept_loop_rejects_over_the_connection_cap` — 上限内正常转发、超限被关、释放后槽位可复用
  - `dual_stack_listeners_share_one_budget` — v4/v6 共享预算
  - `cancel_all_wakes_connection_tasks` / `dropping_runtime_cancels_connections`
  - `no_cap_admits_freely` — 0 = 不限(存量规则的默认值,搞错就是全机队下线)

## 兼容性

需要面板 **1.2.0+** 才会收到 `restart_rule` 或连接上限。两个新增在协议上都是向后兼容的(`#[serde(default)]`),所以 1.2.0 节点接老面板照常跑,只是永远收不到这两样。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
