### PR TITLE
fix(rules): land the restart stack on main + UDP restart / cap fixes

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,6 +11,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`restart_rule` control message.** The panel can ask the node to drop one
+  rule's connections and rebuild its listeners. The node re-creates listeners
+  from its OWN cached config (`ForwarderManager::last_config`), never from
+  anything in the message, so a restart cannot be used to inject listener
+  config. `node_id` is re-checked on arrival as defence in depth even though
+  `send_node` already routed it.
+
+  The WS dispatch arm for this MUST stay above the diagnose arm and MUST check
+  `type`: `DiagnoseRuleMessage` defaults its `challenge` field and ignores
+  unknown fields, so a `restart_rule` payload deserializes into it cleanly
+  (`rule_id` + `request_id` are both present). Ordered after diagnose, every
+  restart would silently become a target probe instead. A test in
+  `relay-shared` pins the ambiguity.
+
+- **Per-rule concurrent TCP connection cap** (`ListenerConfig.max_connections`,
+  None = unlimited). Admission happens in the accept loop, not in the spawned
+  connection task: the accept loop is sequential, so check-then-increment there
+  is exact, whereas incrementing inside the task would let an unbounded number
+  of accepts through before the first increment landed — precisely the
+  connection-flood case the cap exists for. Over the cap, the socket is dropped
+  immediately (the "at cap" warning is rate-limited to once per 60s per
+  listener; a rule sitting at its cap rejects on every accept, and an
+  unthrottled warn would itself become the outage).
+
+  The counter lives per RULE, not per listener: a dual-stack rule runs two
+  accept loops (IPv4 + IPv6), and a per-listener counter would silently grant
+  double the configured cap.
+
+### Fixed
+
+- **Aborting a listener no longer leaves its connections forwarding.**
+  Connections run on detached `tokio::spawn` tasks, so an aborted accept loop
+  stopped new accepts while every established connection kept relaying —
+  verified: a post-abort read/write round-trips fine. Connections now select on
+  a per-rule cancellation channel (`forwarder::gate`). Consequences:
+  - an explicit `restart_rule` genuinely sheds connections rather than just
+    re-binding the port;
+  - a rule removed from the node's config now stops forwarding, instead of
+    relaying bytes for a rule whose traffic counters `apply_config` already
+    pruned.
+
+  `apply_config`'s fingerprint-driven restart (changed targets / rate caps) does
+  NOT cancel: editing a rule must not kick everyone off, which has been the
+  behaviour since v0.3.6.
+
+### Compatibility
+
+- Requires panel **1.2.0+** to be sent `restart_rule` or a connection cap. Both
+  additions are backward compatible on the wire (`#[serde(default)]`), so a
+  1.2.0 node runs against an older panel unchanged — it simply never receives
+  either.
+
 ## [1.1.2] - 2026-07-12
 
 ### Fixed

--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -60,6 +60,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   NOT cancel: editing a rule must not kick everyone off, which has been the
   behaviour since v0.3.6.
 
+- **A UDP-only rule's restart is no longer a silent no-op.** `restart_rule`
+  returned early when the rule had no `RuleRuntime` — but only the TCP arm of
+  `apply_config` creates one (UDP has no `accept()` and no cancellable
+  per-connection tasks), so a UDP-only rule has no runtime while very much
+  having a listener. It was never torn down or rebuilt, and its sessions never
+  dropped. The panel reports success as soon as the command reaches the node, so
+  the operator was told the rule had restarted while nothing happened at all.
+  "No runtime" now means only "no connections to cancel"; whether there are
+  listeners to rebuild is decided separately.
+
 ### Compatibility
 
 - Requires panel **1.2.0+** to be sent `restart_rule` or a connection cap. Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ independent `v*` / `node-v*` tracks since this release).
 
 ### Added
 
+- **Rule restart (manual + batch).** `POST /rules/{id}/restart` drops every
+  connection a rule is currently carrying and rebuilds its listeners on each
+  node of its inbound group. Owner-scoped (a user may restart only their own
+  rules); batch restart is the frontend calling it per rule, matching batch
+  pause/resume, so there is deliberately no bulk endpoint. The rule's `paused`
+  flag is never read or written — a restart is not a state transition. A paused
+  rule is rejected rather than reported as a hollow success: it has no listener
+  to restart, and the user's actual intent there is "resume".
+
+  This is deliberately NOT implemented as pause+resume. That pair leaves the
+  rule PAUSED if the resume half fails (node offline, authorization revoked
+  between the two calls, panel restarted mid-way) — an outage caused by the
+  button whose whole job is to end one. It also frees the listen port for
+  auto-assignment during the gap, and writing `paused` resets `auto_paused`
+  (v1.0.8), corrupting the system-paused vs. human-paused distinction.
+
+  The response's `restarted` field counts nodes ACTUALLY reached and can be 0
+  on an otherwise successful request (every node too old or offline), so the UI
+  keys its message off that rather than the envelope code — a restart that
+  silently did nothing would otherwise be undetectable.
+
 - **Rule connection controls, storage + API** (no enforcement yet — the node
   half lands separately). Two new per-rule settings, both `0` = off/unlimited so
   an upgrade changes nothing until a rule is explicitly opted in:
@@ -31,9 +52,13 @@ independent `v*` / `node-v*` tracks since this release).
   than to 0 — otherwise setting only `max_connections` would silently switch off
   that rule's scheduled restart.
 
-- **`restart_rule` wire message + `node_supports_restart_rule` version gate**
-  (1.2.0+) in `relay-shared`. Nothing sends it yet; the panel endpoint and the
-  node handler land in follow-up PRs.
+### Compatibility
+
+- Nodes below **1.2.0** silently ignore the unknown `restart_rule` message. The
+  panel gates on `node_supports_restart_rule` and surfaces those nodes as
+  "upgrade required" rather than counting them as restarted — a restart that
+  quietly did nothing would be undetectable to the operator. Node Status already
+  offers one-click upgrade.
 
 ### Schema
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ independent `v*` / `node-v*` tracks since this release).
   keys its message off that rather than the envelope code — a restart that
   silently did nothing would otherwise be undetectable.
 
+- **Scheduled rule restart.** A rule with `auto_restart_minutes > 0` has its
+  connections dropped on that interval. The `max_connections` cap is the actual
+  fix for connection accumulation; this is the valve for when you'd rather shed
+  than refuse.
+
+  The schedule lives in MEMORY, not the database. Persisting `last_restart_at`
+  would mean every rule whose interval elapsed while the panel was down comes
+  due at once on boot — a panel upgrade would begin by dropping every
+  auto-restart rule's connections simultaneously. In-memory re-bases each timer
+  to "now" on restart; the cost is at most one skipped cycle, which is invisible
+  next to an unscheduled mass disconnect. A rule seen for the first time is
+  baselined, never restarted on the spot.
+
 - **Rule connection controls, storage + API** (no enforcement yet — the node
   half lands separately). Two new per-rule settings, both `0` = off/unlimited so
   an upgrade changes nothing until a rule is explicitly opted in:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ independent `v*` / `node-v*` tracks since this release).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The connection cap is no longer offered on UDP-only rules.** It is enforced
+  at `accept()`, which UDP doesn't have, so the panel would store the number and
+  ship it to the node where nothing reads it. The field is now disabled for a
+  UDP-only rule with a note saying why; a `tcp_udp` rule keeps it (it governs
+  the TCP half).
+- **Batch restart no longer blames the wrong thing on partial failure.** It
+  reused the batch-resume message ("unauthorized lines can't be resumed"), which
+  has nothing to do with a restart — it now names the real causes (paused rule,
+  or nodes offline / too old).
+
 ### Added
 
 - **Rule restart (manual + batch).** `POST /rules/{id}/restart` drops every

