### PR TITLE
feat(rules): restart endpoint + restart / batch-restart UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ independent `v*` / `node-v*` tracks since this release).
 
 ### Added
 
+- **Rule restart (manual + batch).** `POST /rules/{id}/restart` drops every
+  connection a rule is currently carrying and rebuilds its listeners on each
+  node of its inbound group. Owner-scoped (a user may restart only their own
+  rules); batch restart is the frontend calling it per rule, matching batch
+  pause/resume, so there is deliberately no bulk endpoint. The rule's `paused`
+  flag is never read or written — a restart is not a state transition. A paused
+  rule is rejected rather than reported as a hollow success: it has no listener
+  to restart, and the user's actual intent there is "resume".
+
+  This is deliberately NOT implemented as pause+resume. That pair leaves the
+  rule PAUSED if the resume half fails (node offline, authorization revoked
+  between the two calls, panel restarted mid-way) — an outage caused by the
+  button whose whole job is to end one. It also frees the listen port for
+  auto-assignment during the gap, and writing `paused` resets `auto_paused`
+  (v1.0.8), corrupting the system-paused vs. human-paused distinction.
+
+  The response's `restarted` field counts nodes ACTUALLY reached and can be 0
+  on an otherwise successful request (every node too old or offline), so the UI
+  keys its message off that rather than the envelope code — a restart that
+  silently did nothing would otherwise be undetectable.
+
 - **Rule connection controls, storage + API** (no enforcement yet — the node
   half lands separately). Two new per-rule settings, both `0` = off/unlimited so
   an upgrade changes nothing until a rule is explicitly opted in:
@@ -31,9 +52,13 @@ independent `v*` / `node-v*` tracks since this release).
   than to 0 — otherwise setting only `max_connections` would silently switch off
   that rule's scheduled restart.
 
-- **`restart_rule` wire message + `node_supports_restart_rule` version gate**
-  (1.2.0+) in `relay-shared`. Nothing sends it yet; the panel endpoint and the
-  node handler land in follow-up PRs.
+### Compatibility
+
+- Nodes below **1.2.0** silently ignore the unknown `restart_rule` message. The
+  panel gates on `node_supports_restart_rule` and surfaces those nodes as
+  "upgrade required" rather than counting them as restarted — a restart that
+  quietly did nothing would be undetectable to the operator. Node Status already
+  offers one-click upgrade.
 
 ### Schema
 

