### PR TITLE
feat(panel): add scheduled rule restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ independent `v*` / `node-v*` tracks since this release).
   keys its message off that rather than the envelope code — a restart that
   silently did nothing would otherwise be undetectable.
 
+- **Scheduled rule restart.** A rule with `auto_restart_minutes > 0` has its
+  connections dropped on that interval. The `max_connections` cap is the actual
+  fix for connection accumulation; this is the valve for when you'd rather shed
+  than refuse.
+
+  The schedule lives in MEMORY, not the database. Persisting `last_restart_at`
+  would mean every rule whose interval elapsed while the panel was down comes
+  due at once on boot — a panel upgrade would begin by dropping every
+  auto-restart rule's connections simultaneously. In-memory re-bases each timer
+  to "now" on restart; the cost is at most one skipped cycle, which is invisible
+  next to an unscheduled mass disconnect. A rule seen for the first time is
+  baselined, never restarted on the spot.
+
 - **Rule connection controls, storage + API** (no enforcement yet — the node
   half lands separately). Two new per-rule settings, both `0` = off/unlimited so
   an upgrade changes nothing until a rule is explicitly opted in:

--- a/crates/panel/src/main.rs
+++ b/crates/panel/src/main.rs
@@ -100,7 +100,7 @@ async fn main() {
     // layer; the panel may listen on plain HTTP behind Caddy). See
     // api::security_headers for the exact policy.
     let app = api::security_headers::apply_security_headers(app);
-    let app = app.with_state(api::AppState {
+    let state = api::AppState {
         db,
         config: config.clone(),
         release_cache: api::system::ReleaseCache::new(),
@@ -109,7 +109,14 @@ async fn main() {
         geoip_in_flight: std::sync::Arc::new(tokio::sync::Mutex::new(
             std::collections::HashSet::new(),
         )),
-    });
+    };
+
+    // v1.2.0: scheduled rule restarts. Shares the AppState (and therefore the
+    // same node WS registry) with the HTTP handlers, so a scheduled restart goes
+    // out over exactly the same control channel as a manual one.
+    service::auto_restart::spawn(state.clone());
+
+    let app = app.with_state(state);
 
     let addr: SocketAddr = config.listen.parse().expect("Invalid listen address");
     tracing::info!(

--- a/crates/panel/src/service/auto_restart.rs
+++ b/crates/panel/src/service/auto_restart.rs
@@ -1,0 +1,219 @@
+//! v1.2.0: scheduled rule restarts.
+//!
+//! A rule with `auto_restart_minutes > 0` gets its connections dropped and its
+//! listeners rebuilt on that interval. This is the safety valve for rules whose
+//! connections accumulate faster than they drain (the `max_connections` cap is
+//! the actual fix — this is for when you'd rather shed than refuse).
+//!
+//! ## Why the schedule is in memory, not in the database
+//!
+//! The obvious design stores `last_restart_at` per rule. It survives a panel
+//! restart, which sounds good until you consider what "survives" means here: on
+//! boot, every rule whose interval elapsed while the panel was down comes due at
+//! once, and the panel's first act is to drop every connection on every
+//! auto-restart rule simultaneously. A panel restart (an upgrade, a container
+//! reschedule) would become a fleet-wide disconnect.
+//!
+//! Keeping the schedule in memory means a panel restart re-bases every rule's
+//! timer to "now". The cost is that a rule can go up to one extra interval
+//! without a restart across a panel bounce. That is strictly the safer failure:
+//! this feature exists to shed load periodically, and skipping one cycle is
+//! invisible, while an unscheduled mass disconnect is an incident.
+//!
+//! For the same reason a rule seen for the FIRST time is only baselined, never
+//! restarted on the spot — see `tick`.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::api::restart::{dispatch_restart, NodeRestartStatus};
+use crate::api::AppState;
+
+/// How often the scheduler wakes. The finest interval a user can configure is
+/// `MIN_AUTO_RESTART_MINUTES`, so a 60s tick is comfortably precise enough and
+/// costs one indexed query per minute.
+const TICK: Duration = Duration::from_secs(60);
+
+/// Tracks when each rule was last restarted BY THIS SCHEDULER. Keyed by rule_id.
+///
+/// A manual restart deliberately does NOT reset these timers: the two are
+/// independent controls, and letting a manual restart postpone the scheduled one
+/// would make the schedule silently drift by an amount that depends on operator
+/// behaviour.
+type Schedule = HashMap<i64, Instant>;
+
+/// Start the scheduler. Returns immediately; the loop runs until the process
+/// exits.
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move {
+        let mut schedule: Schedule = HashMap::new();
+        let mut ticker = tokio::time::interval(TICK);
+        // Skip missed ticks rather than firing them back-to-back if the loop is
+        // ever delayed — a burst of catch-up ticks would restart rules far more
+        // often than configured.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        tracing::info!("auto-restart scheduler started (tick {}s)", TICK.as_secs());
+        loop {
+            ticker.tick().await;
+            tick(&state, &mut schedule, Instant::now()).await;
+        }
+    });
+}
+
+/// One scheduler pass. Split out from the loop so it is testable without
+/// waiting on wall-clock time (`now` is injected).
+async fn tick(state: &AppState, schedule: &mut Schedule, now: Instant) {
+    let rules = match state.db.list_auto_restart_rules().await {
+        Ok(r) => r,
+        Err(e) => {
+            // Transient DB trouble must not kill the scheduler — skip this tick.
+            tracing::error!("auto-restart: listing rules failed: {}; skipping tick", e);
+            return;
+        }
+    };
+
+    // Forget rules that no longer auto-restart (disabled, paused, or deleted),
+    // so a rule that gets re-enabled later is baselined fresh rather than
+    // immediately restarted against a stale timestamp.
+    let live: std::collections::HashSet<i64> = rules.iter().map(|(id, _, _)| *id).collect();
+    schedule.retain(|rule_id, _| live.contains(rule_id));
+
+    for (rule_id, group_id, minutes) in rules {
+        // Defensive: the API validates this, but a hand-edited DB row must not
+        // turn into a restart-every-tick loop.
+        if minutes < relay_shared::models::MIN_AUTO_RESTART_MINUTES {
+            tracing::warn!(
+                "auto-restart: rule {} has interval {}min below the {}min floor; skipping",
+                rule_id,
+                minutes,
+                relay_shared::models::MIN_AUTO_RESTART_MINUTES
+            );
+            continue;
+        }
+
+        let due_after = Duration::from_secs(minutes as u64 * 60);
+        match schedule.get(&rule_id) {
+            // First sight: baseline only. Restarting here would mean every panel
+            // start drops every auto-restart rule's connections at once.
+            None => {
+                schedule.insert(rule_id, now);
+                tracing::debug!(
+                    "auto-restart: rule {} baselined, first restart in {}min",
+                    rule_id,
+                    minutes
+                );
+            }
+            Some(&last) if now.duration_since(last) >= due_after => {
+                schedule.insert(rule_id, now);
+                let request_id = format!("auto-{}-{}", rule_id, state.config.listen);
+                match dispatch_restart(state, rule_id, group_id, &request_id).await {
+                    Ok(nodes) => {
+                        let reached = nodes
+                            .iter()
+                            .filter(|n| matches!(n, NodeRestartStatus::Restarted { .. }))
+                            .count();
+                        tracing::info!(
+                            "auto-restart: rule {} restarted on {}/{} node(s) (every {}min)",
+                            rule_id,
+                            reached,
+                            nodes.len(),
+                            minutes
+                        );
+                    }
+                    Err(e) => {
+                        // The timer was already advanced, so a failing rule
+                        // retries on its next interval instead of every tick.
+                        tracing::error!("auto-restart: rule {} dispatch failed: {}", rule_id, e);
+                    }
+                }
+            }
+            Some(_) => {} // not due yet
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scheduling decision, isolated from AppState/DB/WS. Mirrors the
+    /// `match` in `tick`: returns whether the rule is due, given its last-seen
+    /// time.
+    fn is_due(schedule: &mut Schedule, rule_id: i64, minutes: i32, now: Instant) -> bool {
+        let due_after = Duration::from_secs(minutes as u64 * 60);
+        match schedule.get(&rule_id) {
+            None => {
+                schedule.insert(rule_id, now);
+                false
+            }
+            Some(&last) if now.duration_since(last) >= due_after => {
+                schedule.insert(rule_id, now);
+                true
+            }
+            Some(_) => false,
+        }
+    }
+
+    /// A rule the scheduler has never seen is BASELINED, not restarted.
+    ///
+    /// This is the property that keeps a panel restart from becoming a fleet
+    /// disconnect: on boot the schedule is empty, so every auto-restart rule
+    /// hits this path at once. If it returned "due", every one of them would
+    /// drop its connections simultaneously.
+    #[test]
+    fn first_sight_baselines_instead_of_restarting() {
+        let mut s = Schedule::new();
+        let t0 = Instant::now();
+        assert!(!is_due(&mut s, 1, 5, t0), "first sight must NOT restart");
+        assert_eq!(s.get(&1), Some(&t0), "first sight must record a baseline");
+    }
+
+    #[test]
+    fn restarts_only_once_the_interval_has_elapsed() {
+        let mut s = Schedule::new();
+        let t0 = Instant::now();
+        is_due(&mut s, 1, 5, t0); // baseline
+
+        assert!(
+            !is_due(&mut s, 1, 5, t0 + Duration::from_secs(4 * 60)),
+            "4min into a 5min interval is not due"
+        );
+        assert!(
+            is_due(&mut s, 1, 5, t0 + Duration::from_secs(5 * 60)),
+            "exactly 5min is due"
+        );
+        // Firing resets the timer — it must not fire again on the next tick.
+        assert!(
+            !is_due(&mut s, 1, 5, t0 + Duration::from_secs(6 * 60)),
+            "must not re-fire one minute after firing"
+        );
+        assert!(
+            is_due(&mut s, 1, 5, t0 + Duration::from_secs(10 * 60)),
+            "due again a full interval after the last fire"
+        );
+    }
+
+    /// A rule that stops auto-restarting is forgotten, so re-enabling it later
+    /// baselines fresh rather than firing immediately off a stale timestamp.
+    #[test]
+    fn disabled_rule_is_forgotten_and_rebaselined_on_return() {
+        let mut s = Schedule::new();
+        let t0 = Instant::now();
+        is_due(&mut s, 1, 5, t0);
+
+        // Rule disappears from the query (disabled/paused/deleted).
+        let live: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        s.retain(|id, _| live.contains(id));
+        assert!(
+            s.is_empty(),
+            "a rule that stopped auto-restarting is dropped"
+        );
+
+        // It comes back much later: must baseline, not fire instantly.
+        let t1 = t0 + Duration::from_secs(60 * 60);
+        assert!(
+            !is_due(&mut s, 1, 5, t1),
+            "a re-enabled rule must baseline, not fire off its stale timestamp"
+        );
+    }
+}

--- a/crates/panel/src/service/mod.rs
+++ b/crates/panel/src/service/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto_restart;
 pub mod groups;
 pub mod node_config;
 pub mod password;


### PR DESCRIPTION
> **Stacked on #67**。完整合并顺序:**#65 → #66 → #67 → 本 PR**。

第 4/4 个 PR:定时自动重启 —— 用户原话里的「**自动**重启规则」那部分。

规则设了 `auto_restart_minutes > 0` 后,面板每隔这么久自动把它的连接全断一次。连接数上限(#65/#66)才是堆积的根治手段,这个是「宁可断也不拒」时的阀门。

复用 #67 的 `dispatch_restart`,所以定时重启和手动重启走**完全相同**的版本门槛和在线检查 —— 不会出现自动重启偷偷干了手动重启不会干的事。

## 核心设计决定:计时表放内存,不落库

直觉做法是给每条规则存 `last_restart_at`,能扛面板重启。听着对,直到你想清楚"扛住"在这里意味着什么:

**面板启动那一刻,所有在停机期间到期的规则会同时到点。面板的第一个动作就是把每条自动重启规则的连接全部同时断掉。** 一次面板升级、一次容器重新调度,就变成一场全机队断连事故。

放内存的话,面板重启会把每条规则的计时**重新基准到"现在"**。代价是跨一次面板重启最多**少重启一轮** —— 这个代价是隐形的,而一次计划外的大规模断连是事故。这是明显更安全的失败方向。

同理:**第一次见到的规则只做基准,绝不当场重启**。面板刚启动时计时表是空的,所有自动重启规则都会走这条路径 —— 如果它返回"到期了",就是全部一起断。`first_sight_baselines_instead_of_restarting` 专门钉死这个属性,注释里写了原因。

## 其他护栏

- **暂停的规则在 SQL 里就排除**:暂停规则在任何节点上都没有 listener,重启它是稳定的 no-op,却仍要每个节点每 tick 付一次 WS 往返,永远付下去。
- **停用自动重启的规则会被遗忘**:之后重新启用时会重新基准,而不是拿着过期时间戳立刻开炮。
- **错过的 tick 跳过、不补**:补 tick 会让重启密度远超配置。
- **5 分钟下限在这里再查一次**:接口已经校验了,但手改数据库的行不能变成每 tick 重启的死循环。
- **数据库出错只跳过本次 tick**,不会把调度器搞死;派发失败等下个间隔重试(计时器已经先推进了),不是每 tick 重试。

## 验证

- `cargo fmt --check` / `clippy -D warnings` 零告警;Rust 543 测试通过
- 调度决策逻辑单测(基准、到期、重复触发、停用后回归)
- `list_auto_restart_rules` 的 SQLite + PG 双实现都有测试(PG 存 `paused` 是真 BOOLEAN,SQLite 是 INTEGER 0/1,两边实现确实不同)
- 真起了面板,确认启动日志:`auto-restart scheduler started (tick 60s)`
- ⚠️ PG 那条测试本地是**跳过**的(没 `TEST_PG_URL`),CI 上才连真库跑

## 🚨 发布时的坑(合并前请确认)

`node_supports_restart_rule` **硬编码了 `>= 1.2.0`** 的节点版本门槛。节点当前是 **1.1.2**。

**发布时节点必须打 `node-v1.2.0` 或更高。** 如果按小版本习惯打成 `node-v1.1.3`,门槛判断会认为**所有节点都不支持**,面板对每个节点返回"版本过低请升级",重启功能**永久不可用** —— 而且升级节点也救不回来,因为版本号永远到不了 1.2.0。

面板侧建议同批发 `v1.2.0`(新特性,minor bump)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