--- a/crates/node/src/forwarder/gate.rs
+++ b/crates/node/src/forwarder/gate.rs
@@ -1,0 +1,271 @@
+//! v1.2.0: per-rule runtime controls — the concurrent-connection cap and the
+//! restart cancellation channel.
+//!
+//! ## Why this state lives per RULE, not per listener
+//!
+//! A single TCP rule binds up to TWO listeners (IPv4 and IPv6, see the
+//! `(Protocol::Tcp, NodeTransport::Raw)` arm in `manager::apply_config`). If the
+//! live-connection counter were owned by a listener, a dual-stack rule would
+//! admit `max_connections` on v4 PLUS `max_connections` on v6 — silently double
+//! the configured cap. The counter therefore hangs off the rule and both
+//! listeners share one `Arc`, exactly like the rule's rate limiter.
+//!
+//! ## Why a cancellation channel is needed at all
+//!
+//! Each accepted connection is driven by a DETACHED `tokio::spawn` task.
+//! Aborting the accept-loop task does NOT cascade to those children: the
+//! listener stops accepting, but every established connection keeps forwarding
+//! (verified empirically — a post-abort read/write round-trips fine). So
+//! "restart a rule" cannot be implemented as abort-and-rebind; that would only
+//! re-bind the port and shed nothing, which is the entire point of the feature.
+//!
+//! Instead every connection task selects on `RuleGate::cancel`. Bumping the
+//! generation via `RuleRuntime::cancel_all` wakes them all, they drop their
+//! sockets, and the peers see the connection close.
+//!
+//! ## Why cancellation is NOT wired into `apply_config`
+//!
+//! A fingerprint change (new targets, new rate cap) tears the listener down and
+//! rebuilds it, but deliberately leaves live connections alone — that has been
+//! the behaviour since v0.3.6 and users rely on editing a rule without kicking
+//! everyone off. Only an EXPLICIT restart cancels. The two paths are separate on
+//! purpose: `apply_config` never touches the generation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// The half of a rule's runtime state handed to its listeners. Cheap to clone;
+/// a rule's v4 and v6 listeners each hold one and they share the same counter
+/// and cancellation channel.
+#[derive(Clone)]
+pub struct RuleGate {
+    /// Concurrent TCP connections allowed for this rule ON THIS NODE. `None` =
+    /// unlimited (the default, and every pre-v1.2 rule after migration).
+    pub max_connections: Option<u32>,
+    /// Live TCP connections for this rule right now. Incremented by
+    /// [`RuleGate::admit`], decremented when the returned guard drops.
+    live: Arc<AtomicU64>,
+    /// Restart signal. The value is a generation counter; any change means
+    /// "drop the connection you are driving".
+    cancel: watch::Receiver<u64>,
+}
+
+impl RuleGate {
+    /// Try to admit one new connection.
+    ///
+    /// Returns `None` when the rule is at its cap — the caller must drop the
+    /// accepted socket immediately. Returns a guard otherwise; hold it for the
+    /// connection's lifetime, and the count decrements however the task ends
+    /// (clean close, error, panic, or restart cancellation).
+    ///
+    /// MUST be called from the accept loop rather than from inside the spawned
+    /// connection task. The accept loop is sequential, so check-then-increment
+    /// here is atomic with respect to other accepts on the same listener; doing
+    /// it inside the task would let an unbounded number of accepts slip through
+    /// before the first increment lands — precisely the connection-flood case
+    /// this cap exists for. (The v4 and v6 accept loops do race each other, but
+    /// `fetch_add`-then-compare below makes the counter exact regardless.)
+    pub fn admit(&self) -> Option<ConnGuard> {
+        let guard = ConnGuard {
+            live: self.live.clone(),
+        };
+        // Increment FIRST, then compare, so two accept loops (v4 + v6) racing on
+        // the same rule can never both observe "one slot left" and both take it.
+        // The guard is already constructed, so an over-cap increment is undone
+        // by dropping it on the reject path.
+        let now = self.live.fetch_add(1, Ordering::AcqRel) + 1;
+        match self.max_connections {
+            Some(cap) if now > cap as u64 => None, // `guard` drops → decrements
+            _ => Some(guard),
+        }
+    }
+
+    /// Live connection count for this rule on this node.
+    pub fn live(&self) -> u64 {
+        self.live.load(Ordering::Relaxed)
+    }
+
+    /// Resolves when this rule is restarted. Connection tasks select on it and
+    /// drop their sockets when it fires.
+    ///
+    /// Also resolves if the sender is gone (the rule was deleted from the
+    /// node's config), which is the right outcome: a deleted rule's traffic can
+    /// no longer be attributed or billed, so its connections must not outlive
+    /// it.
+    pub async fn cancelled(&mut self) {
+        // `changed()` errors only when the sender dropped; treat that as a
+        // cancel rather than parking forever on a dead channel.
+        let _ = self.cancel.changed().await;
+    }
+}
+
+/// A rule's runtime state as the manager owns it. Dropping this cancels every
+/// connection task belonging to the rule (the `watch::Sender` goes away and each
+/// task's `cancelled()` resolves).
+pub struct RuleRuntime {
+    live: Arc<AtomicU64>,
+    cancel: watch::Sender<u64>,
+}
+
+impl RuleRuntime {
+    pub fn new() -> Self {
+        let (cancel, _) = watch::channel(0);
+        Self {
+            live: Arc::new(AtomicU64::new(0)),
+            cancel,
+        }
+    }
+
+    /// Build the listener-side handle. `max_connections` is passed per-spawn
+    /// rather than stored, because it comes from the config being applied and
+    /// changing it restarts the listener anyway (it is part of the fingerprint).
+    pub fn gate(&self, max_connections: Option<u32>) -> RuleGate {
+        RuleGate {
+            max_connections,
+            live: self.live.clone(),
+            cancel: self.cancel.subscribe(),
+        }
+    }
+
+    /// Drop every in-flight connection of this rule. Returns the number of
+    /// connections that were live at the moment of cancellation — they tear
+    /// down asynchronously, so the counter drains shortly after this returns
+    /// rather than being 0 immediately.
+    pub fn cancel_all(&self) -> u64 {
+        let live = self.live.load(Ordering::Relaxed);
+        // send_modify notifies every receiver even with no listeners attached,
+        // and bumping the generation guarantees a value CHANGE (send_if_modified
+        // with an equal value would not wake anyone).
+        self.cancel.send_modify(|generation| *generation += 1);
+        live
+    }
+}
+
+impl Default for RuleRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII: decrements the rule's live-connection count when the connection task
+/// ends, however it ends.
+pub struct ConnGuard {
+    live: Arc<AtomicU64>,
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.live.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The cap admits exactly `max_connections` and rejects the next one; a
+    /// closed connection frees its slot.
+    #[test]
+    fn admit_enforces_cap_and_guard_frees_slot() {
+        let rt = RuleRuntime::new();
+        let gate = rt.gate(Some(2));
+
+        let g1 = gate.admit().expect("1st under cap");
+        let g2 = gate.admit().expect("2nd hits cap exactly, still admitted");
+        assert_eq!(gate.live(), 2);
+
+        assert!(gate.admit().is_none(), "3rd must be rejected at cap 2");
+        // The rejected admit must NOT leak a slot — the count is still 2, not 3.
+        assert_eq!(
+            gate.live(),
+            2,
+            "a rejected admit must not inflate the count"
+        );
+
+        drop(g1);
+        assert_eq!(gate.live(), 1);
+        let _g3 = gate.admit().expect("slot freed by the closed connection");
+        assert_eq!(gate.live(), 2);
+        drop(g2);
+    }
+
+    /// `None` = unlimited. This is the migration default for every existing
+    /// rule, so getting it wrong would cap the whole fleet at zero on upgrade.
+    #[test]
+    fn no_cap_admits_freely() {
+        let rt = RuleRuntime::new();
+        let gate = rt.gate(None);
+        let guards: Vec<_> = (0..1000)
+            .map(|_| gate.admit().expect("unlimited"))
+            .collect();
+        assert_eq!(gate.live(), 1000);
+        drop(guards);
+        assert_eq!(gate.live(), 0);
+    }
+
+    /// The v4 and v6 listeners of one rule share a counter, so a dual-stack
+    /// rule admits `max_connections` IN TOTAL — not that many per family.
+    #[test]
+    fn dual_stack_listeners_share_one_budget() {
+        let rt = RuleRuntime::new();
+        let v4 = rt.gate(Some(3));
+        let v6 = rt.gate(Some(3));
+
+        let _a = v4.admit().expect("v4 #1");
+        let _b = v6.admit().expect("v6 #1");
+        let _c = v4.admit().expect("v4 #2 — 3 total");
+        assert!(
+            v6.admit().is_none(),
+            "the 4th connection must be rejected regardless of family"
+        );
+        assert_eq!(v4.live(), 3);
+    }
+
+    /// cancel_all wakes a task parked on `cancelled()`. This is what makes a
+    /// restart actually shed connections instead of only rebinding the port.
+    #[tokio::test]
+    async fn cancel_all_wakes_connection_tasks() {
+        let rt = RuleRuntime::new();
+        let mut gate = rt.gate(None);
+        let _g = gate.admit().unwrap();
+
+        let waiter = tokio::spawn(async move {
+            gate.cancelled().await;
+            "cancelled"
+        });
+
+        // Nothing has cancelled yet — the task must still be parked.
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished(), "must not fire before cancel_all");
+
+        assert_eq!(rt.cancel_all(), 1, "reports the connections it is dropping");
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("cancelled() must resolve promptly")
+                .unwrap(),
+            "cancelled"
+        );
+    }
+
+    /// A deleted rule (manager drops its RuleRuntime) must also drop its
+    /// connections, not leave them forwarding for a rule that no longer exists.
+    #[tokio::test]
+    async fn dropping_runtime_cancels_connections() {
+        let rt = RuleRuntime::new();
+        let mut gate = rt.gate(None);
+
+        let waiter = tokio::spawn(async move {
+            gate.cancelled().await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(rt);
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("a dropped RuleRuntime must cancel its connections")
+            .unwrap();
+    }
+}

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -767,12 +767,20 @@ impl ForwarderManager {
     /// carries no listener for it and this is a no-op.
     pub async fn restart_rule(&mut self, rule_id: i64) -> (u64, usize) {
         // Cancel first — see the ordering note above.
-        let dropped = match self.rule_runtime.get(&rule_id) {
-            Some(rt) => rt.cancel_all(),
-            // No runtime → the rule has never had a listener here. Nothing to
-            // restart; don't fabricate an empty runtime for it.
-            None => return (0, 0),
-        };
+        //
+        // No runtime is NOT the same as nothing to do: only the TCP arm of
+        // apply_config creates one (UDP has no accept() and no cancellable
+        // per-connection tasks), so a UDP-only rule legitimately has no runtime
+        // while very much having a listener. Treating that as "return early"
+        // made a UDP rule's restart a silent no-op — and silent is the operative
+        // word, because the panel reports success as soon as the command reaches
+        // the node. Whether there are connections to cancel is decided here;
+        // whether there are listeners to rebuild is decided below.
+        let dropped = self
+            .rule_runtime
+            .get(&rule_id)
+            .map(|rt| rt.cancel_all())
+            .unwrap_or(0);
 
         let keys: Vec<ListenerKey> = self
             .listeners
@@ -780,6 +788,12 @@ impl ForwarderManager {
             .filter(|(_, m)| m.fingerprint.rule_id == rule_id)
             .map(|(k, _)| *k)
             .collect();
+
+        // Genuinely nothing here — this node doesn't serve the rule (it may
+        // legitimately span only some of a group's nodes), or it's paused.
+        if keys.is_empty() {
+            return (dropped, 0);
+        }
 
         for key in &keys {
             if let Some(m) = self.listeners.remove(key) {
@@ -1042,6 +1056,51 @@ mod tests {
         assert!(
             mgr.rule_runtime.is_empty(),
             "must not create runtime state for a rule that isn't here"
+        );
+    }
+
+    /// A UDP-only rule must still restart: its listener is torn down and
+    /// rebuilt, which is what drops its sessions (they live in the listener
+    /// task's session map).
+    ///
+    /// Only the TCP arm of apply_config creates a RuleRuntime — UDP has no
+    /// accept() and no cancellable per-connection tasks. So restart_rule must
+    /// NOT treat "no runtime" as "nothing to do": a UDP-only rule has no
+    /// runtime but very much has a listener. Getting this wrong is invisible
+    /// from the panel, which reports success as soon as the command reaches the
+    /// node — the operator would be told the rule restarted while the node did
+    /// nothing at all.
+    #[tokio::test]
+    async fn restart_udp_only_rule_rebuilds_its_listener() {
+        let mut mgr = fresh_mgr();
+        mgr.listen_ipv6 = String::new();
+        let c = cfg(
+            40571,
+            Protocol::Udp,
+            NodeTransport::Raw,
+            vec!["127.0.0.1:9"],
+            None,
+        );
+        mgr.apply_config(&c).await;
+        assert_eq!(
+            mgr.listener_keys().len(),
+            1,
+            "the UDP listener must be running before we restart it"
+        );
+
+        let (dropped, restarted) = mgr.restart_rule(1).await;
+        assert_eq!(
+            restarted, 1,
+            "a UDP-only rule's listener MUST be rebuilt; 0 here means the \
+             restart silently did nothing while the panel reported success"
+        );
+        // UDP sessions aren't individually cancellable — they die with the
+        // listener — so nothing is reported as a dropped connection.
+        assert_eq!(dropped, 0, "UDP has no per-connection tasks to cancel");
+        assert_eq!(
+            mgr.listener_keys().len(),
+            1,
+            "the listener must be back after the restart"
         );
     }
 

--- a/crates/node/src/forwarder/manager.rs
+++ b/crates/node/src/forwarder/manager.rs
@@ -1,3 +1,4 @@
+use super::gate::RuleRuntime;
 use super::limiter::RateLimit;
 use super::selector::TargetSelector;
 use super::tcp;
@@ -63,6 +64,15 @@ struct ListenerFingerprint {
     /// takes effect without a node restart.
     upload_limit_bps: Option<u64>,
     download_limit_bps: Option<u64>,
+    /// v1.2.0: concurrent-connection cap (None = unlimited). The accept loop
+    /// captures this when it spawns, so a change must restart the listener for
+    /// the new cap to apply — same reasoning as the rate caps above.
+    ///
+    /// Note this restart does NOT drop live connections (only an explicit
+    /// `restart_rule` does that), so editing the cap on a busy rule is safe:
+    /// existing connections keep running and the new cap governs admissions
+    /// from that point on. A lowered cap takes effect by attrition.
+    max_connections: Option<u32>,
 }
 
 impl ListenerFingerprint {
@@ -75,6 +85,7 @@ impl ListenerFingerprint {
             node_transport: l.node_transport,
             upload_limit_bps: l.upload_limit_bps,
             download_limit_bps: l.download_limit_bps,
+            max_connections: l.max_connections,
         }
     }
 }
@@ -98,6 +109,20 @@ pub struct ListenerInfo {
 
 pub struct ForwarderManager {
     listeners: HashMap<ListenerKey, ManagedListener>,
+    /// v1.2.0: per-rule runtime state (live-connection counter + restart
+    /// cancellation), keyed by rule_id. Lives HERE rather than in the listener
+    /// because a rule's IPv4 and IPv6 listeners must share one connection
+    /// budget, and because it has to survive the listener being torn down and
+    /// rebuilt by `apply_config` (a config edit must not reset the count while
+    /// the connections it counted are still alive). Entries are dropped when the
+    /// rule leaves the config, which cancels its connections — see `gate.rs`.
+    rule_runtime: HashMap<i64, RuleRuntime>,
+    /// v1.2.0: the most recent config, kept so `restart_rule` can rebuild a
+    /// rule's listeners without asking the panel for the config again. A restart
+    /// must be able to run while the control channel is busy, and re-fetching
+    /// would also let a config change ride in on what the operator asked to be a
+    /// pure restart.
+    last_config: Option<NodeConfigResponse>,
     counter: Arc<TrafficCounter>,
     connections: Arc<ConnectionTracker>,
     /// Bind/runtime errors captured from spawned listener tasks since the last
@@ -118,6 +143,8 @@ impl ForwarderManager {
     pub fn new(counter: Arc<TrafficCounter>, connections: Arc<ConnectionTracker>) -> Self {
         Self {
             listeners: HashMap::new(),
+            rule_runtime: HashMap::new(),
+            last_config: None,
             counter,
             connections,
             listener_errors: Arc::new(Mutex::new(Vec::new())),
@@ -474,6 +501,15 @@ impl ForwarderManager {
                     let cn = connections.clone();
                     let rid = rule_id;
                     let ipv4_src = src_ipv4;
+                    // v1.2.0: both families get a gate cloned from the SAME
+                    // RuleRuntime, so `max_connections` is a per-rule total
+                    // rather than a per-family allowance.
+                    let gate4 = self
+                        .rule_runtime
+                        .entry(rule_id)
+                        .or_default()
+                        .gate(listener.max_connections);
+                    let gate6 = gate4.clone();
                     tokio::spawn(async move {
                         type SrvResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
                         let (tgt4, sel4, rl4, ctr4, cn4) = (
@@ -486,7 +522,7 @@ impl ForwarderManager {
                         let v4_fut = async move {
                             if let Some(l) = v4_listener {
                                 tcp::serve_tcp_listener(
-                                    l, tgt4, sel4, rl4, ctr4, cn4, rid, ipv4_src,
+                                    l, tgt4, sel4, rl4, ctr4, cn4, rid, ipv4_src, gate4,
                                 )
                                 .await
                             } else {
@@ -495,8 +531,10 @@ impl ForwarderManager {
                         };
                         let v6_fut = async move {
                             if let Some(l) = v6_listener {
-                                tcp::serve_tcp_listener(l, tgt, sel, rl, ctr, cn, rid, ipv4_src)
-                                    .await
+                                tcp::serve_tcp_listener(
+                                    l, tgt, sel, rl, ctr, cn, rid, ipv4_src, gate6,
+                                )
+                                .await
                             } else {
                                 std::future::pending::<SrvResult>().await
                             }
@@ -695,6 +733,93 @@ impl ForwarderManager {
                 },
             );
         }
+
+        // ── Step 5: forget rules that are gone ──
+        // v1.2.0: dropping a rule's RuleRuntime drops its watch::Sender, which
+        // cancels any connection still forwarding for it. That is deliberate: a
+        // rule removed from the config can no longer have its traffic attributed
+        // or billed (step 2/3 already pruned its counters), so letting its
+        // connections outlive it would forward bytes nobody accounts for.
+        self.rule_runtime
+            .retain(|rule_id, _| desired_rule_ids.contains(rule_id));
+
+        // v1.2.0: remember the applied config so restart_rule can rebuild a
+        // rule's listeners from it without a round-trip to the panel.
+        self.last_config = Some(config.clone());
+    }
+
+    /// v1.2.0: restart ONE rule — drop every connection it is currently
+    /// forwarding, then rebuild its listeners from the last applied config.
+    ///
+    /// Returns `(connections_dropped, listeners_restarted)`. A rule with no
+    /// listeners on this node returns `(0, 0)`; the caller reports that as
+    /// "nothing to do here" rather than an error, because a rule legitimately
+    /// spans only some of a group's nodes.
+    ///
+    /// Order matters. Connections are cancelled BEFORE the listeners are torn
+    /// down and rebuilt: the connection tasks are detached, so tearing the
+    /// listener down first would rebind the port while the old connections kept
+    /// forwarding — the exact no-op this command exists to avoid.
+    ///
+    /// The rule's `paused` state is never consulted or written here. A restart
+    /// is not a state transition: it re-creates whatever the current config
+    /// says should be running. If the panel has paused the rule, the config
+    /// carries no listener for it and this is a no-op.
+    pub async fn restart_rule(&mut self, rule_id: i64) -> (u64, usize) {
+        // Cancel first — see the ordering note above.
+        let dropped = match self.rule_runtime.get(&rule_id) {
+            Some(rt) => rt.cancel_all(),
+            // No runtime → the rule has never had a listener here. Nothing to
+            // restart; don't fabricate an empty runtime for it.
+            None => return (0, 0),
+        };
+
+        let keys: Vec<ListenerKey> = self
+            .listeners
+            .iter()
+            .filter(|(_, m)| m.fingerprint.rule_id == rule_id)
+            .map(|(k, _)| *k)
+            .collect();
+
+        for key in &keys {
+            if let Some(m) = self.listeners.remove(key) {
+                let handle = m.handle;
+                handle.abort();
+                // Await the aborted task so the OS releases the listen socket
+                // before the rebuild re-binds the same port — without this the
+                // bind races teardown and fails with "address already in use".
+                // (Same reason as the equivalent await in apply_config.)
+                let _ = (&mut { handle }).await;
+            }
+        }
+
+        let restarted = keys.len();
+        if restarted > 0 {
+            // Rebuild from the cached config. apply_config re-creates exactly
+            // the listeners we just removed (every other listener still matches
+            // its fingerprint and is skipped), and it reuses this rule's
+            // existing RuleRuntime, so the live counter stays consistent with
+            // the connections that survive — there are none, we just cancelled
+            // them all.
+            if let Some(cfg) = self.last_config.clone() {
+                self.apply_config(&cfg).await;
+            } else {
+                tracing::warn!(
+                    "rule {}: restart tore down {} listener(s) but no cached config exists \
+                     to rebuild from; the next config push will restore them",
+                    rule_id,
+                    restarted
+                );
+            }
+        }
+
+        tracing::info!(
+            "rule {}: restarted — dropped {} connection(s), rebuilt {} listener(s)",
+            rule_id,
+            dropped,
+            restarted
+        );
+        (dropped, restarted)
     }
 }
 
@@ -704,6 +829,7 @@ mod tests {
     use crate::reporter::{ConnectionTracker, TrafficCounter};
     use relay_shared::protocol::{ListenerConfig, NodeConfigResponse, NodeTransport, Protocol};
     use std::sync::Arc;
+    use std::time::Duration;
 
     impl ForwarderManager {
         /// Test-only accessor: the set of listener keys currently registered.
@@ -791,6 +917,169 @@ mod tests {
         let down_limited = ListenerFingerprint::from_listener(&l);
         assert_ne!(up_limited, down_limited);
         assert_ne!(unlimited, down_limited);
+    }
+
+    /// v1.2.0: a connection-cap change must restart the listener, for the same
+    /// reason a rate-limit change must — the accept loop captures the cap when
+    /// it spawns.
+    #[test]
+    fn max_connections_change_alters_fingerprint() {
+        let mut l = one_rule(40051, Protocol::Tcp, NodeTransport::Raw)
+            .listeners
+            .pop()
+            .unwrap();
+        let uncapped = ListenerFingerprint::from_listener(&l);
+
+        l.max_connections = Some(100);
+        let capped = ListenerFingerprint::from_listener(&l);
+        assert_ne!(
+            uncapped, capped,
+            "setting a connection cap must change the fingerprint"
+        );
+
+        l.max_connections = Some(200);
+        assert_ne!(
+            capped,
+            ListenerFingerprint::from_listener(&l),
+            "raising the cap must also change the fingerprint"
+        );
+    }
+
+    /// Spawn an echo server and return its address. Used by the restart tests to
+    /// prove a forwarded connection is really carrying data.
+    async fn echo_target() -> SocketAddr {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = l.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut s, _)) = l.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut b = [0u8; 256];
+                    loop {
+                        match s.read(&mut b).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => {
+                                if s.write_all(&b[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    /// THE test for the restart feature: a live connection must actually be
+    /// dropped, and the listener must come back up.
+    ///
+    /// This is not a formality. Connection tasks are detached `tokio::spawn`s,
+    /// so the intuitive implementation (abort the listener, re-bind) leaves
+    /// every established connection forwarding — the port gets rebound and not
+    /// one connection is shed, which is the whole point of the feature. If this
+    /// test regresses to "connection still alive", the restart is a placebo.
+    #[tokio::test]
+    async fn restart_rule_drops_live_connections_and_rebuilds_listener() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let target = echo_target().await;
+        let mut mgr = fresh_mgr();
+        mgr.listen_ipv6 = String::new(); // IPv4-only keeps the assertions simple.
+        let port = 40561;
+        let c = cfg(
+            port,
+            Protocol::Tcp,
+            NodeTransport::Raw,
+            vec![&target.to_string()],
+            None,
+        );
+        mgr.apply_config(&c).await;
+
+        // Establish a connection and prove it forwards.
+        let mut client = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("listener must be up");
+        client.write_all(b"before").await.unwrap();
+        let mut buf = [0u8; 64];
+        let n = client.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"before", "the rule must forward before restart");
+
+        let (dropped, restarted) = mgr.restart_rule(1).await;
+        assert_eq!(dropped, 1, "the one live connection must be counted");
+        assert_eq!(restarted, 1, "the rule's single TCP listener must rebuild");
+
+        // The OLD connection must now be dead. Read returns EOF (or errors) —
+        // anything that echoes here means the restart shed nothing.
+        let r = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf)).await;
+        match r {
+            Ok(Ok(0)) | Ok(Err(_)) => {}
+            Ok(Ok(n)) => panic!(
+                "restart did NOT drop the connection — it echoed {:?}",
+                String::from_utf8_lossy(&buf[..n])
+            ),
+            Err(_) => panic!("restart did NOT drop the connection — the read is still hanging"),
+        }
+
+        // ...and the listener must be serving again, on the same port.
+        let mut fresh = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("listener must be re-bound after restart");
+        fresh.write_all(b"after").await.unwrap();
+        let n = fresh.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"after", "the rebuilt listener must forward");
+    }
+
+    /// Restarting a rule this node doesn't serve is a no-op, not a panic or a
+    /// fabricated runtime entry — a rule legitimately spans only some nodes.
+    #[tokio::test]
+    async fn restart_unknown_rule_is_a_noop() {
+        let mut mgr = fresh_mgr();
+        assert_eq!(mgr.restart_rule(999).await, (0, 0));
+        assert!(
+            mgr.rule_runtime.is_empty(),
+            "must not create runtime state for a rule that isn't here"
+        );
+    }
+
+    /// The cap must survive an unrelated config push. apply_config rebuilds its
+    /// local limiter map each run; if the connection counter were rebuilt the
+    /// same way, every config edit would reset the count to 0 while the counted
+    /// connections were still alive, and the cap would over-admit.
+    #[tokio::test]
+    async fn rule_runtime_survives_apply_and_is_dropped_with_the_rule() {
+        let mut mgr = fresh_mgr();
+        mgr.listen_ipv6 = String::new();
+        let c = cfg(
+            40562,
+            Protocol::Tcp,
+            NodeTransport::Raw,
+            vec!["127.0.0.1:1"],
+            None,
+        );
+        mgr.apply_config(&c).await;
+        assert!(
+            mgr.rule_runtime.contains_key(&1),
+            "runtime created on apply"
+        );
+
+        // Re-applying the identical config must not disturb the runtime.
+        mgr.apply_config(&c).await;
+        assert!(
+            mgr.rule_runtime.contains_key(&1),
+            "an unchanged apply must keep the rule's runtime"
+        );
+
+        // Removing the rule drops its runtime (which cancels its connections).
+        mgr.apply_config(&NodeConfigResponse { listeners: vec![] })
+            .await;
+        assert!(
+            !mgr.rule_runtime.contains_key(&1),
+            "a removed rule must not leak its runtime"
+        );
     }
 
     #[tokio::test]
@@ -1217,6 +1506,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );
@@ -1276,6 +1566,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );
@@ -1291,6 +1582,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );
@@ -1329,6 +1621,7 @@ mod tests {
                     node_transport: NodeTransport::Raw,
                     upload_limit_bps: None,
                     download_limit_bps: None,
+                    max_connections: None,
                 },
             },
         );

--- a/crates/node/src/forwarder/mod.rs
+++ b/crates/node/src/forwarder/mod.rs
@@ -1,4 +1,5 @@
 pub mod cert_reloader;
+pub mod gate;
 pub mod limiter;
 pub mod manager;
 pub mod outbound;

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -4,13 +4,24 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
+use super::gate::RuleGate;
 use super::limiter::RateLimit;
 use super::selector::TargetSelector;
 use crate::reporter::{ConnectionTracker, TrafficCounter};
 
+/// v1.2.0: how often the "rule is at its connection cap" warning may be logged
+/// per listener. A rule sitting at its cap rejects on EVERY accept, so an
+/// unthrottled warn! here would itself become the outage (disk + CPU) that the
+/// cap exists to prevent.
+const CAP_WARN_INTERVAL: Duration = Duration::from_secs(60);
+
 /// v1.0.4: serve an ALREADY-BOUND TcpListener. Binding happens in the manager
 /// (synchronously, so errors surface immediately and per-family success is
 /// known). This function only runs the accept loop.
+///
+/// v1.2.0: `gate` carries the rule's connection cap and its restart
+/// cancellation. It is cloned from the rule's `RuleRuntime`, so the rule's IPv4
+/// and IPv6 listeners share one connection budget and one cancel signal.
 #[allow(clippy::too_many_arguments)]
 pub async fn serve_tcp_listener(
     listener: TcpListener,
@@ -21,6 +32,7 @@ pub async fn serve_tcp_listener(
     connections: Arc<ConnectionTracker>,
     rule_id: i64,
     source_ipv4: Option<Ipv4Addr>,
+    gate: RuleGate,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let listen_addr = listener
         .local_addr()
@@ -32,9 +44,37 @@ pub async fn serve_tcp_listener(
     // whole listener task, leaving the port dead until node restart. Now we
     // classify the error: transient -> back off and retry; the listener stays
     // up. A non-transient error (e.g. the listener was closed) ends the task.
+    let mut last_cap_warn: Option<std::time::Instant> = None;
     loop {
         match listener.accept().await {
             Ok((inbound, client_addr)) => {
+                // v1.2.0: admit against the rule's connection cap BEFORE doing
+                // any further work. `admit` is called here, in the sequential
+                // accept loop, rather than inside the spawned task below — if the
+                // count were incremented in the task, an inbound flood would let
+                // an unbounded number of accepts through before the first
+                // increment landed, which is exactly the case the cap is for.
+                let Some(conn_guard) = gate.admit() else {
+                    // At cap: close immediately. We accept-then-drop rather than
+                    // stop accepting, because leaving connections in the kernel's
+                    // backlog would stall the queue and make the client hang
+                    // instead of failing fast and retrying elsewhere.
+                    drop(inbound);
+                    let now = std::time::Instant::now();
+                    if last_cap_warn.is_none_or(|t| now.duration_since(t) >= CAP_WARN_INTERVAL) {
+                        last_cap_warn = Some(now);
+                        tracing::warn!(
+                            "TCP rule {}: at connection cap ({} live / {} max), rejecting new \
+                             connections (latest from {}); rate-limited to once per {}s",
+                            rule_id,
+                            gate.live(),
+                            gate.max_connections.unwrap_or(0),
+                            client_addr,
+                            CAP_WARN_INTERVAL.as_secs()
+                        );
+                    }
+                    continue;
+                };
                 // v1.0.8: disable Nagle on the accepted (client-facing) socket.
                 // See the note in outbound::tcp_connect — a relay MUST set
                 // TCP_NODELAY on both ends or small packets get buffered ~40ms
@@ -56,25 +96,45 @@ pub async fn serve_tcp_listener(
                 let rate_limit = rate_limit.clone();
                 let counter = counter.clone();
                 let connections = connections.clone();
+                let mut gate = gate.clone();
 
                 tokio::spawn(async move {
                     // RAII guard: increments the active-TCP count on create,
                     // decrements on drop (end of task — normal close, error, or
                     // panic). Guarantees the count is correct even on abrupt close.
                     let _guard = connections.tcp_handle();
-                    if let Err(e) = handle_tcp_connection(
-                        inbound,
-                        client_addr,
-                        targets,
-                        selector,
-                        rate_limit,
-                        counter,
-                        rule_id,
-                        source_ipv4,
-                    )
-                    .await
-                    {
-                        tracing::debug!("TCP connection error: {}", e);
+                    // v1.2.0: holds this connection's slot in the rule's cap;
+                    // drops with the task however it ends, including when the
+                    // select! below takes the cancellation branch.
+                    let _conn_guard = conn_guard;
+                    // v1.2.0: this task is DETACHED — aborting the accept loop
+                    // does not stop it (verified: an established connection keeps
+                    // forwarding after the listener task is aborted). So a rule
+                    // restart cannot work by killing the listener; it fires this
+                    // cancellation instead, and dropping the handle_tcp_connection
+                    // future here closes both sockets.
+                    tokio::select! {
+                        _ = gate.cancelled() => {
+                            tracing::debug!(
+                                "TCP rule {}: dropping connection from {} (rule restarted)",
+                                rule_id,
+                                client_addr
+                            );
+                        }
+                        r = handle_tcp_connection(
+                            inbound,
+                            client_addr,
+                            targets,
+                            selector,
+                            rate_limit,
+                            counter,
+                            rule_id,
+                            source_ipv4,
+                        ) => {
+                            if let Err(e) = r {
+                                tracing::debug!("TCP connection error: {}", e);
+                            }
+                        }
                     }
                 });
             }
@@ -303,6 +363,7 @@ mod tests {
         let selector = Arc::new(TargetSelector::new(LoadBalanceStrategy::First, 1));
         let counter = Arc::new(TrafficCounter::new());
         let connections = Arc::new(ConnectionTracker::new());
+        let runtime = crate::forwarder::gate::RuleRuntime::new();
         tokio::spawn(serve_tcp_listener(
             listener,
             vec![target_addr.to_string()],
@@ -312,7 +373,11 @@ mod tests {
             connections,
             1,
             None,
+            runtime.gate(None),
         ));
+        // Keep the runtime alive for the duration of the test: dropping it would
+        // cancel the connection we are about to make.
+        let _runtime = runtime;
 
         // Client connects to the relay and round-trips through to the echo.
         let mut client = TcpStream::connect(listen_addr).await.unwrap();
@@ -327,5 +392,91 @@ mod tests {
             b"ping-through-relay",
             "relay must echo the target"
         );
+    }
+
+    /// v1.2.0: the cap is enforced at accept. Connections up to the cap forward
+    /// normally; the one over it is closed immediately rather than queued, so a
+    /// client fails fast instead of hanging.
+    #[tokio::test]
+    async fn accept_loop_rejects_over_the_connection_cap() {
+        // Echo target that serves many connections concurrently.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut s, _)) = target.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut b = [0u8; 64];
+                    loop {
+                        match s.read(&mut b).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => {
+                                if s.write_all(&b[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        let listener = bind_tcp_listener(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+        let runtime = crate::forwarder::gate::RuleRuntime::new();
+        tokio::spawn(serve_tcp_listener(
+            listener,
+            vec![target_addr.to_string()],
+            Arc::new(TargetSelector::new(LoadBalanceStrategy::First, 1)),
+            RateLimit::Unlimited,
+            Arc::new(TrafficCounter::new()),
+            Arc::new(ConnectionTracker::new()),
+            1,
+            None,
+            runtime.gate(Some(2)),
+        ));
+        let _runtime = runtime;
+
+        // Two connections fit under the cap and must both forward.
+        let mut a = TcpStream::connect(listen_addr).await.unwrap();
+        a.write_all(b"a").await.unwrap();
+        let mut buf = [0u8; 16];
+        assert_eq!(a.read(&mut buf).await.unwrap(), 1, "conn 1 must forward");
+
+        let mut b = TcpStream::connect(listen_addr).await.unwrap();
+        b.write_all(b"b").await.unwrap();
+        assert_eq!(b.read(&mut buf).await.unwrap(), 1, "conn 2 must forward");
+
+        // The third is over the cap. The TCP handshake still completes (the
+        // kernel accepts it, then we close), so the rejection shows up as EOF on
+        // read rather than a connect error.
+        let mut c = TcpStream::connect(listen_addr).await.unwrap();
+        let _ = c.write_all(b"c").await;
+        match tokio::time::timeout(Duration::from_secs(2), c.read(&mut buf)).await {
+            Ok(Ok(0)) | Ok(Err(_)) => {}
+            Ok(Ok(n)) => panic!(
+                "over-cap connection was served — echoed {:?}",
+                String::from_utf8_lossy(&buf[..n])
+            ),
+            Err(_) => panic!("over-cap connection hung instead of being closed"),
+        }
+
+        // Closing one frees its slot, and a new connection is admitted again.
+        drop(a);
+        // Give the closed connection's task a moment to drop its guard.
+        for _ in 0..50 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let mut d = TcpStream::connect(listen_addr).await.unwrap();
+            if d.write_all(b"d").await.is_ok() {
+                if let Ok(Ok(1)) =
+                    tokio::time::timeout(Duration::from_millis(200), d.read(&mut buf)).await
+                {
+                    return; // slot was freed and reused — done.
+                }
+            }
+        }
+        panic!("a freed slot was never reused — the guard did not release the cap");
     }
 }

--- a/crates/node/src/ws_client.rs
+++ b/crates/node/src/ws_client.rs
@@ -266,6 +266,51 @@ async fn connect_and_run(
                                 }
                             }
                             return WsExit::ConfigChanged;
+                        } else if let Some(rm) =
+                            serde_json::from_str::<relay_shared::protocol::RestartRuleMessage>(&text)
+                                .ok()
+                                .filter(|rm| rm.msg_type == "restart_rule")
+                        {
+                            // v1.2.0: restart ONE rule's listeners and drop its
+                            // connections.
+                            //
+                            // This arm MUST stay ABOVE the diagnose arm, and MUST
+                            // check msg_type. DiagnoseRuleMessage defaults its
+                            // `challenge` field and ignores unknown fields, so a
+                            // restart_rule payload deserializes into it cleanly
+                            // (rule_id + request_id are both present) — order it
+                            // after diagnose and every restart silently becomes a
+                            // target probe instead.
+                            //
+                            // send_node already routed this to us; re-check as
+                            // defence in depth (same as upgrade_node below).
+                            if rm.node_id != node_id {
+                                tracing::warn!(
+                                    "websocket: ignoring restart of rule {} for node {} (I am {})",
+                                    rm.rule_id,
+                                    rm.node_id,
+                                    node_id
+                                );
+                            } else {
+                                tracing::info!(
+                                    "websocket: restart_rule request_id={} rule_id={}",
+                                    rm.request_id,
+                                    rm.rule_id
+                                );
+                                // Held across the restart: apply_config takes the
+                                // same lock, so a concurrent config push cannot
+                                // interleave with the teardown/rebuild.
+                                let mut mgr = manager.lock().await;
+                                let (dropped, restarted) = mgr.restart_rule(rm.rule_id).await;
+                                tracing::info!(
+                                    "websocket: restart_rule request_id={} rule_id={} done \
+                                     ({} connection(s) dropped, {} listener(s) rebuilt)",
+                                    rm.request_id,
+                                    rm.rule_id,
+                                    dropped,
+                                    restarted
+                                );
+                            }
                         } else if let Ok(dm) =
                             serde_json::from_str::<relay_shared::protocol::DiagnoseRuleMessage>(&text)
                         {

--- a/crates/panel/src/api/diagnose.rs
+++ b/crates/panel/src/api/diagnose.rs
@@ -233,11 +233,15 @@ pub struct DiagnoseResponse {
 /// A node's status row from kvs, parsed for diagnosis scheduling. v0.4.15:
 /// carries group_name + public_ip so each NodeDiagnoseStatus can show
 /// "分组名 · 公网IP" without exposing the raw node_id as the label.
-struct NodeStatusRow {
-    node_id: String,
-    node_version: Option<String>,
-    public_ip: Option<String>,
-    group_name: String,
+/// v1.2.0: `pub(crate)` so `api::restart` can reuse the same node enumeration.
+/// Restart and diagnose both need "the nodes of this rule's inbound group, with
+/// their versions", and duplicating that logic would let the two drift apart on
+/// which nodes are considered live.
+pub(crate) struct NodeStatusRow {
+    pub(crate) node_id: String,
+    pub(crate) node_version: Option<String>,
+    pub(crate) public_ip: Option<String>,
+    pub(crate) group_name: String,
 }
 
 /// POST /api/v1/rules/{id}/diagnose — start a diagnosis run for a rule.
@@ -617,7 +621,7 @@ pub async fn receive_diagnose_result(
 /// `group_name` is passed in by the caller (which has already loaded the group)
 /// and attached to each row; `public_ip` is read from the status JSON for
 /// display. No extra DB lookup here.
-async fn group_node_statuses(
+pub(crate) async fn group_node_statuses(
     state: &AppState,
     group_id: i64,
     group_name: String,

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod geoip;
 pub mod groups;
 pub mod middleware;
 pub mod node;
+pub mod restart;
 pub mod security_headers;
 pub mod stats;
 pub mod system;
@@ -90,6 +91,14 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/rules/{id}/diagnose",
             axum::routing::post(diagnose::diagnose_rule),
+        )
+        // v1.2.0: drop a rule's live connections and rebuild its listeners.
+        // Owner-scoped like diagnose — a user may restart only their own rules.
+        // Batch restart is the frontend calling this per rule (same shape as
+        // batch pause/resume), so there is deliberately no /rules/restart.
+        .route(
+            "/rules/{id}/restart",
+            axum::routing::post(restart::restart_rule),
         )
         // v0.4.12: device groups are admin-only shared infrastructure again.
         // Writes use the AdminOnly guard; the service layer operates with

--- a/crates/panel/src/api/restart.rs
+++ b/crates/panel/src/api/restart.rs
@@ -1,0 +1,257 @@
+//! v1.2.0: manual rule restart — drop a rule's live connections and rebuild its
+//! listeners on every node of its inbound group.
+//!
+//! ## Why this is not pause + resume
+//!
+//! The obvious implementation is two writes: `paused = true`, then
+//! `paused = false`. It needs no new protocol, but it is wrong for a button
+//! whose entire job is "get me unstuck":
+//!
+//! - If the resume half fails (node offline, authorization revoked between the
+//!   two calls, panel restarted mid-way), the rule is left PAUSED. The user
+//!   clicked "restart" and got an outage. Batch restart makes this worse: a
+//!   partial failure strands an arbitrary subset of rules off.
+//! - The port is released while paused, so auto-assignment can hand it to
+//!   another rule in the gap.
+//! - It writes `paused`, which resets `auto_paused` (v1.0.8) and so corrupts
+//!   the system-paused vs. human-paused distinction.
+//!
+//! A restart carries no state instead: it either happens or it doesn't, and the
+//! rule's stored fields are never touched.
+//!
+//! ## Old nodes
+//!
+//! A node below `node_supports_restart_rule` silently ignores the unknown WS
+//! message. Reporting those as restarted would be a lie the user can't detect,
+//! so they are surfaced explicitly as "upgrade this node" — the Node Status page
+//! already offers one-click upgrade.
+
+use axum::extract::{Path, State};
+use axum::Json;
+use relay_shared::protocol::{node_supports_restart_rule, ApiResponse, RestartRuleMessage};
+use serde::Serialize;
+
+use crate::api::diagnose::group_node_statuses;
+use crate::api::middleware::AuthUser;
+use crate::api::AppState;
+use crate::db::repo::ResourceScope;
+
+/// One node's outcome for a restart request.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum NodeRestartStatus {
+    /// The restart command reached this node's live control channel.
+    Restarted {
+        node_id: String,
+        group_name: String,
+        public_ip: Option<String>,
+    },
+    /// The node is too old to understand `restart_rule`. It would ignore the
+    /// message, so we do NOT send it and tell the operator to upgrade instead.
+    Unsupported {
+        node_id: String,
+        group_name: String,
+        public_ip: Option<String>,
+        node_version: Option<String>,
+    },
+    /// No live WS connection (or it dropped between the check and the send).
+    ControlChannelOffline {
+        node_id: String,
+        group_name: String,
+        public_ip: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub struct RestartResponse {
+    pub rule_id: i64,
+    /// How many nodes actually received the command. The frontend keys its
+    /// success/warning message off this rather than off the HTTP status: a
+    /// request can succeed while restarting nothing (every node old or offline).
+    pub restarted: usize,
+    pub nodes: Vec<NodeRestartStatus>,
+}
+
+/// Send `restart_rule` for `rule_id` to every eligible node of `group_id`.
+///
+/// Shared by the HTTP handler and the auto-restart scheduler so both apply the
+/// same version gate and the same online check — a scheduled restart must not
+/// quietly do something a manual one wouldn't.
+///
+/// `request_id` only correlates panel logs with node logs; nothing is sent back
+/// over the wire. A restart is fire-and-forget by design: the node's work is
+/// local and bounded (cancel connections, rebind), and making the HTTP call wait
+/// for confirmation from every node would hold a request open on the slowest
+/// node for no decision the caller can act on.
+pub(crate) async fn dispatch_restart(
+    state: &AppState,
+    rule_id: i64,
+    group_id: i64,
+    request_id: &str,
+) -> Result<Vec<NodeRestartStatus>, crate::db::error::DbError> {
+    // ResourceScope::All: the group is shared infrastructure and the caller's
+    // ownership of the RULE was already checked. Scoping this lookup to the
+    // caller would make a regular user's restart fail on an admin-owned group.
+    let group_name = crate::db::repo::GroupRepository::find_by_id(
+        state.db.as_ref(),
+        group_id,
+        &ResourceScope::All,
+    )
+    .await
+    .ok()
+    .flatten()
+    .map(|g| g.name)
+    .unwrap_or_else(|| format!("#{group_id}"));
+
+    let nodes = group_node_statuses(state, group_id, group_name).await?;
+    let online = state.node_connections.online_node_ids(group_id).await;
+
+    let msg_for = |node_id: &str| {
+        serde_json::to_string(&RestartRuleMessage::new(
+            node_id.to_string(),
+            rule_id,
+            request_id.to_string(),
+        ))
+        .unwrap_or_default()
+    };
+
+    let mut out = Vec::with_capacity(nodes.len());
+    for n in &nodes {
+        // Version FIRST, then liveness — mirrors the diagnose classifier. An old
+        // node with a healthy socket must read as "upgrade me", not "offline":
+        // the socket is fine, the node just can't do this.
+        if !node_supports_restart_rule(n.node_version.as_deref()) {
+            out.push(NodeRestartStatus::Unsupported {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+                node_version: n.node_version.clone(),
+            });
+            continue;
+        }
+        if !online.contains(&n.node_id) {
+            out.push(NodeRestartStatus::ControlChannelOffline {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+            });
+            continue;
+        }
+        // send_node returns the number of live connections it reached; 0 means
+        // the WS dropped between the online check above and here.
+        if state
+            .node_connections
+            .send_node(group_id, &n.node_id, &msg_for(&n.node_id))
+            .await
+            > 0
+        {
+            out.push(NodeRestartStatus::Restarted {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+            });
+        } else {
+            out.push(NodeRestartStatus::ControlChannelOffline {
+                node_id: n.node_id.clone(),
+                group_name: n.group_name.clone(),
+                public_ip: n.public_ip.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// POST /api/v1/rules/{id}/restart — drop the rule's connections and rebuild its
+/// listeners.
+///
+/// Owner-scoped: a regular user may restart only their own rules (the scope
+/// folds `uid = ?` into the lookup, so someone else's rule_id is a uniform 404).
+/// Admins are unscoped.
+pub async fn restart_rule(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(rule_id): Path<i64>,
+) -> Json<ApiResponse<RestartResponse>> {
+    let scope = user.resource_scope();
+    tracing::info!(
+        action = "restart_rule",
+        rule_id = rule_id,
+        actor_id = user.user_id,
+        actor_admin = user.admin,
+        "rule restart requested"
+    );
+
+    let rule = match state.db.find_rule_by_id(rule_id, &scope).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return Json(ApiResponse {
+                code: 404,
+                message: "Rule not found".into(),
+                data: None,
+            })
+        }
+        Err(e) => {
+            tracing::error!("restart_rule {}: find_rule_by_id failed: {}", rule_id, e);
+            return Json(ApiResponse {
+                code: 500,
+                message: "database error".into(),
+                data: None,
+            });
+        }
+    };
+
+    // A paused rule has no listener on any node, so a restart is a guaranteed
+    // no-op. Reject rather than report a hollow success — the user's actual
+    // intent for a paused rule is "resume", which is a different button.
+    if rule.paused {
+        return Json(ApiResponse {
+            code: 400,
+            message: "规则已暂停，无需重启（启用后才有连接）".into(),
+            data: None,
+        });
+    }
+
+    let request_id = uuid_like_id();
+    let nodes = match dispatch_restart(&state, rule_id, rule.device_group_in, &request_id).await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!("restart_rule {}: dispatch failed: {}", rule_id, e);
+            return Json(ApiResponse {
+                code: 500,
+                message: "database error".into(),
+                data: None,
+            });
+        }
+    };
+
+    let restarted = nodes
+        .iter()
+        .filter(|n| matches!(n, NodeRestartStatus::Restarted { .. }))
+        .count();
+    tracing::info!(
+        "restart_rule: actor_id={} rule_id={} request_id={} reached {}/{} node(s)",
+        user.user_id,
+        rule_id,
+        request_id,
+        restarted,
+        nodes.len()
+    );
+
+    Json(ApiResponse::success(RestartResponse {
+        rule_id,
+        restarted,
+        nodes,
+    }))
+}
+
+/// Correlation id for one restart run. Not a real UUID and not security-
+/// relevant — it only ties a panel log line to a node log line, so process id +
+/// nanosecond timestamp is enough to be unique in practice.
+fn uuid_like_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("rst-{}-{}", std::process::id(), nanos)
+}

--- a/crates/panel/src/main.rs
+++ b/crates/panel/src/main.rs
@@ -100,7 +100,7 @@ async fn main() {
     // layer; the panel may listen on plain HTTP behind Caddy). See
     // api::security_headers for the exact policy.
     let app = api::security_headers::apply_security_headers(app);
-    let app = app.with_state(api::AppState {
+    let state = api::AppState {
         db,
         config: config.clone(),
         release_cache: api::system::ReleaseCache::new(),
@@ -109,7 +109,14 @@ async fn main() {
         geoip_in_flight: std::sync::Arc::new(tokio::sync::Mutex::new(
             std::collections::HashSet::new(),
         )),
-    });
+    };
+
+    // v1.2.0: scheduled rule restarts. Shares the AppState (and therefore the
+    // same node WS registry) with the HTTP handlers, so a scheduled restart goes
+    // out over exactly the same control channel as a manual one.
+    service::auto_restart::spawn(state.clone());
+
+    let app = app.with_state(state);
 
     let addr: SocketAddr = config.listen.parse().expect("Invalid listen address");
     tracing::info!(

--- a/crates/panel/src/service/auto_restart.rs
+++ b/crates/panel/src/service/auto_restart.rs
@@ -1,0 +1,219 @@
+//! v1.2.0: scheduled rule restarts.
+//!
+//! A rule with `auto_restart_minutes > 0` gets its connections dropped and its
+//! listeners rebuilt on that interval. This is the safety valve for rules whose
+//! connections accumulate faster than they drain (the `max_connections` cap is
+//! the actual fix — this is for when you'd rather shed than refuse).
+//!
+//! ## Why the schedule is in memory, not in the database
+//!
+//! The obvious design stores `last_restart_at` per rule. It survives a panel
+//! restart, which sounds good until you consider what "survives" means here: on
+//! boot, every rule whose interval elapsed while the panel was down comes due at
+//! once, and the panel's first act is to drop every connection on every
+//! auto-restart rule simultaneously. A panel restart (an upgrade, a container
+//! reschedule) would become a fleet-wide disconnect.
+//!
+//! Keeping the schedule in memory means a panel restart re-bases every rule's
+//! timer to "now". The cost is that a rule can go up to one extra interval
+//! without a restart across a panel bounce. That is strictly the safer failure:
+//! this feature exists to shed load periodically, and skipping one cycle is
+//! invisible, while an unscheduled mass disconnect is an incident.
+//!
+//! For the same reason a rule seen for the FIRST time is only baselined, never
+//! restarted on the spot — see `tick`.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::api::restart::{dispatch_restart, NodeRestartStatus};
+use crate::api::AppState;
+
+/// How often the scheduler wakes. The finest interval a user can configure is
+/// `MIN_AUTO_RESTART_MINUTES`, so a 60s tick is comfortably precise enough and
+/// costs one indexed query per minute.
+const TICK: Duration = Duration::from_secs(60);
+
+/// Tracks when each rule was last restarted BY THIS SCHEDULER. Keyed by rule_id.
+///
+/// A manual restart deliberately does NOT reset these timers: the two are
+/// independent controls, and letting a manual restart postpone the scheduled one
+/// would make the schedule silently drift by an amount that depends on operator
+/// behaviour.
+type Schedule = HashMap<i64, Instant>;
+
+/// Start the scheduler. Returns immediately; the loop runs until the process
+/// exits.
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move {
+        let mut schedule: Schedule = HashMap::new();
+        let mut ticker = tokio::time::interval(TICK);
+        // Skip missed ticks rather than firing them back-to-back if the loop is
+        // ever delayed — a burst of catch-up ticks would restart rules far more
+        // often than configured.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        tracing::info!("auto-restart scheduler started (tick {}s)", TICK.as_secs());
+        loop {
+            ticker.tick().await;
+            tick(&state, &mut schedule, Instant::now()).await;
+        }
+    });
+}
+
+/// One scheduler pass. Split out from the loop so it is testable without
+/// waiting on wall-clock time (`now` is injected).
+async fn tick(state: &AppState, schedule: &mut Schedule, now: Instant) {
+    let rules = match state.db.list_auto_restart_rules().await {
+        Ok(r) => r,
+        Err(e) => {
+            // Transient DB trouble must not kill the scheduler — skip this tick.
+            tracing::error!("auto-restart: listing rules failed: {}; skipping tick", e);
+            return;
+        }
+    };
+
+    // Forget rules that no longer auto-restart (disabled, paused, or deleted),
+    // so a rule that gets re-enabled later is baselined fresh rather than
+    // immediately restarted against a stale timestamp.
+    let live: std::collections::HashSet<i64> = rules.iter().map(|(id, _, _)| *id).collect();
+    schedule.retain(|rule_id, _| live.contains(rule_id));
+
+    for (rule_id, group_id, minutes) in rules {
+        // Defensive: the API validates this, but a hand-edited DB row must not
+        // turn into a restart-every-tick loop.
+        if minutes < relay_shared::models::MIN_AUTO_RESTART_MINUTES {
+            tracing::warn!(
+                "auto-restart: rule {} has interval {}min below the {}min floor; skipping",
+                rule_id,
+                minutes,
+                relay_shared::models::MIN_AUTO_RESTART_MINUTES
+            );
+            continue;
+        }
+
+        let due_after = Duration::from_secs(minutes as u64 * 60);
+        match schedule.get(&rule_id) {
+            // First sight: baseline only. Restarting here would mean every panel
+            // start drops every auto-restart rule's connections at once.
+            None => {
+                schedule.insert(rule_id, now);
+                tracing::debug!(
+                    "auto-restart: rule {} baselined, first restart in {}min",
+                    rule_id,
+                    minutes
+                );
+            }
+            Some(&last) if now.duration_since(last) >= due_after => {
+                schedule.insert(rule_id, now);
+                let request_id = format!("auto-{}-{}", rule_id, state.config.listen);
+                match dispatch_restart(state, rule_id, group_id, &request_id).await {
+                    Ok(nodes) => {
+                        let reached = nodes
+                            .iter()
+                            .filter(|n| matches!(n, NodeRestartStatus::Restarted { .. }))
+                            .count();
+                        tracing::info!(
+                            "auto-restart: rule {} restarted on {}/{} node(s) (every {}min)",
+                            rule_id,
+                            reached,
+                            nodes.len(),
+                            minutes
+                        );
+                    }
+                    Err(e) => {
+                        // The timer was already advanced, so a failing rule
+                        // retries on its next interval instead of every tick.
+                        tracing::error!("auto-restart: rule {} dispatch failed: {}", rule_id, e);
+                    }
+                }
+            }
+            Some(_) => {} // not due yet
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scheduling decision, isolated from AppState/DB/WS. Mirrors the
+    /// `match` in `tick`: returns whether the rule is due, given its last-seen
+    /// time.
+    fn is_due(schedule: &mut Schedule, rule_id: i64, minutes: i32, now: Instant) -> bool {
+        let due_after = Duration::from_secs(minutes as u64 * 60);
+        match schedule.get(&rule_id) {
+            None => {
+                schedule.insert(rule_id, now);
+                false
+            }
+            Some(&last) if now.duration_since(last) >= due_after => {
+                schedule.insert(rule_id, now);
+                true
+            }
+            Some(_) => false,
+        }
+    }
+
+    /// A rule the scheduler has never seen is BASELINED, not restarted.
+    ///
+    /// This is the property that keeps a panel restart from becoming a fleet
+    /// disconnect: on boot the schedule is empty, so every auto-restart rule
+    /// hits this path at once. If it returned "due", every one of them would
+    /// drop its connections simultaneously.
+    #[test]
+    fn first_sight_baselines_instead_of_restarting() {
+        let mut s = Schedule::new();
+        let t0 = Instant::now();
+        assert!(!is_due(&mut s, 1, 5, t0), "first sight must NOT restart");
+        assert_eq!(s.get(&1), Some(&t0), "first sight must record a baseline");
+    }
+
+    #[test]
+    fn restarts_only_once_the_interval_has_elapsed() {
+        let mut s = Schedule::new();
+        let t0 = Instant::now();
+        is_due(&mut s, 1, 5, t0); // baseline
+
+        assert!(
+            !is_due(&mut s, 1, 5, t0 + Duration::from_secs(4 * 60)),
+            "4min into a 5min interval is not due"
+        );
+        assert!(
+            is_due(&mut s, 1, 5, t0 + Duration::from_secs(5 * 60)),
+            "exactly 5min is due"
+        );
+        // Firing resets the timer — it must not fire again on the next tick.
+        assert!(
+            !is_due(&mut s, 1, 5, t0 + Duration::from_secs(6 * 60)),
+            "must not re-fire one minute after firing"
+        );
+        assert!(
+            is_due(&mut s, 1, 5, t0 + Duration::from_secs(10 * 60)),
+            "due again a full interval after the last fire"
+        );
+    }
+
+    /// A rule that stops auto-restarting is forgotten, so re-enabling it later
+    /// baselines fresh rather than firing immediately off a stale timestamp.
+    #[test]
+    fn disabled_rule_is_forgotten_and_rebaselined_on_return() {
+        let mut s = Schedule::new();
+        let t0 = Instant::now();
+        is_due(&mut s, 1, 5, t0);
+
+        // Rule disappears from the query (disabled/paused/deleted).
+        let live: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        s.retain(|id, _| live.contains(id));
+        assert!(
+            s.is_empty(),
+            "a rule that stopped auto-restarting is dropped"
+        );
+
+        // It comes back much later: must baseline, not fire instantly.
+        let t1 = t0 + Duration::from_secs(60 * 60);
+        assert!(
+            !is_due(&mut s, 1, 5, t1),
+            "a re-enabled rule must baseline, not fire off its stale timestamp"
+        );
+    }
+}

--- a/crates/panel/src/service/auto_restart.rs
+++ b/crates/panel/src/service/auto_restart.rs
@@ -105,7 +105,18 @@ async fn tick(state: &AppState, schedule: &mut Schedule, now: Instant) {
             }
             Some(&last) if now.duration_since(last) >= due_after => {
                 schedule.insert(rule_id, now);
-                let request_id = format!("auto-{}-{}", rule_id, state.config.listen);
+                // Unique per RUN, not per rule. The id exists to tie a panel log
+                // line to the matching node log line; a constant id makes every
+                // restart of this rule indistinguishable in the logs — exactly
+                // when you're reading them to find out which run misbehaved.
+                let request_id = format!(
+                    "auto-{}-{}",
+                    rule_id,
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis())
+                        .unwrap_or(0)
+                );
                 match dispatch_restart(state, rule_id, group_id, &request_id).await {
                     Ok(nodes) => {
                         let reached = nodes

--- a/crates/panel/src/service/mod.rs
+++ b/crates/panel/src/service/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto_restart;
 pub mod groups;
 pub mod node_config;
 pub mod password;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -80,10 +80,42 @@ export interface ForwardRule {
   /** v0.4.7: bound tunnel profile (source of transport config).
    *  null/undefined = legacy (use public_transport/ws_path). */
   tunnel_profile_id?: number | null;
+  /** v1.2.0: cap on concurrent TCP connections, counted PER NODE (0 = unlimited).
+   *  A rule served by 3 nodes admits up to 3x this in total. TCP only. */
+  max_connections?: number;
+  /** v1.2.0: restart the rule every N minutes to shed connections (0 = off).
+   *  Non-zero values are floored at MIN_AUTO_RESTART_MINUTES by the API. */
+  auto_restart_minutes?: number;
   config: string;
   traffic_used: number;
   status: string;
   created_at: string;
+}
+
+/** v1.2.0: the API's floor for a non-zero auto_restart_minutes. Mirrors
+ *  relay_shared::models::MIN_AUTO_RESTART_MINUTES — the backend rejects
+ *  anything between 1 and this, so the form must not offer it. */
+export const MIN_AUTO_RESTART_MINUTES = 5;
+
+/** v1.2.0: one node's outcome in a restart response. */
+export interface NodeRestartStatus {
+  /** "restarted" = the command reached the node's live control channel.
+   *  "unsupported" = node too old to understand restart_rule (upgrade it).
+   *  "control_channel_offline" = no live WS connection. */
+  state: 'restarted' | 'unsupported' | 'control_channel_offline';
+  node_id: string;
+  group_name: string;
+  public_ip?: string | null;
+  node_version?: string | null;
+}
+
+/** v1.2.0: POST /rules/{id}/restart. `restarted` counts nodes actually reached
+ *  — it can be 0 on an otherwise successful request (all nodes old/offline), so
+ *  callers must check it rather than only the envelope code. */
+export interface RestartResponse {
+  rule_id: number;
+  restarted: number;
+  nodes: NodeRestartStatus[];
 }
 
 /** v0.4.0: a tunnel profile (matches backend TunnelProfile struct). Builtin

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -514,6 +514,29 @@ export const enUS: Dict = {
   batchPartial: '{ok} succeeded, {fail} failed (unauthorized lines can\'t be resumed)',
   selectedCount: '{count} selected',
 
+  // ── v1.2.0: rule restart + connection cap + scheduled restart ──
+  restart: 'Restart',
+  batchRestart: 'Batch Restart',
+  restartConfirmTitle: 'Restart this rule?',
+  restartConfirmDesc: 'Every connection this rule is currently carrying is dropped immediately and clients must reconnect. The rule stays enabled/paused as it is.',
+  batchRestartConfirm: 'Restart {count} selected rules?',
+  restartPausedHint: 'Rule is paused — there are no connections to restart',
+  restartSuccess: 'Restarted on {count} node(s)',
+  batchRestartSuccess: 'Restarted {count} rules',
+  restartFailed: 'Restart failed',
+  // Partial success: appended to restartSuccess to say which nodes missed out.
+  restartOutdatedSuffix: '({count} node(s) too old — upgrade them first)',
+  restartOfflineSuffix: '({count} node(s) offline)',
+  restartAllOutdated: 'Nothing restarted: {count} node(s) are too old. Upgrade them from Node Status first.',
+  restartAllOffline: 'Nothing restarted: {count} node(s) are offline',
+  restartNoNodes: 'Nothing restarted: this rule\'s inbound group has no nodes',
+  maxConnections: 'Max connections',
+  maxConnectionsHint: '0 = unlimited. TCP only, and counted PER NODE — a rule running on 3 nodes allows 3x this number in total. Connections past the cap are refused immediately. Changing the cap does not drop existing connections; it applies to new ones from now on.',
+  autoRestart: 'Auto-restart interval',
+  autoRestartHint: '0 = off. Drops all of this rule\'s connections on this interval to clear accumulation. Minimum {min} minutes. The timer restarts when the panel restarts.',
+  autoRestartTooSmall: 'Minimum {min} minutes (0 = off)',
+  minutes: 'minutes',
+
   // ── v1.0.8: plans + shop + suspension ──
   shop: 'Shop',
   planManagement: 'Plans',

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -523,6 +523,7 @@ export const enUS: Dict = {
   restartPausedHint: 'Rule is paused — there are no connections to restart',
   restartSuccess: 'Restarted on {count} node(s)',
   batchRestartSuccess: 'Restarted {count} rules',
+  batchRestartPartial: '{ok} restarted, {fail} had no effect (paused rules, or nodes offline / too old)',
   restartFailed: 'Restart failed',
   // Partial success: appended to restartSuccess to say which nodes missed out.
   restartOutdatedSuffix: '({count} node(s) too old — upgrade them first)',
@@ -532,6 +533,7 @@ export const enUS: Dict = {
   restartNoNodes: 'Nothing restarted: this rule\'s inbound group has no nodes',
   maxConnections: 'Max connections',
   maxConnectionsHint: '0 = unlimited. TCP only, and counted PER NODE — a rule running on 3 nodes allows 3x this number in total. Connections past the cap are refused immediately. Changing the cap does not drop existing connections; it applies to new ones from now on.',
+  maxConnectionsUdpUnsupported: 'Not applicable to UDP rules: the cap is checked at accept(), and UDP has no connections to accept (sessions self-expire after 60s idle, so they cannot pile up the same way). A TCP+UDP rule can set it — it governs the TCP half.',
   autoRestart: 'Auto-restart interval',
   autoRestartHint: '0 = off. Drops all of this rule\'s connections on this interval to clear accumulation. Minimum {min} minutes. The timer restarts when the panel restarts.',
   autoRestartTooSmall: 'Minimum {min} minutes (0 = off)',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -513,6 +513,29 @@ export const zhCN = {
   batchPartial: '成功 {ok} 条，失败 {fail} 条（无权限的线路无法启动）',
   selectedCount: '已选 {count} 条',
 
+  // ── v1.2.0: 规则重启 + 连接数上限 + 定时自动重启 ──
+  restart: '重启',
+  batchRestart: '批量重启',
+  restartConfirmTitle: '确定重启这条规则？',
+  restartConfirmDesc: '会立即断开该规则当前的所有连接，客户端需要重连。规则的启用/暂停状态不变。',
+  batchRestartConfirm: '确定重启选中的 {count} 条规则？',
+  restartPausedHint: '规则已暂停，没有连接可重启',
+  restartSuccess: '已在 {count} 个节点上重启',
+  batchRestartSuccess: '已重启 {count} 条规则',
+  restartFailed: '重启失败',
+  // 部分成功：拼在 restartSuccess 后面，说明哪些节点没轮到
+  restartOutdatedSuffix: '（{count} 个节点版本过低，需先升级节点）',
+  restartOfflineSuffix: '（{count} 个节点离线）',
+  restartAllOutdated: '重启未生效：{count} 个节点版本过低，请先在「节点状态」升级节点',
+  restartAllOffline: '重启未生效：{count} 个节点当前离线',
+  restartNoNodes: '重启未生效：该规则的入口分组下没有节点',
+  maxConnections: '最大连接数',
+  maxConnectionsHint: '0 = 不限。仅对 TCP 生效，且按「每个节点」独立计数——规则跑在 3 个节点上时总量是这里的 3 倍。超出后新连接会被直接拒绝。修改上限不会断开已有连接，新上限从此刻起对新连接生效。',
+  autoRestart: '自动重启间隔',
+  autoRestartHint: '0 = 关闭。开启后每隔这么久自动断开该规则的全部连接一次，用于清理堆积的连接。最小 {min} 分钟。面板重启后重新计时。',
+  autoRestartTooSmall: '最小 {min} 分钟（0 = 关闭）',
+  minutes: '分钟',
+
   // ── v1.0.8: plans + shop + suspension ──
   shop: '套餐商店',
   planManagement: '套餐管理',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -522,6 +522,7 @@ export const zhCN = {
   restartPausedHint: '规则已暂停，没有连接可重启',
   restartSuccess: '已在 {count} 个节点上重启',
   batchRestartSuccess: '已重启 {count} 条规则',
+  batchRestartPartial: '成功 {ok} 条，未生效 {fail} 条（已暂停的规则、或节点离线/版本过低）',
   restartFailed: '重启失败',
   // 部分成功：拼在 restartSuccess 后面，说明哪些节点没轮到
   restartOutdatedSuffix: '（{count} 个节点版本过低，需先升级节点）',
@@ -531,6 +532,7 @@ export const zhCN = {
   restartNoNodes: '重启未生效：该规则的入口分组下没有节点',
   maxConnections: '最大连接数',
   maxConnectionsHint: '0 = 不限。仅对 TCP 生效，且按「每个节点」独立计数——规则跑在 3 个节点上时总量是这里的 3 倍。超出后新连接会被直接拒绝。修改上限不会断开已有连接，新上限从此刻起对新连接生效。',
+  maxConnectionsUdpUnsupported: 'UDP 规则不适用：上限在 accept 时判断，而 UDP 没有「连接」这个东西（会话按 60 秒空闲自动回收，不会无限堆积）。TCP+UDP 规则可以设，只管其中的 TCP 部分。',
   autoRestart: '自动重启间隔',
   autoRestartHint: '0 = 关闭。开启后每隔这么久自动断开该规则的全部连接一次，用于清理堆积的连接。最小 {min} 分钟。面板重启后重新计时。',
   autoRestartTooSmall: '最小 {min} 分钟（0 = 关闭）',

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -1,10 +1,11 @@
 import { Table, Button, Modal, Form, Input, InputNumber, Select, Space, message, Popconfirm, Tag, Alert, Typography, Dropdown, Switch, Tabs, Spin, Tooltip } from 'antd';
 import type { MenuProps } from 'antd';
-import { PlusOutlined, ReloadOutlined, EditOutlined, ApiOutlined, CopyOutlined, DownloadOutlined, UploadOutlined, PauseCircleOutlined, PlayCircleOutlined, DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, MedicineBoxOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { PlusOutlined, ReloadOutlined, EditOutlined, ApiOutlined, CopyOutlined, DownloadOutlined, UploadOutlined, PauseCircleOutlined, PlayCircleOutlined, DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, MedicineBoxOutlined, QuestionCircleOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import api from '../api/client';
-import type { ApiEnvelope, ForwardRule, DeviceGroup, User, UserSelf, RuleTargetInput, DiagnoseResponse, NodeDiagnoseStatus, DiagnoseTargetResult, SharedGroupSummary } from '../api/types';
+import type { ApiEnvelope, ForwardRule, DeviceGroup, User, UserSelf, RuleTargetInput, DiagnoseResponse, NodeDiagnoseStatus, DiagnoseTargetResult, SharedGroupSummary, RestartResponse } from '../api/types';
+import { MIN_AUTO_RESTART_MINUTES } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { formatBytes } from '../utils/format';
 import { useAuth } from '../auth/useAuth';
@@ -246,6 +247,8 @@ export default function Rules() {
       load_balance_strategy: r.load_balance_strategy ?? 'first',
       upload_limit_mbps: r.upload_limit_mbps ?? 0,
       download_limit_mbps: r.download_limit_mbps ?? 0,
+      max_connections: r.max_connections ?? 0,
+      auto_restart_minutes: r.auto_restart_minutes ?? 0,
     });
     setEditOpen(true);
   };
@@ -264,6 +267,9 @@ export default function Rules() {
       load_balance_strategy: r.load_balance_strategy ?? 'first',
       upload_limit_mbps: r.upload_limit_mbps ?? 0,
       download_limit_mbps: r.download_limit_mbps ?? 0,
+      // v1.2.0: max_connections / auto_restart_minutes are NOT carried over —
+      // they're edit-only (the create path can't store them), so the copy starts
+      // uncapped and the user sets them via Edit if wanted.
     });
     setCreateOpen(true);
   };
@@ -347,6 +353,8 @@ const IMPORT_DEFAULTS = {
     load_balance_strategy?: string;
     upload_limit_mbps?: number;
     download_limit_mbps?: number;
+    max_connections?: number;
+    auto_restart_minutes?: number;
   }) => {
     if (!editing) return;
     const payload: Record<string, unknown> = {};
@@ -374,6 +382,15 @@ const IMPORT_DEFAULTS = {
     if (newUp !== (editing.upload_limit_mbps ?? 0) || newDown !== (editing.download_limit_mbps ?? 0)) {
       payload.upload_limit_mbps = newUp;
       payload.download_limit_mbps = newDown;
+    }
+    // v1.2.0: send both together when either changed. The API defaults an
+    // omitted one to the rule's current value, so sending a single field is
+    // safe — but sending the pair keeps the request self-describing.
+    const newMaxConn = values.max_connections ?? 0;
+    const newAutoRestart = values.auto_restart_minutes ?? 0;
+    if (newMaxConn !== (editing.max_connections ?? 0) || newAutoRestart !== (editing.auto_restart_minutes ?? 0)) {
+      payload.max_connections = newMaxConn;
+      payload.auto_restart_minutes = newAutoRestart;
     }
     if (Object.keys(payload).length === 0) { setEditOpen(false); return; }
     try {
@@ -436,6 +453,65 @@ const IMPORT_DEFAULTS = {
     }
     setSelectedRowKeys([]);
     load();
+  };
+
+  /** v1.2.0: restart one rule — drop its live connections and rebuild its
+   *  listeners on every node of its inbound group. The rule's paused state is
+   *  untouched; this is not a pause/resume round-trip.
+   *
+   *  `restarted` (nodes actually reached) drives the message rather than the
+   *  HTTP code: the request can succeed while restarting nothing, e.g. every
+   *  node is too old to understand the command. Reporting that as success would
+   *  hide exactly the case the user needs to act on. */
+  const handleRestart = async (r: ForwardRule) => {
+    try {
+      const res = await api.post<unknown, ApiEnvelope<RestartResponse>>(`/rules/${r.id}/restart`, {});
+      if (res.code !== 0) {
+        message.error(res.message || t('restartFailed'));
+        return;
+      }
+      const data = res.data;
+      const outdated = (data?.nodes ?? []).filter(n => n.state === 'unsupported').length;
+      const offline = (data?.nodes ?? []).filter(n => n.state === 'control_channel_offline').length;
+      if ((data?.restarted ?? 0) > 0) {
+        let msg = t('restartSuccess').replace('{count}', String(data?.restarted ?? 0));
+        if (outdated > 0) msg += ` ${t('restartOutdatedSuffix').replace('{count}', String(outdated))}`;
+        if (offline > 0) msg += ` ${t('restartOfflineSuffix').replace('{count}', String(offline))}`;
+        if (outdated > 0 || offline > 0) message.warning(msg);
+        else message.success(msg);
+      } else if (outdated > 0) {
+        message.warning(t('restartAllOutdated').replace('{count}', String(outdated)));
+      } else if (offline > 0) {
+        message.warning(t('restartAllOffline').replace('{count}', String(offline)));
+      } else {
+        message.warning(t('restartNoNodes'));
+      }
+    } catch {
+      message.error(t('restartFailed'));
+    }
+  };
+
+  /** v1.2.0: batch restart. Per-rule POST like batch pause/resume — there is no
+   *  bulk endpoint. A rule can fail individually (paused → 400, or not owned →
+   *  404), so tally ok/fail rather than assuming Promise.all means success. */
+  const handleBatchRestart = async () => {
+    const ids = selectedRowKeys as number[];
+    if (ids.length === 0) return;
+    const results = await Promise.all(ids.map(async id => {
+      try {
+        const res = await api.post<unknown, ApiEnvelope<RestartResponse>>(`/rules/${id}/restart`, {});
+        // Reaching zero nodes is not a success worth reporting as one.
+        return res.code === 0 && (res.data?.restarted ?? 0) > 0;
+      } catch { return false; }
+    }));
+    const ok = results.filter(Boolean).length;
+    const fail = results.length - ok;
+    if (fail === 0) {
+      message.success(t('batchRestartSuccess').replace('{count}', String(ok)));
+    } else {
+      message.warning(t('batchPartial').replace('{ok}', String(ok)).replace('{fail}', String(fail)));
+    }
+    setSelectedRowKeys([]);
   };
 
   /** v0.4.8: run a diagnosis for a rule. The panel fans the probe out to the
@@ -563,6 +639,26 @@ const IMPORT_DEFAULTS = {
           <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => handleCopy(r)}>{t('copy')}</Button>
           {/* v0.4.9: diagnosis is TCP-only — disable for pure-UDP rules. */}
           <Button size="small" type="text" icon={<MedicineBoxOutlined />} disabled={r.protocol === 'udp'} onClick={() => handleDiagnose(r)} title={r.protocol === 'udp' ? t('diagnoseUdpUnsupported') : t('diagnose')}>{t('diagnose')}</Button>
+          {/* v1.2.0: restart drops every live connection on this rule, so it is
+              behind a confirm (diagnose is read-only and isn't). Disabled while
+              paused — there are no listeners to restart. */}
+          <Popconfirm
+            title={t('restartConfirmTitle')}
+            description={t('restartConfirmDesc')}
+            onConfirm={() => handleRestart(r)}
+            okButtonProps={{ danger: true }}
+            disabled={r.paused}
+          >
+            <Button
+              size="small"
+              type="text"
+              icon={<ThunderboltOutlined />}
+              disabled={r.paused}
+              title={r.paused ? t('restartPausedHint') : t('restart')}
+            >
+              {t('restart')}
+            </Button>
+          </Popconfirm>
           <Popconfirm title={t('deleteRuleConfirm')} onConfirm={() => handleDelete(r.id)}>
             <Button danger size="small" type="text">{t('delete')}</Button>
           </Popconfirm>
@@ -615,6 +711,45 @@ const IMPORT_DEFAULTS = {
       />
     );
   };
+
+  /** v1.2.0: connection cap + scheduled restart. Shared by the create and edit
+   *  forms so the two can't drift (the rate-limit block above predates this and
+   *  is still duplicated).
+   *
+   *  Both fields are 0 = off. The cap's `extra` says the count is PER NODE and
+   *  TCP-only, because neither is guessable: a rule on 3 nodes admits 3x the
+   *  number typed here, and setting it on a UDP-only rule does nothing. */
+  const renderConnectionControls = () => (
+    <>
+      <Form.Item
+        name="max_connections"
+        label={t('maxConnections')}
+        extra={t('maxConnectionsHint')}
+        initialValue={0}
+      >
+        <InputNumber min={0} style={{ width: '100%' }} placeholder="0" />
+      </Form.Item>
+      <Form.Item
+        name="auto_restart_minutes"
+        label={t('autoRestart')}
+        extra={t('autoRestartHint').replace('{min}', String(MIN_AUTO_RESTART_MINUTES))}
+        initialValue={0}
+        rules={[{
+          // Mirrors the API's floor. 0 = off is always allowed; anything between
+          // 1 and the floor would drop connections faster than clients reconnect.
+          validator: (_, value) => {
+            const v = Number(value ?? 0);
+            if (v === 0 || v >= MIN_AUTO_RESTART_MINUTES) return Promise.resolve();
+            return Promise.reject(new Error(
+              t('autoRestartTooSmall').replace('{min}', String(MIN_AUTO_RESTART_MINUTES))
+            ));
+          },
+        }]}
+      >
+        <InputNumber min={0} style={{ width: '100%' }} addonAfter={t('minutes')} placeholder="0" />
+      </Form.Item>
+    </>
+  );
 
   const renderTargetsEditor = () => (
     <Form.List name="targets" initialValue={[{ host: '', port: undefined as unknown as number, enabled: true }]}>
@@ -709,6 +844,18 @@ const IMPORT_DEFAULTS = {
             <Button icon={<PauseCircleOutlined />} onClick={() => handleBatchSetPaused(true)}>
               {t('batchPause')} ({selectedRowKeys.length})
             </Button>
+          )}
+          {selectedRowKeys.length > 0 && (
+            <Popconfirm
+              title={t('batchRestartConfirm').replace('{count}', String(selectedRowKeys.length))}
+              description={t('restartConfirmDesc')}
+              onConfirm={handleBatchRestart}
+              okButtonProps={{ danger: true }}
+            >
+              <Button icon={<ThunderboltOutlined />}>
+                {t('batchRestart')} ({selectedRowKeys.length})
+              </Button>
+            </Popconfirm>
           )}
           {selectedRowKeys.length > 0 && (
             <Popconfirm
@@ -816,6 +963,12 @@ const IMPORT_DEFAULTS = {
                     <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
+                {/* v1.2.0: the connection cap / auto-restart controls are
+                    deliberately EDIT-ONLY. The atomic create transaction
+                    (create_rule_with_guard) doesn't carry them, so offering them
+                    here would silently discard whatever the user typed. They are
+                    also settings you tune after watching a rule misbehave, not
+                    ones you can guess up front. */}
               </>),
             },
           ]} />
@@ -882,6 +1035,7 @@ const IMPORT_DEFAULTS = {
                     <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
+                {renderConnectionControls()}
               </>),
             },
           ]} />

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -509,7 +509,13 @@ const IMPORT_DEFAULTS = {
     if (fail === 0) {
       message.success(t('batchRestartSuccess').replace('{count}', String(ok)));
     } else {
-      message.warning(t('batchPartial').replace('{ok}', String(ok)).replace('{fail}', String(fail)));
+      // NOT batchPartial: that message blames "unauthorized lines can't be
+      // resumed", which is the batch-resume failure mode and has nothing to do
+      // with a restart. A restart fails when the rule is paused or every node is
+      // old/offline — say that instead of pointing at the wrong cause.
+      message.warning(
+        t('batchRestartPartial').replace('{ok}', String(ok)).replace('{fail}', String(fail))
+      );
     }
     setSelectedRowKeys([]);
   };
@@ -716,18 +722,26 @@ const IMPORT_DEFAULTS = {
    *  forms so the two can't drift (the rate-limit block above predates this and
    *  is still duplicated).
    *
-   *  Both fields are 0 = off. The cap's `extra` says the count is PER NODE and
-   *  TCP-only, because neither is guessable: a rule on 3 nodes admits 3x the
-   *  number typed here, and setting it on a UDP-only rule does nothing. */
-  const renderConnectionControls = () => (
+   *  Both fields are 0 = off. The cap's `extra` says the count is PER NODE,
+   *  because that isn't guessable: a rule on 3 nodes admits 3x the number typed
+   *  here.
+   *
+   *  The cap is disabled for a UDP-ONLY rule. It is enforced at accept(), which
+   *  UDP doesn't have — the panel would happily store the number and ship it to
+   *  the node, where nothing would ever read it. Showing an editable field that
+   *  silently does nothing is worse than showing a disabled one that says why.
+   *  A tcp_udp rule keeps it: the cap governs its TCP half. */
+  const renderConnectionControls = (proto?: string) => {
+    const udpOnly = proto === 'udp';
+    return (
     <>
       <Form.Item
         name="max_connections"
         label={t('maxConnections')}
-        extra={t('maxConnectionsHint')}
+        extra={udpOnly ? t('maxConnectionsUdpUnsupported') : t('maxConnectionsHint')}
         initialValue={0}
       >
-        <InputNumber min={0} style={{ width: '100%' }} placeholder="0" />
+        <InputNumber min={0} style={{ width: '100%' }} placeholder="0" disabled={udpOnly} />
       </Form.Item>
       <Form.Item
         name="auto_restart_minutes"
@@ -749,7 +763,8 @@ const IMPORT_DEFAULTS = {
         <InputNumber min={0} style={{ width: '100%' }} addonAfter={t('minutes')} placeholder="0" />
       </Form.Item>
     </>
-  );
+    );
+  };
 
   const renderTargetsEditor = () => (
     <Form.List name="targets" initialValue={[{ host: '', port: undefined as unknown as number, enabled: true }]}>
@@ -1035,7 +1050,7 @@ const IMPORT_DEFAULTS = {
                     <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
-                {renderConnectionControls()}
+                {renderConnectionControls(editProto)}
               </>),
             },
           ]} />


### PR DESCRIPTION
## ⚠️ 先说最重要的:#66 / #67 / #68 的代码从来没进 main

它们的状态都显示 MERGED,但**合并目标是各自的上游分支,不是 main**:

| PR | base(实际合进了哪) |
|---|---|
| #65 | `main` ✅ |
| #66 | `feat/rule-conn-controls-schema` ← #65 的分支 |
| #67 | `feat/node-conn-cap-restart` ← #66 的分支 |
| #68 | `feat/rule-restart-api-ui` ← #67 的分支 |

原因是 stacked PR 的 base 前移是**异步**的:#65 在 06:08:18 合并,#66 在 **39 秒后**就合了,GitHub 还没来得及把 #66 的 base 从 `feat/rule-conn-controls-schema` 改成 `main`,于是它合进了原来的 base。#67、#68 同理,一个套一个。

**结果:main 上只有 #65 的地基(字段、迁移、API),节点执行、重启接口、前端按钮、定时调度器全都不在。** 也就是说现在 main 上这个功能是不完整的 —— 字段能设,但没有任何东西读它。

代码一点没丢,还在那几个分支上。这个 PR 把 #66/#67/#68 的三个提交 cherry-pick 到 main(核对过:结果树和完整分支**逐字节一致**),外加下面这轮审查发现的修复。

---

## 审查发现的 bug

### 1. 🔴 纯 UDP 规则的重启是彻底的空操作(node)

`restart_rule` 开头在没有 `RuleRuntime` 时直接 `return (0, 0)`。但 `rule_runtime` **只在 `(Protocol::Tcp, NodeTransport::Raw)` 那个 match 臂里创建** —— UDP 没有 `accept()`,也没有可取消的 per-connection 任务,所以纯 UDP 规则**天生没有 runtime,却实实在在有 listener**。

后果:UDP 规则的 listener 从不重建,会话从不断开。而且**从外面完全看不出来** —— 面板是按"指令送达节点"算成功的,所以用户看到「已在 N 个节点上重启」,节点那边一动没动。正是我在别处极力避免的那种静默撒谎,结果自己在 UDP 路径上犯了。

修复:「没有 runtime」现在只表示「没有连接要取消」;**有没有 listener 要重建是另一个判断**。UDP 规则的会话存在 listener 任务里,重建 listener 就是断会话的方式。

先写了失败测试证明(`restarted` 返回 0,应为 1),再修:
```
assertion `left == right` failed: a UDP-only rule's listener MUST be rebuilt;
0 here means the restart silently did nothing while the panel reported success
  left: 0   right: 1
```

### 2. 🟡 连接数上限对 UDP 规则开放,但它什么也不做(前端)

`max_connections` 在 `accept()` 时判断。面板会老老实实把 500 存下来并下发给节点,而节点那边根本没有代码读它。**这个我是在真面板上验证的** —— 节点视角的配置 JSON 确实是:

```json
{"rule_id":1,"protocol":"udp",...,"max_connections":500}
```

现在纯 UDP 规则的这个字段**禁用**并给出原因;`tcp_udp` 规则保留(它管其中的 TCP 部分)。浏览器里核对过:UDP 规则字段 `disabled=true` + 提示文案,TCP 规则照常可编辑。

### 3. 🟡 批量重启部分失败时甩锅甩错了对象

它复用了 `batchPartial`,而那句文案是「**无权限的线路无法启动**」—— 那是**批量启动**的失败原因,跟重启毫无关系。现在说真正的原因:规则已暂停,或节点离线/版本过低。

### 4. 🟢 调度器的 request_id 每次都一样

`auto-{rule_id}-{listen}` 对同一条规则恒定不变。这个字段存在的意义就是把一次面板日志和对应的节点日志串起来,恒定的 id 让所有历史重启在日志里**无法区分** —— 而你翻日志的时候正是想知道是哪一次出的问题。改成带时间戳,和手动路径一致。

---

## 核对过没问题的

- **改上限会不会下发到节点**:会。`update_rule` 成功后广播 `config_changed`,且 `max_connections` 在 listener 指纹里 → 节点重建 listener → 新上限生效。
- **上限有没有真的进配置**:真面板拉 `/node/config` 验证过,JSON 里带 `max_connections`。
- **`tcp_udp` 规则的重启**:正常(TCP 臂创建了 runtime,重建时按 rule_id 过滤会把 UDP listener 一起重建)。
- **调度器排除暂停规则**:SQL 里就排除了,正确。
- **重启持有 manager 锁会不会死锁**:不会,`apply_config` 是 `&mut self`,同一把锁。
- **控制台 duplicate-key 报错**:本来就有的,在未改动的 main 上复现过,不是这批引入的。

## 验证

- `cargo fmt --check` / `clippy --workspace --all-targets -D warnings` 零告警
- Rust **524** 测试通过(新增 `restart_udp_only_rule_rebuilds_its_listener`)
- 前端 typecheck / lint / 159 测试全过
- 浏览器里真跑:UDP 规则上限字段禁用+提示、TCP 规则可编辑、UDP 重启按钮可用且诚实上报
- ⚠️ PG 测试本地跳过(无 `TEST_PG_URL`),CI 会连真库跑

## 合并后

这个 PR 合掉之后,`feat/rule-conn-controls-schema`、`feat/node-conn-cap-restart`、`feat/rule-restart-api-ui`、`feat/rule-auto-restart-scheduler` 四个分支就可以删了,它们的内容全部落在 main 上。

**发布提醒仍然有效:** 节点版本门槛硬编码 `>= 1.2.0`,发布必须打 `node-v1.2.0`,打成 `node-v1.1.3` 的话重启功能永久失效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