--- a/crates/panel/src/api/diagnose.rs
+++ b/crates/panel/src/api/diagnose.rs
@@ -233,11 +233,15 @@ pub struct DiagnoseResponse {
 /// A node's status row from kvs, parsed for diagnosis scheduling. v0.4.15:
 /// carries group_name + public_ip so each NodeDiagnoseStatus can show
 /// "分组名 · 公网IP" without exposing the raw node_id as the label.
-struct NodeStatusRow {
-    node_id: String,
-    node_version: Option<String>,
-    public_ip: Option<String>,
-    group_name: String,
+/// v1.2.0: `pub(crate)` so `api::restart` can reuse the same node enumeration.
+/// Restart and diagnose both need "the nodes of this rule's inbound group, with
+/// their versions", and duplicating that logic would let the two drift apart on
+/// which nodes are considered live.
+pub(crate) struct NodeStatusRow {
+    pub(crate) node_id: String,
+    pub(crate) node_version: Option<String>,
+    pub(crate) public_ip: Option<String>,
+    pub(crate) group_name: String,
 }
 
 /// POST /api/v1/rules/{id}/diagnose — start a diagnosis run for a rule.
@@ -617,7 +621,7 @@ pub async fn receive_diagnose_result(
 /// `group_name` is passed in by the caller (which has already loaded the group)
 /// and attached to each row; `public_ip` is read from the status JSON for
 /// display. No extra DB lookup here.
-async fn group_node_statuses(
+pub(crate) async fn group_node_statuses(
     state: &AppState,
     group_id: i64,
     group_name: String,

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod geoip;
 pub mod groups;
 pub mod middleware;
 pub mod node;
+pub mod restart;
 pub mod security_headers;
 pub mod stats;
 pub mod system;
@@ -90,6 +91,14 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/rules/{id}/diagnose",
             axum::routing::post(diagnose::diagnose_rule),
+        )
+        // v1.2.0: drop a rule's live connections and rebuild its listeners.
+        // Owner-scoped like diagnose — a user may restart only their own rules.
+        // Batch restart is the frontend calling this per rule (same shape as
+        // batch pause/resume), so there is deliberately no /rules/restart.
+        .route(
+            "/rules/{id}/restart",
+            axum::routing::post(restart::restart_rule),
         )
         // v0.4.12: device groups are admin-only shared infrastructure again.
         // Writes use the AdminOnly guard; the service layer operates with

--- a/crates/panel/src/api/restart.rs
+++ b/crates/panel/src/api/restart.rs
@@ -1,0 +1,257 @@
+//! v1.2.0: manual rule restart — drop a rule's live connections and rebuild its
+//! listeners on every node of its inbound group.
+//!
+//! ## Why this is not pause + resume
+//!
+//! The obvious implementation is two writes: `paused = true`, then
+//! `paused = false`. It needs no new protocol, but it is wrong for a button
+//! whose entire job is "get me unstuck":
+//!
+//! - If the resume half fails (node offline, authorization revoked between the
+//!   two calls, panel restarted mid-way), the rule is left PAUSED. The user
+//!   clicked "restart" and got an outage. Batch restart makes this worse: a
+//!   partial failure strands an arbitrary subset of rules off.
+//! - The port is released while paused, so auto-assignment can hand it to
+//!   another rule in the gap.
+//! - It writes `paused`, which resets `auto_paused` (v1.0.8) and so corrupts
+//!   the system-paused vs. human-paused distinction.
+//!
+//! A restart carries no state instead: it either happens or it doesn't, and the
+//! rule's stored fields are never touched.
+//!
+//! ## Old nodes
+//!
+//! A node below `node_supports_restart_rule` silently ignores the unknown WS
+//! message. Reporting those as restarted would be a lie the user can't detect,
+//! so they are surfaced explicitly as "upgrade this node" — the Node Status page
+//! already offers one-click upgrade.
+
+use axum::extract::{Path, State};
+use axum::Json;
+use relay_shared::protocol::{node_supports_restart_rule, ApiResponse, RestartRuleMessage};
+use serde::Serialize;
+
+use crate::api::diagnose::group_node_statuses;
+use crate::api::middleware::AuthUser;
+use crate::api::AppState;
+use crate::db::repo::ResourceScope;
+
+/// One node's outcome for a restart request.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum NodeRestartStatus {
+    /// The restart command reached this node's live control channel.
+    Restarted {
+        node_id: String,
+        group_name: String,
+        public_ip: Option<String>,
+    },
+    /// The node is too old to understand `restart_rule`. It would ignore the
+    /// message, so we do NOT send it and tell the operator to upgrade instead.
+    Unsupported {
+        node_id: String,
+        group_name: String,
+        public_ip: Option<String>,
+        node_version: Option<String>,
+    },
+    /// No live WS connection (or it dropped between the check and the send).
+    ControlChannelOffline {
+        node_id: String,
+        group_name: String,
+        public_ip: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub struct RestartResponse {
+    pub rule_id: i64,
+    /// How many nodes actually received the command. The frontend keys its
+    /// success/warning message off this rather than off the HTTP status: a
+    /// request can succeed while restarting nothing (every node old or offline).
+    pub restarted: usize,
+    pub nodes: Vec<NodeRestartStatus>,
+}
+
+/// Send `restart_rule` for `rule_id` to every eligible node of `group_id`.
+///
+/// Shared by the HTTP handler and the auto-restart scheduler so both apply the
+/// same version gate and the same online check — a scheduled restart must not
+/// quietly do something a manual one wouldn't.
+///
+/// `request_id` only correlates panel logs with node logs; nothing is sent back
+/// over the wire. A restart is fire-and-forget by design: the node's work is
+/// local and bounded (cancel connections, rebind), and making the HTTP call wait
+/// for confirmation from every node would hold a request open on the slowest
+/// node for no decision the caller can act on.
+pub(crate) async fn dispatch_restart(
+    state: &AppState,
+    rule_id: i64,
+    group_id: i64,
+    request_id: &str,
+) -> Result<Vec<NodeRestartStatus>, crate::db::error::DbError> {
+    // ResourceScope::All: the group is shared infrastructure and the caller's
+    // ownership of the RULE was already checked. Scoping this lookup to the
+    // caller would make a regular user's restart fail on an admin-owned group.
+    let group_name = crate::db::repo::GroupRepository::find_by_id(
+        state.db.as_ref(),
+        group_id,
+        &ResourceScope::All,
+    )
+    .await
+    .ok()
+    .flatten()
+    .map(|g| g.name)
+    .unwrap_or_else(|| format!("#{group_id}"));
+
+    let nodes = group_node_statuses(state, group_id, group_name).await?;
+    let online = state.node_connections.online_node_ids(group_id).await;
+
+    let msg_for = |node_id: &str| {
+        serde_json::to_string(&RestartRuleMessage::new(
+            node_id.to_string(),
+            rule_id,
+            request_id.to_string(),
+        ))
+        .unwrap_or_default()
+    };
+
+    let mut out = Vec::with_capacity(nodes.len());
+    for n in &nodes {
+        // Version FIRST, then liveness — mirrors the diagnose classifier. An old
+        // node with a healthy socket must read as "upgrade me", not "offline":
+        // the socket is fine, the node just can't do this.
+        if !node_supports_restart_rule(n.node_version.as_deref()) {
+            out.push(NodeRestartStatus::Unsupported {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+                node_version: n.node_version.clone(),
+            });
+            continue;
+        }
+        if !online.contains(&n.node_id) {
+            out.push(NodeRestartStatus::ControlChannelOffline {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+            });
+            continue;
+        }
+        // send_node returns the number of live connections it reached; 0 means
+        // the WS dropped between the online check above and here.
+        if state
+            .node_connections
+            .send_node(group_id, &n.node_id, &msg_for(&n.node_id))
+            .await
+            > 0
+        {
+            out.push(NodeRestartStatus::Restarted {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+            });
+        } else {
+            out.push(NodeRestartStatus::ControlChannelOffline {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// POST /api/v1/rules/{id}/restart — drop the rule's connections and rebuild its
+/// listeners.
+///
+/// Owner-scoped: a regular user may restart only their own rules (the scope
+/// folds `uid = ?` into the lookup, so someone else's rule_id is a uniform 404).
+/// Admins are unscoped.
+pub async fn restart_rule(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(rule_id): Path<i64>,
+) -> Json<ApiResponse<RestartResponse>> {
+    let scope = user.resource_scope();
+    tracing::info!(
+        action = "restart_rule",
+        rule_id = rule_id,
+        actor_id = user.user_id,
+        actor_admin = user.admin,
+        "rule restart requested"
+    );
+
+    let rule = match state.db.find_rule_by_id(rule_id, &scope).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return Json(ApiResponse {
+                code: 404,
+                message: "Rule not found".into(),
+                data: None,
+            })
+        }
+        Err(e) => {
+            tracing::error!("restart_rule {}: find_rule_by_id failed: {}", rule_id, e);
+            return Json(ApiResponse {
+                code: 500,
+                message: "database error".into(),
+                data: None,
+            });
+        }
+    };
+
+    // A paused rule has no listener on any node, so a restart is a guaranteed
+    // no-op. Reject rather than report a hollow success — the user's actual
+    // intent for a paused rule is "resume", which is a different button.
+    if rule.paused {
+        return Json(ApiResponse {
+            code: 400,
+            message: "规则已暂停，无需重启（启用后才有连接）".into(),
+            data: None,
+        });
+    }
+
+    let request_id = uuid_like_id();
+    let nodes = match dispatch_restart(&state, rule_id, rule.device_group_in, &request_id).await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!("restart_rule {}: dispatch failed: {}", rule_id, e);
+            return Json(ApiResponse {
+                code: 500,
+                message: "database error".into(),
+                data: None,
+            });
+        }
+    };
+
+    let restarted = nodes
+        .iter()
+        .filter(|n| matches!(n, NodeRestartStatus::Restarted { .. }))
+        .count();
+    tracing::info!(
+        "restart_rule: actor_id={} rule_id={} request_id={} reached {}/{} node(s)",
+        user.user_id,
+        rule_id,
+        request_id,
+        restarted,
+        nodes.len()
+    );
+
+    Json(ApiResponse::success(RestartResponse {
+        rule_id,
+        restarted,
+        nodes,
+    }))
+}
+
+/// Correlation id for one restart run. Not a real UUID and not security-
+/// relevant — it only ties a panel log line to a node log line, so process id +
+/// nanosecond timestamp is enough to be unique in practice.
+fn uuid_like_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("rst-{}-{}", std::process::id(), nanos)
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -80,10 +80,42 @@ export interface ForwardRule {
   /** v0.4.7: bound tunnel profile (source of transport config).
    *  null/undefined = legacy (use public_transport/ws_path). */
   tunnel_profile_id?: number | null;
+  /** v1.2.0: cap on concurrent TCP connections, counted PER NODE (0 = unlimited).
+   *  A rule served by 3 nodes admits up to 3x this in total. TCP only. */
+  max_connections?: number;
+  /** v1.2.0: restart the rule every N minutes to shed connections (0 = off).
+   *  Non-zero values are floored at MIN_AUTO_RESTART_MINUTES by the API. */
+  auto_restart_minutes?: number;
   config: string;
   traffic_used: number;
   status: string;
   created_at: string;
+}
+
+/** v1.2.0: the API's floor for a non-zero auto_restart_minutes. Mirrors
+ *  relay_shared::models::MIN_AUTO_RESTART_MINUTES — the backend rejects
+ *  anything between 1 and this, so the form must not offer it. */
+export const MIN_AUTO_RESTART_MINUTES = 5;
+
+/** v1.2.0: one node's outcome in a restart response. */
+export interface NodeRestartStatus {
+  /** "restarted" = the command reached the node's live control channel.
+   *  "unsupported" = node too old to understand restart_rule (upgrade it).
+   *  "control_channel_offline" = no live WS connection. */
+  state: 'restarted' | 'unsupported' | 'control_channel_offline';
+  node_id: string;
+  group_name: string;
+  public_ip?: string | null;
+  node_version?: string | null;
+}
+
+/** v1.2.0: POST /rules/{id}/restart. `restarted` counts nodes actually reached
+ *  — it can be 0 on an otherwise successful request (all nodes old/offline), so
+ *  callers must check it rather than only the envelope code. */
+export interface RestartResponse {
+  rule_id: number;
+  restarted: number;
+  nodes: NodeRestartStatus[];
 }
 
 /** v0.4.0: a tunnel profile (matches backend TunnelProfile struct). Builtin

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -514,6 +514,29 @@ export const enUS: Dict = {
   batchPartial: '{ok} succeeded, {fail} failed (unauthorized lines can\'t be resumed)',
   selectedCount: '{count} selected',
 
+  // ── v1.2.0: rule restart + connection cap + scheduled restart ──
+  restart: 'Restart',
+  batchRestart: 'Batch Restart',
+  restartConfirmTitle: 'Restart this rule?',
+  restartConfirmDesc: 'Every connection this rule is currently carrying is dropped immediately and clients must reconnect. The rule stays enabled/paused as it is.',
+  batchRestartConfirm: 'Restart {count} selected rules?',
+  restartPausedHint: 'Rule is paused — there are no connections to restart',
+  restartSuccess: 'Restarted on {count} node(s)',
+  batchRestartSuccess: 'Restarted {count} rules',
+  restartFailed: 'Restart failed',
+  // Partial success: appended to restartSuccess to say which nodes missed out.
+  restartOutdatedSuffix: '({count} node(s) too old — upgrade them first)',
+  restartOfflineSuffix: '({count} node(s) offline)',
+  restartAllOutdated: 'Nothing restarted: {count} node(s) are too old. Upgrade them from Node Status first.',
+  restartAllOffline: 'Nothing restarted: {count} node(s) are offline',
+  restartNoNodes: 'Nothing restarted: this rule\'s inbound group has no nodes',
+  maxConnections: 'Max connections',
+  maxConnectionsHint: '0 = unlimited. TCP only, and counted PER NODE — a rule running on 3 nodes allows 3x this number in total. Connections past the cap are refused immediately. Changing the cap does not drop existing connections; it applies to new ones from now on.',
+  autoRestart: 'Auto-restart interval',
+  autoRestartHint: '0 = off. Drops all of this rule\'s connections on this interval to clear accumulation. Minimum {min} minutes. The timer restarts when the panel restarts.',
+  autoRestartTooSmall: 'Minimum {min} minutes (0 = off)',
+  minutes: 'minutes',
+
   // ── v1.0.8: plans + shop + suspension ──
   shop: 'Shop',
   planManagement: 'Plans',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -513,6 +513,29 @@ export const zhCN = {
   batchPartial: '成功 {ok} 条，失败 {fail} 条（无权限的线路无法启动）',
   selectedCount: '已选 {count} 条',
 
+  // ── v1.2.0: 规则重启 + 连接数上限 + 定时自动重启 ──
+  restart: '重启',
+  batchRestart: '批量重启',
+  restartConfirmTitle: '确定重启这条规则？',
+  restartConfirmDesc: '会立即断开该规则当前的所有连接，客户端需要重连。规则的启用/暂停状态不变。',
+  batchRestartConfirm: '确定重启选中的 {count} 条规则？',
+  restartPausedHint: '规则已暂停，没有连接可重启',
+  restartSuccess: '已在 {count} 个节点上重启',
+  batchRestartSuccess: '已重启 {count} 条规则',
+  restartFailed: '重启失败',
+  // 部分成功：拼在 restartSuccess 后面，说明哪些节点没轮到
+  restartOutdatedSuffix: '（{count} 个节点版本过低，需先升级节点）',
+  restartOfflineSuffix: '（{count} 个节点离线）',
+  restartAllOutdated: '重启未生效：{count} 个节点版本过低，请先在「节点状态」升级节点',
+  restartAllOffline: '重启未生效：{count} 个节点当前离线',
+  restartNoNodes: '重启未生效：该规则的入口分组下没有节点',
+  maxConnections: '最大连接数',
+  maxConnectionsHint: '0 = 不限。仅对 TCP 生效，且按「每个节点」独立计数——规则跑在 3 个节点上时总量是这里的 3 倍。超出后新连接会被直接拒绝。修改上限不会断开已有连接，新上限从此刻起对新连接生效。',
+  autoRestart: '自动重启间隔',
+  autoRestartHint: '0 = 关闭。开启后每隔这么久自动断开该规则的全部连接一次，用于清理堆积的连接。最小 {min} 分钟。面板重启后重新计时。',
+  autoRestartTooSmall: '最小 {min} 分钟（0 = 关闭）',
+  minutes: '分钟',
+
   // ── v1.0.8: plans + shop + suspension ──
   shop: '套餐商店',
   planManagement: '套餐管理',

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -1,10 +1,11 @@
 import { Table, Button, Modal, Form, Input, InputNumber, Select, Space, message, Popconfirm, Tag, Alert, Typography, Dropdown, Switch, Tabs, Spin, Tooltip } from 'antd';
 import type { MenuProps } from 'antd';
-import { PlusOutlined, ReloadOutlined, EditOutlined, ApiOutlined, CopyOutlined, DownloadOutlined, UploadOutlined, PauseCircleOutlined, PlayCircleOutlined, DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, MedicineBoxOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { PlusOutlined, ReloadOutlined, EditOutlined, ApiOutlined, CopyOutlined, DownloadOutlined, UploadOutlined, PauseCircleOutlined, PlayCircleOutlined, DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, MedicineBoxOutlined, QuestionCircleOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import api from '../api/client';
-import type { ApiEnvelope, ForwardRule, DeviceGroup, User, UserSelf, RuleTargetInput, DiagnoseResponse, NodeDiagnoseStatus, DiagnoseTargetResult, SharedGroupSummary } from '../api/types';
+import type { ApiEnvelope, ForwardRule, DeviceGroup, User, UserSelf, RuleTargetInput, DiagnoseResponse, NodeDiagnoseStatus, DiagnoseTargetResult, SharedGroupSummary, RestartResponse } from '../api/types';
+import { MIN_AUTO_RESTART_MINUTES } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { formatBytes } from '../utils/format';
 import { useAuth } from '../auth/useAuth';
@@ -246,6 +247,8 @@ export default function Rules() {
       load_balance_strategy: r.load_balance_strategy ?? 'first',
       upload_limit_mbps: r.upload_limit_mbps ?? 0,
       download_limit_mbps: r.download_limit_mbps ?? 0,
+      max_connections: r.max_connections ?? 0,
+      auto_restart_minutes: r.auto_restart_minutes ?? 0,
     });
     setEditOpen(true);
   };
@@ -264,6 +267,9 @@ export default function Rules() {
       load_balance_strategy: r.load_balance_strategy ?? 'first',
       upload_limit_mbps: r.upload_limit_mbps ?? 0,
       download_limit_mbps: r.download_limit_mbps ?? 0,
+      // v1.2.0: max_connections / auto_restart_minutes are NOT carried over —
+      // they're edit-only (the create path can't store them), so the copy starts
+      // uncapped and the user sets them via Edit if wanted.
     });
     setCreateOpen(true);
   };
@@ -347,6 +353,8 @@ const IMPORT_DEFAULTS = {
     load_balance_strategy?: string;
     upload_limit_mbps?: number;
     download_limit_mbps?: number;
+    max_connections?: number;
+    auto_restart_minutes?: number;
   }) => {
     if (!editing) return;
     const payload: Record<string, unknown> = {};
@@ -374,6 +382,15 @@ const IMPORT_DEFAULTS = {
     if (newUp !== (editing.upload_limit_mbps ?? 0) || newDown !== (editing.download_limit_mbps ?? 0)) {
       payload.upload_limit_mbps = newUp;
       payload.download_limit_mbps = newDown;
+    }
+    // v1.2.0: send both together when either changed. The API defaults an
+    // omitted one to the rule's current value, so sending a single field is
+    // safe — but sending the pair keeps the request self-describing.
+    const newMaxConn = values.max_connections ?? 0;
+    const newAutoRestart = values.auto_restart_minutes ?? 0;
+    if (newMaxConn !== (editing.max_connections ?? 0) || newAutoRestart !== (editing.auto_restart_minutes ?? 0)) {
+      payload.max_connections = newMaxConn;
+      payload.auto_restart_minutes = newAutoRestart;
     }
     if (Object.keys(payload).length === 0) { setEditOpen(false); return; }
     try {
@@ -436,6 +453,65 @@ const IMPORT_DEFAULTS = {
     }
     setSelectedRowKeys([]);
     load();
+  };
+
+  /** v1.2.0: restart one rule — drop its live connections and rebuild its
+   *  listeners on every node of its inbound group. The rule's paused state is
+   *  untouched; this is not a pause/resume round-trip.
+   *
+   *  `restarted` (nodes actually reached) drives the message rather than the
+   *  HTTP code: the request can succeed while restarting nothing, e.g. every
+   *  node is too old to understand the command. Reporting that as success would
+   *  hide exactly the case the user needs to act on. */
+  const handleRestart = async (r: ForwardRule) => {
+    try {
+      const res = await api.post<unknown, ApiEnvelope<RestartResponse>>(`/rules/${r.id}/restart`, {});
+      if (res.code !== 0) {
+        message.error(res.message || t('restartFailed'));
+        return;
+      }
+      const data = res.data;
+      const outdated = (data?.nodes ?? []).filter(n => n.state === 'unsupported').length;
+      const offline = (data?.nodes ?? []).filter(n => n.state === 'control_channel_offline').length;
+      if ((data?.restarted ?? 0) > 0) {
+        let msg = t('restartSuccess').replace('{count}', String(data?.restarted ?? 0));
+        if (outdated > 0) msg += ` ${t('restartOutdatedSuffix').replace('{count}', String(outdated))}`;
+        if (offline > 0) msg += ` ${t('restartOfflineSuffix').replace('{count}', String(offline))}`;
+        if (outdated > 0 || offline > 0) message.warning(msg);
+        else message.success(msg);
+      } else if (outdated > 0) {
+        message.warning(t('restartAllOutdated').replace('{count}', String(outdated)));
+      } else if (offline > 0) {
+        message.warning(t('restartAllOffline').replace('{count}', String(offline)));
+      } else {
+        message.warning(t('restartNoNodes'));
+      }
+    } catch {
+      message.error(t('restartFailed'));
+    }
+  };
+
+  /** v1.2.0: batch restart. Per-rule POST like batch pause/resume — there is no
+   *  bulk endpoint. A rule can fail individually (paused → 400, or not owned →
+   *  404), so tally ok/fail rather than assuming Promise.all means success. */
+  const handleBatchRestart = async () => {
+    const ids = selectedRowKeys as number[];
+    if (ids.length === 0) return;
+    const results = await Promise.all(ids.map(async id => {
+      try {
+        const res = await api.post<unknown, ApiEnvelope<RestartResponse>>(`/rules/${id}/restart`, {});
+        // Reaching zero nodes is not a success worth reporting as one.
+        return res.code === 0 && (res.data?.restarted ?? 0) > 0;
+      } catch { return false; }
+    }));
+    const ok = results.filter(Boolean).length;
+    const fail = results.length - ok;
+    if (fail === 0) {
+      message.success(t('batchRestartSuccess').replace('{count}', String(ok)));
+    } else {
+      message.warning(t('batchPartial').replace('{ok}', String(ok)).replace('{fail}', String(fail)));
+    }
+    setSelectedRowKeys([]);
   };
 
   /** v0.4.8: run a diagnosis for a rule. The panel fans the probe out to the
@@ -563,6 +639,26 @@ const IMPORT_DEFAULTS = {
           <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => handleCopy(r)}>{t('copy')}</Button>
           {/* v0.4.9: diagnosis is TCP-only — disable for pure-UDP rules. */}
           <Button size="small" type="text" icon={<MedicineBoxOutlined />} disabled={r.protocol === 'udp'} onClick={() => handleDiagnose(r)} title={r.protocol === 'udp' ? t('diagnoseUdpUnsupported') : t('diagnose')}>{t('diagnose')}</Button>
+          {/* v1.2.0: restart drops every live connection on this rule, so it is
+              behind a confirm (diagnose is read-only and isn't). Disabled while
+              paused — there are no listeners to restart. */}
+          <Popconfirm
+            title={t('restartConfirmTitle')}
+            description={t('restartConfirmDesc')}
+            onConfirm={() => handleRestart(r)}
+            okButtonProps={{ danger: true }}
+            disabled={r.paused}
+          >
+            <Button
+              size="small"
+              type="text"
+              icon={<ThunderboltOutlined />}
+              disabled={r.paused}
+              title={r.paused ? t('restartPausedHint') : t('restart')}
+            >
+              {t('restart')}
+            </Button>
+          </Popconfirm>
           <Popconfirm title={t('deleteRuleConfirm')} onConfirm={() => handleDelete(r.id)}>
             <Button danger size="small" type="text">{t('delete')}</Button>
           </Popconfirm>
@@ -615,6 +711,45 @@ const IMPORT_DEFAULTS = {
       />
     );
   };
+
+  /** v1.2.0: connection cap + scheduled restart. Shared by the create and edit
+   *  forms so the two can't drift (the rate-limit block above predates this and
+   *  is still duplicated).
+   *
+   *  Both fields are 0 = off. The cap's `extra` says the count is PER NODE and
+   *  TCP-only, because neither is guessable: a rule on 3 nodes admits 3x the
+   *  number typed here, and setting it on a UDP-only rule does nothing. */
+  const renderConnectionControls = () => (
+    <>
+      <Form.Item
+        name="max_connections"
+        label={t('maxConnections')}
+        extra={t('maxConnectionsHint')}
+        initialValue={0}
+      >
+        <InputNumber min={0} style={{ width: '100%' }} placeholder="0" />
+      </Form.Item>
+      <Form.Item
+        name="auto_restart_minutes"
+        label={t('autoRestart')}
+        extra={t('autoRestartHint').replace('{min}', String(MIN_AUTO_RESTART_MINUTES))}
+        initialValue={0}
+        rules={[{
+          // Mirrors the API's floor. 0 = off is always allowed; anything between
+          // 1 and the floor would drop connections faster than clients reconnect.
+          validator: (_, value) => {
+            const v = Number(value ?? 0);
+            if (v === 0 || v >= MIN_AUTO_RESTART_MINUTES) return Promise.resolve();
+            return Promise.reject(new Error(
+              t('autoRestartTooSmall').replace('{min}', String(MIN_AUTO_RESTART_MINUTES))
+            ));
+          },
+        }]}
+      >
+        <InputNumber min={0} style={{ width: '100%' }} addonAfter={t('minutes')} placeholder="0" />
+      </Form.Item>
+    </>
+  );
 
   const renderTargetsEditor = () => (
     <Form.List name="targets" initialValue={[{ host: '', port: undefined as unknown as number, enabled: true }]}>
@@ -709,6 +844,18 @@ const IMPORT_DEFAULTS = {
             <Button icon={<PauseCircleOutlined />} onClick={() => handleBatchSetPaused(true)}>
               {t('batchPause')} ({selectedRowKeys.length})
             </Button>
+          )}
+          {selectedRowKeys.length > 0 && (
+            <Popconfirm
+              title={t('batchRestartConfirm').replace('{count}', String(selectedRowKeys.length))}
+              description={t('restartConfirmDesc')}
+              onConfirm={handleBatchRestart}
+              okButtonProps={{ danger: true }}
+            >
+              <Button icon={<ThunderboltOutlined />}>
+                {t('batchRestart')} ({selectedRowKeys.length})
+              </Button>
+            </Popconfirm>
           )}
           {selectedRowKeys.length > 0 && (
             <Popconfirm
@@ -816,6 +963,12 @@ const IMPORT_DEFAULTS = {
                     <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
+                {/* v1.2.0: the connection cap / auto-restart controls are
+                    deliberately EDIT-ONLY. The atomic create transaction
+                    (create_rule_with_guard) doesn't carry them, so offering them
+                    here would silently discard whatever the user typed. They are
+                    also settings you tune after watching a rule misbehave, not
+                    ones you can guess up front. */}
               </>),
             },
           ]} />
@@ -882,6 +1035,7 @@ const IMPORT_DEFAULTS = {
                     <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
+                {renderConnectionControls()}
               </>),
             },
           ]} />


### PR DESCRIPTION
> **Stacked on #66**(而 #66 stacked on #65)。合并顺序:**#65 → #66 → 本 PR**。每合一个,GitHub 会自动把下游 PR 的 base 前移。

第 3/4 个 PR:**这是用户实际看得见的那一半** —— 「我的规则」里的重启按钮和批量重启。

## 用户要什么

原话:「转发面板能不能上一个自动重启规则的功能,连接数多卡爆炸了」。#65/#66 已经把根因(没有连接数上限)修了,这个 PR 给的是**应急手段**:手动把一条规则的连接全断掉重来。

## 接口

`POST /rules/{id}/restart` —— owner-scoped(普通用户只能重启自己的规则,别人的 rule_id 统一 404)。复用了 diagnose 现成的节点枚举,免得两边对"哪些节点算在线"的判断慢慢跑偏。

批量重启就是前端**逐条调这个接口**(和现有批量启停一个形状),故意不做批量接口。

## 为什么不是 pause + resume

两次 PUT 是最省事的实现,但对一个「帮我脱困」的按钮是错的:

- resume 那一半失败(节点掉线、两次调用之间权限被撤、面板中途重启),规则就**永久停在暂停** —— 用户点了"重启"结果收获一次故障。批量重启更糟:部分失败会让任意一批规则停在关闭状态。
- 暂停期间端口被释放,可能被自动端口分配抢走。
- 写 `paused` 会重置 `auto_paused`(v1.0.8),破坏"系统暂停 vs 人工暂停"的区分。

重启不携带状态:要么发生,要么没发生。

## 诚实上报,不谎报成功

`restarted` 字段是**真正送达的节点数**,在请求成功的情况下也可能是 **0**(所有节点版本过低或离线)。所以前端的提示是按这个数字走的,**不是按 envelope code** —— 一次什么都没干的重启却报"成功",恰恰藏起了用户唯一需要行动的那种情况。

老节点被归类为「**请先升级节点**」而不是「离线」:它的 socket 是好的,只是干不了这活。节点状态页本来就有一键升级,路径是顺的。

暂停中的规则直接 **400 拒绝**,而不是报个空洞的成功 —— 它在任何节点上都没有 listener,而且用户对暂停规则的真实意图是"启用"。

## 界面

- 每行一个「重启」+ 工具栏「批量重启」,都带二次确认(文案写明**会断开所有连接**);诊断是只读的所以没有确认框
- 暂停中的规则按钮禁用
- 编辑表单加「最大连接数」「自动重启间隔」,前端校验镜像后端的 5 分钟下限
- 这两个字段**只在编辑里出现**:`create_rule_with_guard` 那个原子建规则事务不携带它们,在新建里放出来只会静默丢弃用户填的值

## 浏览器里真跑过

不是只过了 typecheck —— 起了真面板 + vite,在浏览器里验证:

- 点重启 → 确认框出现(文案正确)→ 发出真请求
- 测试规则的分组下没有节点,提示是 **「重启未生效:该规则的入口分组下没有节点」** —— 它**没有**谎报成功 ✅
- 编辑表单读到数据库里的真实值(800 / 10)
- 「最小 5 分钟」校验拦住保存,并且**核对了服务端确实没被写进去**(仍是 10,不是 2)
- 批量重启按钮在选中行时正确出现

另外核对过:控制台那个 duplicate-key 报错是**本来就有的**(把我的 Rules.tsx stash 掉、在未改动的 main 上复现了),不是这个 PR 引入的,也不在本 PR 范围内。

## 验证

- `cargo fmt --check` / `clippy -D warnings` 零告警;Rust 540 测试通过
- 前端 typecheck / lint / 159 测试 / build 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
