### PR TITLE
feat(stats): 流量历史(24小时 / 7天 / 30天)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ independent `v*` / `node-v*` tracks since this release).
 
 ### Added
 
+- **Traffic history (24h / 7d / 30d).** `forward_rules.traffic_used` was a running
+  total with no time dimension, so nobody could answer "how much did I use this
+  week" or "which rule suddenly burned 500 GB last night" — the two questions
+  that matter when usage looks wrong. Usage is now recorded hourly and charted
+  on the dashboard (fleet-wide, with a per-rule drill-down) and on the account
+  page (the user's own).
+
+  - **The chart's primary series is BILLED traffic — the same number the quota
+    deducts**, accumulated inside the same transaction as the charge. On a line
+    with `rate != 1` the real and billed bytes genuinely differ, and a chart
+    showing only real bytes would read as the panel over-charging. Real
+    upload/download stay in the tooltip.
+  - **One row per (rule, hour), written as an UPSERT.** Nodes report on the poll
+    interval (~10s), so a row per report would be ~8.6k rows/rule/day; hourly
+    accumulation keeps 100 rules × 35 days at ~84k rows.
+  - **Day grouping happens in the VIEWER'S timezone, not the server's.** Buckets
+    are stored in UTC, and a UTC "day" starts at 08:00 for a UTC+8 operator —
+    grouping server-side would visibly misfile yesterday's traffic. The folding
+    logic is a unit-tested pure function, including the UTC+8 case.
+  - **No foreign key on the history table, deliberately.** Deleting a rule must
+    not retroactively shrink "last 7 days". Rows die by retention (35 days,
+    hourly sweeper) and nothing else.
+  - Quiet hours are zero-filled rather than collapsed, so the axis can't imply
+    continuous usage that didn't happen.
+
 - **Node offline alerts (Telegram + email).** A node could die and nothing told
   anyone — the operator found out from a user complaint or by happening to
   refresh the panel. A background watcher now scans node status and notifies
@@ -81,8 +106,8 @@ independent `v*` / `node-v*` tracks since this release).
 
 ### Schema
 
-- SQLite Migration **39**, PG revision **22** (`PG_SCHEMA_VERSION` 21 → 22):
-  the `redeem_codes` table.
+- SQLite Migrations **39-40**, PG revisions **22-23** (`PG_SCHEMA_VERSION` 21 → 23):
+  the `redeem_codes` and `traffic_history` tables.
 
 ### Fixed
 

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -216,6 +216,12 @@ pub fn routes() -> Router<AppState> {
         )
         // Stats & monitoring
         .route("/stats", axum::routing::get(stats::get_stats))
+        // v1.2.0: traffic-history chart data. Owner-scoped inside the handler
+        // (non-admins are pinned to their own uid), so it is NOT admin-gated.
+        .route(
+            "/stats/traffic",
+            axum::routing::get(stats::get_traffic_history),
+        )
         // v0.4.10: node status is owner-scoped (a user sees only nodes for
         // groups they own). Renamed /node_status → /nodes.
         .route("/nodes", axum::routing::get(stats::get_node_status))

--- a/crates/panel/src/api/stats.rs
+++ b/crates/panel/src/api/stats.rs
@@ -109,6 +109,83 @@ pub async fn get_stats(
     Json(ApiResponse::success(stats))
 }
 
+/// v1.2.0: query for the traffic-history chart.
+#[derive(Debug, serde::Deserialize)]
+pub struct TrafficHistoryQuery {
+    /// "1d" | "7d" | "30d".
+    pub range: String,
+    /// Optional drill-down to one rule.
+    #[serde(default)]
+    pub rule_id: Option<i64>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct TrafficHistoryResponse {
+    /// "hour" | "day" — tells the chart how to format the x axis.
+    pub granularity: String,
+    /// Inclusive UTC lower bound actually used, so the chart can render empty
+    /// leading buckets instead of starting at the first datapoint.
+    pub since: String,
+    pub buckets: Vec<crate::db::repo::TrafficHistoryBucket>,
+}
+
+/// GET /api/v1/stats/traffic?range=1d|7d|30d[&rule_id=N]
+///
+/// Owner-scoped: a regular user's query is FORCED to `uid = caller` regardless
+/// of what they pass — a foreign rule_id then simply matches nothing, which
+/// also means the endpoint can't be used to probe whether a rule id exists.
+/// Admins see everything.
+///
+/// ALWAYS returns hourly buckets, even for 7d/30d (≤ 720 rows — trivial). Day
+/// grouping happens client-side in the VIEWER'S timezone: buckets are stored
+/// in UTC, and a server-side UTC "day" starts at 08:00 for a CST viewer, which
+/// would visibly misfile "yesterday's" traffic for every non-UTC operator.
+/// (The repo's daily aggregation still exists for UTC-day consumers.)
+pub async fn get_traffic_history(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Query(q): Query<TrafficHistoryQuery>,
+) -> Json<ApiResponse<TrafficHistoryResponse>> {
+    let days = match q.range.as_str() {
+        "1d" => 1,
+        "7d" => 7,
+        "30d" => 30,
+        other => {
+            return Json(ApiResponse {
+                code: 400,
+                message: format!("range 只能是 1d / 7d / 30d,收到: {other}"),
+                data: None,
+            });
+        }
+    };
+    let since = (chrono::Utc::now() - chrono::Duration::days(days))
+        .format("%Y-%m-%d %H:00:00")
+        .to_string();
+    // The scope decision, in one place: admin = unrestricted, everyone else =
+    // pinned to their own uid. The repo layer trusts this argument.
+    let uid = if user.admin { None } else { Some(user.user_id) };
+
+    match state
+        .db
+        .query_traffic_history(uid, q.rule_id, &since, false)
+        .await
+    {
+        Ok(buckets) => Json(ApiResponse::success(TrafficHistoryResponse {
+            granularity: "hour".into(),
+            since,
+            buckets,
+        })),
+        Err(e) => {
+            tracing::error!("get_traffic_history: db error: {}", e);
+            Json(ApiResponse {
+                code: 500,
+                message: "数据库错误".into(),
+                data: None,
+            })
+        }
+    }
+}
+
 pub async fn get_node_status(
     user: AuthUser,
     State(state): State<AppState>,

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -4627,3 +4627,204 @@ async fn pg_list_and_count_filter_by_status() {
     assert_eq!(db.count_redeem_codes(&unused).await.unwrap(), 1);
     cleanup(&db).await;
 }
+
+// ── v1.2.0: traffic history (PG twins) ──
+//
+// The write path differs on both backends (SQLite ON CONFLICT excluded.x vs
+// PG's table-qualified EXCLUDED, NUMERIC SUM vs INTEGER SUM), so the agreement
+// invariant has to hold on each independently.
+
+/// PG twin of the SQLite fixture. Returns uid.
+async fn pg_seed_history_fixture(
+    db: &PgRepository,
+    username: &str,
+    group_id: i64,
+    rule_id: i64,
+    rate: f64,
+) -> i64 {
+    db.insert_user(username, "h", 1).await.unwrap();
+    let uid = db.find_by_username(username).await.unwrap().unwrap().id;
+    sqlx::query(
+        "INSERT INTO device_groups (id, name, group_type, token, uid, rate) \
+         VALUES ($1, 'gin', 'in', $2, $3, $4)",
+    )
+    .bind(group_id)
+    .bind(format!("tok-{group_id}"))
+    .bind(uid)
+    .bind(rate)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO forward_rules \
+         (id, name, uid, listen_port, device_group_in, target_addr, target_port) \
+         VALUES ($1, $2, $3, 20000, $4, '127.0.0.1', 80)",
+    )
+    .bind(rule_id)
+    .bind(format!("r{rule_id}"))
+    .bind(uid)
+    .bind(group_id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    uid
+}
+
+#[tokio::test]
+async fn pg_traffic_history_agrees_with_quota_charge() {
+    let Some(db) = repo("th_agree").await else {
+        return;
+    };
+    let uid = pg_seed_history_fixture(&db, "hist_a", 60, 200, 3.0).await;
+
+    let res = db
+        .apply_traffic_batch(
+            60,
+            &[relay_shared::protocol::TrafficEntry {
+                rule_id: 200,
+                upload: 1000,
+                download: 2000,
+            }],
+        )
+        .await
+        .unwrap();
+    assert!(matches!(res[0], TrafficEntryResult::Ok));
+
+    let user_used: i64 = sqlx::query_scalar("SELECT traffic_used FROM users WHERE id = $1")
+        .bind(uid)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    let (h_up, h_down, h_billed): (i64, i64, i64) = sqlx::query_as(
+        "SELECT COALESCE(SUM(real_upload),0)::BIGINT, COALESCE(SUM(real_download),0)::BIGINT, \
+                COALESCE(SUM(billed_total),0)::BIGINT \
+         FROM traffic_history WHERE rule_id = 200",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+
+    assert_eq!(user_used, 9000, "user is billed real × rate");
+    assert_eq!(h_billed, user_used, "history MUST equal the quota charge");
+    assert_eq!((h_up, h_down), (1000, 2000), "real bytes stay unrated");
+    cleanup(&db).await;
+}
+
+#[tokio::test]
+async fn pg_traffic_history_upserts_within_the_hour() {
+    let Some(db) = repo("th_upsert").await else {
+        return;
+    };
+    pg_seed_history_fixture(&db, "hist_b", 61, 201, 1.0).await;
+
+    for _ in 0..3 {
+        db.apply_traffic_batch(
+            61,
+            &[relay_shared::protocol::TrafficEntry {
+                rule_id: 201,
+                upload: 100,
+                download: 0,
+            }],
+        )
+        .await
+        .unwrap();
+    }
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM traffic_history WHERE rule_id = 201")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    let total: i64 = sqlx::query_scalar(
+        "SELECT SUM(real_upload)::BIGINT FROM traffic_history WHERE rule_id = 201",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert!(
+        rows <= 2,
+        "3 batches must fold into hour buckets, got {rows}"
+    );
+    assert_eq!(total, 300, "accumulation must not lose bytes");
+    cleanup(&db).await;
+}
+
+#[tokio::test]
+async fn pg_traffic_history_query_scopes_and_aggregates() {
+    let Some(db) = repo("th_scope").await else {
+        return;
+    };
+    let alice = pg_seed_history_fixture(&db, "hist_c", 62, 202, 1.0).await;
+    let bob = pg_seed_history_fixture(&db, "hist_d", 63, 203, 1.0).await;
+
+    for (uid, rule, hour, up) in [
+        (alice, 202i64, "2026-07-20 10:00:00", 100i64),
+        (alice, 202, "2026-07-20 11:00:00", 200),
+        (bob, 203, "2026-07-20 10:00:00", 999),
+    ] {
+        sqlx::query(
+            "INSERT INTO traffic_history (rule_id, uid, hour_ts, real_upload, real_download, billed_total) \
+             VALUES ($1, $2, $3, $4, 0, $5)",
+        )
+        .bind(rule)
+        .bind(uid)
+        .bind(hour)
+        .bind(up)
+        .bind(up)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    let daily = db
+        .query_traffic_history(Some(alice), None, "2026-07-01 00:00:00", true)
+        .await
+        .unwrap();
+    assert_eq!(daily.len(), 1, "two hours of one day fold into one bucket");
+    assert_eq!(daily[0].bucket, "2026-07-20");
+    assert_eq!(daily[0].real_upload, 300, "alice's hours summed");
+
+    let hourly = db
+        .query_traffic_history(Some(alice), None, "2026-07-01 00:00:00", false)
+        .await
+        .unwrap();
+    assert_eq!(hourly.len(), 2);
+
+    let all = db
+        .query_traffic_history(None, None, "2026-07-01 00:00:00", true)
+        .await
+        .unwrap();
+    assert_eq!(all[0].real_upload, 300 + 999, "admin sees everyone");
+
+    let foreign = db
+        .query_traffic_history(Some(alice), Some(203), "2026-07-01 00:00:00", true)
+        .await
+        .unwrap();
+    assert!(foreign.is_empty(), "a foreign rule matches nothing");
+    cleanup(&db).await;
+}
+
+#[tokio::test]
+async fn pg_traffic_history_prune_respects_cutoff() {
+    let Some(db) = repo("th_prune").await else {
+        return;
+    };
+    let uid = pg_seed_history_fixture(&db, "hist_e", 64, 204, 1.0).await;
+    for hour in ["2026-05-01 00:00:00", "2026-07-20 00:00:00"] {
+        sqlx::query(
+            "INSERT INTO traffic_history (rule_id, uid, hour_ts, real_upload, real_download, billed_total) \
+             VALUES (204, $1, $2, 1, 1, 1)",
+        )
+        .bind(uid)
+        .bind(hour)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    let deleted = db
+        .prune_traffic_history("2026-06-15 00:00:00")
+        .await
+        .unwrap();
+    assert_eq!(deleted, 1, "only the pre-cutoff row dies");
+    cleanup(&db).await;
+}

--- a/crates/panel/src/db/pg_repo/traffic.rs
+++ b/crates/panel/src/db/pg_repo/traffic.rs
@@ -151,6 +151,9 @@ impl TrafficRepository for PgRepository {
 
         // ── Pass 3: apply writes (one UPDATE per distinct rule + its user).
         // v1.0.8: forward_rules += REAL bytes; users += BILLED bytes. ──
+        // v1.2.0: one hour bucket for the whole batch (see the SQLite impl for
+        // why history accumulates per (rule, hour) rather than per report).
+        let hour_ts = chrono::Utc::now().format("%Y-%m-%d %H:00:00").to_string();
         for r in &resolved {
             let up = r.delta_up as i64;
             let down = r.delta_down as i64;
@@ -167,9 +170,72 @@ impl TrafficRepository for PgRepository {
                 .bind(r.uid)
                 .execute(&mut *tx)
                 .await?;
+            // v1.2.0: same billed_delta as the user charge above, in the same
+            // tx — the history chart can never disagree with the quota.
+            sqlx::query(
+                "INSERT INTO traffic_history \
+                   (rule_id, uid, hour_ts, real_upload, real_download, billed_total) \
+                 VALUES ($1, $2, $3, $4, $5, $6) \
+                 ON CONFLICT (rule_id, hour_ts) DO UPDATE SET \
+                   real_upload = traffic_history.real_upload + EXCLUDED.real_upload, \
+                   real_download = traffic_history.real_download + EXCLUDED.real_download, \
+                   billed_total = traffic_history.billed_total + EXCLUDED.billed_total",
+            )
+            .bind(r.rule_id)
+            .bind(r.uid)
+            .bind(&hour_ts)
+            .bind(up)
+            .bind(down)
+            .bind(r.billed_delta)
+            .execute(&mut *tx)
+            .await?;
         }
 
         tx.commit().await?;
         Ok(vec![TrafficEntryResult::Ok])
+    }
+
+    async fn query_traffic_history(
+        &self,
+        uid: Option<i64>,
+        rule_id: Option<i64>,
+        since: &str,
+        daily: bool,
+    ) -> Result<Vec<TrafficHistoryBucket>, DbError> {
+        // SUM(bigint) is NUMERIC in PG — cast back to BIGINT or sqlx can't
+        // decode into the i64 fields of TrafficHistoryBucket.
+        let sql = if daily {
+            "SELECT substr(hour_ts, 1, 10) AS bucket, \
+                    SUM(real_upload)::BIGINT AS real_upload, \
+                    SUM(real_download)::BIGINT AS real_download, \
+                    SUM(billed_total)::BIGINT AS billed_total \
+             FROM traffic_history \
+             WHERE hour_ts >= $1 AND uid = COALESCE($2, uid) AND rule_id = COALESCE($3, rule_id) \
+             GROUP BY bucket ORDER BY bucket"
+        } else {
+            "SELECT hour_ts AS bucket, \
+                    SUM(real_upload)::BIGINT AS real_upload, \
+                    SUM(real_download)::BIGINT AS real_download, \
+                    SUM(billed_total)::BIGINT AS billed_total \
+             FROM traffic_history \
+             WHERE hour_ts >= $1 AND uid = COALESCE($2, uid) AND rule_id = COALESCE($3, rule_id) \
+             GROUP BY bucket ORDER BY bucket"
+        };
+        Ok(sqlx::query_as(sql)
+            .bind(since)
+            .bind(uid)
+            .bind(rule_id)
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    async fn prune_traffic_history(&self, cutoff: &str) -> Result<u64, DbError> {
+        Ok(
+            sqlx::query("DELETE FROM traffic_history WHERE hour_ts < $1")
+                .bind(cutoff)
+                .execute(&self.pool)
+                .await?
+                .rows_affected(),
+        )
     }
 }

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -198,6 +198,21 @@ CREATE INDEX IF NOT EXISTS idx_redeem_codes_status ON redeem_codes(status);
 CREATE INDEX IF NOT EXISTS idx_redeem_codes_batch ON redeem_codes(batch_id);
 CREATE INDEX IF NOT EXISTS idx_redeem_codes_used_by ON redeem_codes(used_by);
 
+-- v1.2.0: hourly traffic history (mirrors the SQLite baseline — see the
+-- comment there for why one row per (rule, hour), why billed_total reuses the
+-- exact charged number, and why there is deliberately NO FK).
+CREATE TABLE IF NOT EXISTS traffic_history (
+    rule_id BIGINT NOT NULL,
+    uid BIGINT NOT NULL,
+    hour_ts TEXT NOT NULL,
+    real_upload BIGINT NOT NULL DEFAULT 0,
+    real_download BIGINT NOT NULL DEFAULT 0,
+    billed_total BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (rule_id, hour_ts)
+);
+CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts);
+CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts);
+
 -- v1.0.9: plan ↔ device_group grant map (mirrors SQLite baseline + Migration 35).
 CREATE TABLE IF NOT EXISTS plan_device_groups (
     plan_id BIGINT NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
@@ -304,7 +319,7 @@ INSERT INTO schema_version (version) VALUES (1) ON CONFLICT (version) DO NOTHING
 /// The schema revision this build's baseline `PG_SCHEMA_SQL` represents. When a
 /// future release adds a column/table, bump this and add a matching arm in
 /// `run_pg_migrations`. `apply_pg_schema` seeds `schema_version` with revision 1.
-pub const PG_SCHEMA_VERSION: i32 = 22;
+pub const PG_SCHEMA_VERSION: i32 = 23;
 
 /// Apply PG_SCHEMA_SQL to a pool. PostgreSQL's prepared-statement protocol
 /// rejects multi-statement strings ("cannot insert multiple commands into a
@@ -1166,6 +1181,35 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
         tracing::info!("PG migration 22: redeem_codes table present");
+    }
+
+    if current < 23 {
+        // v1.2.0: hourly traffic history. See the baseline comment.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS traffic_history (
+                rule_id BIGINT NOT NULL,
+                uid BIGINT NOT NULL,
+                hour_ts TEXT NOT NULL,
+                real_upload BIGINT NOT NULL DEFAULT 0,
+                real_download BIGINT NOT NULL DEFAULT 0,
+                billed_total BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (rule_id, hour_ts)
+            )",
+        )
+        .execute(pool)
+        .await?;
+        for idx in [
+            "CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts)",
+            "CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts)",
+        ] {
+            sqlx::query(idx).execute(pool).await?;
+        }
+        sqlx::query(
+            "INSERT INTO schema_version (version) VALUES (23) ON CONFLICT (version) DO NOTHING",
+        )
+        .execute(pool)
+        .await?;
+        tracing::info!("PG migration 23: traffic_history table present");
     }
 
     Ok(())

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -682,6 +682,42 @@ pub trait TrafficRepository: Send + Sync {
         group_id: i64,
         entries: &[TrafficEntry],
     ) -> Result<Vec<TrafficEntryResult>, DbError>;
+
+    // ── v1.2.0: hourly traffic history ──
+
+    /// Aggregated history buckets, oldest first.
+    ///
+    /// `since` is an inclusive 'YYYY-MM-DD HH:00:00' UTC lower bound. `daily`
+    /// collapses hour rows into per-day buckets ('YYYY-MM-DD') — a 30-day
+    /// hourly series is 720 points of noise, so 7d/30d views aggregate by day.
+    ///
+    /// `uid = None` means all users (admin); `rule_id = None` means all rules.
+    /// The API layer is responsible for forcing `uid = Some(caller)` on
+    /// non-admins — this layer trusts its arguments.
+    async fn query_traffic_history(
+        &self,
+        uid: Option<i64>,
+        rule_id: Option<i64>,
+        since: &str,
+        daily: bool,
+    ) -> Result<Vec<TrafficHistoryBucket>, DbError>;
+
+    /// Delete rows with `hour_ts < cutoff`. Returns rows deleted. Called by
+    /// the retention sweeper; the table has no FK so this is the ONLY way rows
+    /// die.
+    async fn prune_traffic_history(&self, cutoff: &str) -> Result<u64, DbError>;
+}
+
+/// One point of the traffic-history series.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow, serde::Serialize)]
+pub struct TrafficHistoryBucket {
+    /// 'YYYY-MM-DD HH:00:00' (hourly) or 'YYYY-MM-DD' (daily), UTC.
+    pub bucket: String,
+    pub real_upload: i64,
+    pub real_download: i64,
+    /// What was actually charged against quota in this bucket — the chart's
+    /// primary series, so it can never disagree with the quota numbers.
+    pub billed_total: i64,
 }
 
 // ── KVS (generic key-value) ──

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -250,6 +250,34 @@ CREATE INDEX IF NOT EXISTS idx_redeem_codes_status ON redeem_codes(status);
 CREATE INDEX IF NOT EXISTS idx_redeem_codes_batch ON redeem_codes(batch_id);
 CREATE INDEX IF NOT EXISTS idx_redeem_codes_used_by ON redeem_codes(used_by);
 
+-- v1.2.0: hourly traffic history, written by apply_traffic_batch as an UPSERT
+-- accumulate. Nodes report every ~10s (poll-frequency), so inserting a row per
+-- report would explode; one row per (rule, hour) keeps 100 rules × 35 days at
+-- ~84k rows.
+--
+-- `billed_total` is the SAME number charged to the user in that batch
+-- (round((up+down) × group rate)), accumulated — so the history chart and the
+-- quota deduction can never disagree. real_upload/real_download stay unrated
+-- for the tooltip.
+--
+-- DELIBERATELY no FK on rule_id/uid: deleting a rule (or a user) must not
+-- erase the usage that already happened — a cascade would make "last 7 days"
+-- quietly shrink. Rows die by retention (35 days), not by parent deletion.
+--
+-- hour_ts is 'YYYY-MM-DD HH:00:00' UTC — the schema-wide TEXT timestamp format
+-- whose lexicographic order is chronological.
+CREATE TABLE IF NOT EXISTS traffic_history (
+    rule_id INTEGER NOT NULL,
+    uid INTEGER NOT NULL,
+    hour_ts TEXT NOT NULL,
+    real_upload INTEGER NOT NULL DEFAULT 0,
+    real_download INTEGER NOT NULL DEFAULT 0,
+    billed_total INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (rule_id, hour_ts)
+);
+CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts);
+CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts);
+
 -- v1.0.9: plan ↔ device_group grant map. Buying a plan (with grant_all_groups=0)
 -- REPLACES the user's user_device_groups with these groups (v1.0.8: purchase is
 -- replace, not append — the plan's grant becomes the user's whole authorized
@@ -1465,6 +1493,30 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
         sqlx::query(idx).execute(pool).await?;
     }
     tracing::info!("Migration 39: redeem_codes table present");
+
+    // ── Migration 40: v1.2.0 hourly traffic history ──
+    // See the SCHEMA_SQL comment for why there is no FK and why one row per
+    // (rule, hour).
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS traffic_history (
+            rule_id INTEGER NOT NULL,
+            uid INTEGER NOT NULL,
+            hour_ts TEXT NOT NULL,
+            real_upload INTEGER NOT NULL DEFAULT 0,
+            real_download INTEGER NOT NULL DEFAULT 0,
+            billed_total INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (rule_id, hour_ts)
+        )",
+    )
+    .execute(pool)
+    .await?;
+    for idx in [
+        "CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts)",
+        "CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts)",
+    ] {
+        sqlx::query(idx).execute(pool).await?;
+    }
+    tracing::info!("Migration 40: traffic_history table present");
 
     Ok(())
 }

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -4554,3 +4554,216 @@ async fn list_and_count_filter_by_status() {
     assert_eq!(rows[0].code, "AAAA0000AAAA0001");
     assert_eq!(db.count_redeem_codes(&unused).await.unwrap(), 1);
 }
+
+// ── v1.2.0: traffic history ──
+
+/// Seed a user + inbound group + rule, mirroring the traffic-batch fixtures.
+/// Returns (uid, group_id, rule_id).
+async fn seed_history_fixture(
+    db: &SqliteRepository,
+    username: &str,
+    group_id: i64,
+    rule_id: i64,
+    rate: f64,
+) -> i64 {
+    db.insert_user(username, "h", 1).await.unwrap();
+    let uid = db.find_by_username(username).await.unwrap().unwrap().id;
+    sqlx::query(
+        "INSERT INTO device_groups (id, name, group_type, token, uid, rate) \
+         VALUES (?, 'gin', 'in', ?, ?, ?)",
+    )
+    .bind(group_id)
+    .bind(format!("tok-{group_id}"))
+    .bind(uid)
+    .bind(rate)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO forward_rules \
+         (id, name, uid, listen_port, device_group_in, target_addr, target_port) \
+         VALUES (?, ?, ?, 20000, ?, '127.0.0.1', 80)",
+    )
+    .bind(rule_id)
+    .bind(format!("r{rule_id}"))
+    .bind(uid)
+    .bind(group_id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+    uid
+}
+
+/// THE agreement invariant: the history's billed_total is the SAME number that
+/// was charged against the user's quota — written in the same transaction.
+/// With rate 3.0, real 1000+2000 bytes bill 9000; history must say 9000 too.
+/// If these ever diverge, the chart calls the billing a liar (or vice versa).
+#[tokio::test]
+async fn traffic_history_agrees_with_quota_charge() {
+    let db = repo().await;
+    let uid = seed_history_fixture(&db, "hist_a", 60, 200, 3.0).await;
+
+    let res = db
+        .apply_traffic_batch(
+            60,
+            &[relay_shared::protocol::TrafficEntry {
+                rule_id: 200,
+                upload: 1000,
+                download: 2000,
+            }],
+        )
+        .await
+        .unwrap();
+    assert!(matches!(res[0], TrafficEntryResult::Ok));
+
+    let user_used: i64 = sqlx::query_scalar("SELECT traffic_used FROM users WHERE id = ?")
+        .bind(uid)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    // SUM over buckets, not one row: a batch straddling an hour rollover may
+    // legitimately produce two rows.
+    let (h_up, h_down, h_billed): (i64, i64, i64) = sqlx::query_as(
+        "SELECT COALESCE(SUM(real_upload),0), COALESCE(SUM(real_download),0), \
+                COALESCE(SUM(billed_total),0) \
+         FROM traffic_history WHERE rule_id = 200",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+
+    assert_eq!(user_used, 9000, "user is billed real × rate");
+    assert_eq!(h_billed, user_used, "history MUST equal the quota charge");
+    assert_eq!((h_up, h_down), (1000, 2000), "real bytes stay unrated");
+}
+
+/// Reports arrive every ~10s; the second batch in the same hour must FOLD into
+/// the existing (rule, hour) row, not add one. If this regresses, the table
+/// grows ~8.6k rows per rule per day and the retention sweeper can't save it.
+#[tokio::test]
+async fn traffic_history_upserts_within_the_hour() {
+    let db = repo().await;
+    seed_history_fixture(&db, "hist_b", 61, 201, 1.0).await;
+
+    for _ in 0..3 {
+        db.apply_traffic_batch(
+            61,
+            &[relay_shared::protocol::TrafficEntry {
+                rule_id: 201,
+                upload: 100,
+                download: 0,
+            }],
+        )
+        .await
+        .unwrap();
+    }
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM traffic_history WHERE rule_id = 201")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    let total: i64 =
+        sqlx::query_scalar("SELECT SUM(real_upload) FROM traffic_history WHERE rule_id = 201")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    // ≤ 2 not == 1: the test could legitimately straddle an hour boundary.
+    assert!(
+        rows <= 2,
+        "3 batches must fold into hour buckets, got {rows} rows"
+    );
+    assert_eq!(total, 300, "accumulation must not lose bytes");
+}
+
+/// Owner scoping + daily aggregation. Alice must never see Bob's buckets, and
+/// the daily view must sum a day's hours into one bucket.
+#[tokio::test]
+async fn traffic_history_query_scopes_and_aggregates() {
+    let db = repo().await;
+    let alice = seed_history_fixture(&db, "hist_c", 62, 202, 1.0).await;
+    let bob = seed_history_fixture(&db, "hist_d", 63, 203, 1.0).await;
+
+    // Hand-written buckets with controlled timestamps (yesterday, two hours).
+    for (uid, rule, hour, up) in [
+        (alice, 202, "2026-07-20 10:00:00", 100i64),
+        (alice, 202, "2026-07-20 11:00:00", 200),
+        (bob, 203, "2026-07-20 10:00:00", 999),
+    ] {
+        sqlx::query(
+            "INSERT INTO traffic_history (rule_id, uid, hour_ts, real_upload, real_download, billed_total) \
+             VALUES (?, ?, ?, ?, 0, ?)",
+        )
+        .bind(rule)
+        .bind(uid)
+        .bind(hour)
+        .bind(up)
+        .bind(up)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    // Alice's daily view: ONE bucket for 2026-07-20, summing her two hours,
+    // with zero contamination from Bob.
+    let daily = db
+        .query_traffic_history(Some(alice), None, "2026-07-01 00:00:00", true)
+        .await
+        .unwrap();
+    assert_eq!(daily.len(), 1, "two hours of one day fold into one bucket");
+    assert_eq!(daily[0].bucket, "2026-07-20");
+    assert_eq!(daily[0].real_upload, 300, "alice's hours summed");
+    assert_eq!(daily[0].billed_total, 300);
+
+    // Hourly view keeps the two hours distinct.
+    let hourly = db
+        .query_traffic_history(Some(alice), None, "2026-07-01 00:00:00", false)
+        .await
+        .unwrap();
+    assert_eq!(hourly.len(), 2);
+    assert_eq!(hourly[0].bucket, "2026-07-20 10:00:00");
+
+    // The unscoped (admin) view sees both users.
+    let all = db
+        .query_traffic_history(None, None, "2026-07-01 00:00:00", true)
+        .await
+        .unwrap();
+    assert_eq!(all[0].real_upload, 300 + 999, "admin sees everyone");
+
+    // rule_id drill-down on a FOREIGN rule returns nothing for alice — the
+    // uid pin makes the endpoint useless as a rule-id existence probe.
+    let foreign = db
+        .query_traffic_history(Some(alice), Some(203), "2026-07-01 00:00:00", true)
+        .await
+        .unwrap();
+    assert!(foreign.is_empty(), "a foreign rule matches nothing");
+}
+
+/// Retention: prune removes strictly-older rows and leaves the rest.
+#[tokio::test]
+async fn traffic_history_prune_respects_cutoff() {
+    let db = repo().await;
+    let uid = seed_history_fixture(&db, "hist_e", 64, 204, 1.0).await;
+    for hour in ["2026-05-01 00:00:00", "2026-07-20 00:00:00"] {
+        sqlx::query(
+            "INSERT INTO traffic_history (rule_id, uid, hour_ts, real_upload, real_download, billed_total) \
+             VALUES (204, ?, ?, 1, 1, 1)",
+        )
+        .bind(uid)
+        .bind(hour)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    let deleted = db
+        .prune_traffic_history("2026-06-15 00:00:00")
+        .await
+        .unwrap();
+    assert_eq!(deleted, 1, "only the pre-cutoff row dies");
+    let left: String =
+        sqlx::query_scalar("SELECT hour_ts FROM traffic_history WHERE rule_id = 204")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(left, "2026-07-20 00:00:00");
+}

--- a/crates/panel/src/db/sqlite_repo/traffic.rs
+++ b/crates/panel/src/db/sqlite_repo/traffic.rs
@@ -184,6 +184,13 @@ impl TrafficRepository for SqliteRepository {
         // trips + no double-counting).
         // v1.0.8: forward_rules += REAL bytes (up+down); users += BILLED bytes
         // (billed_delta = round((up+down) * rate)). ──
+        // v1.2.0: one hour bucket for the whole batch. Nodes report every ~10s,
+        // so history MUST accumulate into (rule, hour) rows — an insert per
+        // report would be ~8.6k rows/rule/day. Computed once so every rule in
+        // the batch lands in the same bucket even across an hour rollover
+        // mid-loop.
+        let hour_ts = chrono::Utc::now().format("%Y-%m-%d %H:00:00").to_string();
+
         for r in &resolved {
             let up = r.delta_up as i64;
             let down = r.delta_down as i64;
@@ -200,9 +207,73 @@ impl TrafficRepository for SqliteRepository {
                 .bind(r.uid)
                 .execute(&mut *tx)
                 .await?;
+            // v1.2.0: history accumulates the SAME billed_delta charged to the
+            // user above — inside the same tx, so the chart and the quota can
+            // never disagree, not even by a crashed half-batch.
+            sqlx::query(
+                "INSERT INTO traffic_history \
+                   (rule_id, uid, hour_ts, real_upload, real_download, billed_total) \
+                 VALUES (?, ?, ?, ?, ?, ?) \
+                 ON CONFLICT(rule_id, hour_ts) DO UPDATE SET \
+                   real_upload = real_upload + excluded.real_upload, \
+                   real_download = real_download + excluded.real_download, \
+                   billed_total = billed_total + excluded.billed_total",
+            )
+            .bind(r.rule_id)
+            .bind(r.uid)
+            .bind(&hour_ts)
+            .bind(up)
+            .bind(down)
+            .bind(r.billed_delta)
+            .execute(&mut *tx)
+            .await?;
         }
 
         tx.commit().await?;
         Ok(vec![TrafficEntryResult::Ok])
+    }
+
+    async fn query_traffic_history(
+        &self,
+        uid: Option<i64>,
+        rule_id: Option<i64>,
+        since: &str,
+        daily: bool,
+    ) -> Result<Vec<TrafficHistoryBucket>, DbError> {
+        // Two statements rather than a parameterised bucket expression — the
+        // GROUP BY column can't be a bind parameter. COALESCE folds the two
+        // optional filters into one prepared statement each (the statistics
+        // query's trick).
+        let sql = if daily {
+            "SELECT substr(hour_ts, 1, 10) AS bucket, \
+                    SUM(real_upload) AS real_upload, \
+                    SUM(real_download) AS real_download, \
+                    SUM(billed_total) AS billed_total \
+             FROM traffic_history \
+             WHERE hour_ts >= ? AND uid = COALESCE(?, uid) AND rule_id = COALESCE(?, rule_id) \
+             GROUP BY bucket ORDER BY bucket"
+        } else {
+            "SELECT hour_ts AS bucket, \
+                    SUM(real_upload) AS real_upload, \
+                    SUM(real_download) AS real_download, \
+                    SUM(billed_total) AS billed_total \
+             FROM traffic_history \
+             WHERE hour_ts >= ? AND uid = COALESCE(?, uid) AND rule_id = COALESCE(?, rule_id) \
+             GROUP BY bucket ORDER BY bucket"
+        };
+        Ok(sqlx::query_as(sql)
+            .bind(since)
+            .bind(uid)
+            .bind(rule_id)
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    async fn prune_traffic_history(&self, cutoff: &str) -> Result<u64, DbError> {
+        Ok(sqlx::query("DELETE FROM traffic_history WHERE hour_ts < ?")
+            .bind(cutoff)
+            .execute(&self.pool)
+            .await?
+            .rows_affected())
     }
 }

--- a/crates/panel/src/main.rs
+++ b/crates/panel/src/main.rs
@@ -121,6 +121,10 @@ async fn main() {
     // doesn't immediately fire for outages that started before.
     service::node_watch::spawn(state.clone());
 
+    // v1.2.0: traffic-history retention. The history table has no FK, so this
+    // sweeper is the only thing that ever deletes its rows.
+    service::history_prune::spawn(state.clone());
+
     let app = app.with_state(state);
 
     let addr: SocketAddr = config.listen.parse().expect("Invalid listen address");

--- a/crates/panel/src/service/history_prune.rs
+++ b/crates/panel/src/service/history_prune.rs
@@ -1,0 +1,41 @@
+//! v1.2.0: traffic-history retention sweeper.
+//!
+//! `traffic_history` has no FK — rows are never deleted by a parent cascade
+//! (deliberate: deleting a rule must not shrink "last 7 days"), so this sweeper
+//! is the ONLY thing that removes them. Without it the table grows forever.
+
+use std::time::Duration;
+
+use crate::api::AppState;
+
+/// Keep 35 days: the UI's largest window is 30d, plus margin so a bucket that
+/// straddles the boundary mid-query never disappears from under a chart.
+const RETENTION_DAYS: i64 = 35;
+
+/// One sweep per hour. Deletion is cheap (indexed range delete) and the
+/// granularity of the data is hourly anyway — sweeping faster buys nothing.
+const TICK: Duration = Duration::from_secs(3600);
+
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(TICK);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        tracing::info!(
+            "traffic-history sweeper started (retention {}d, tick {}s)",
+            RETENTION_DAYS,
+            TICK.as_secs()
+        );
+        loop {
+            ticker.tick().await;
+            let cutoff = (chrono::Utc::now() - chrono::Duration::days(RETENTION_DAYS))
+                .format("%Y-%m-%d %H:00:00")
+                .to_string();
+            match state.db.prune_traffic_history(&cutoff).await {
+                Ok(0) => {}
+                Ok(n) => tracing::info!("traffic-history: pruned {} rows older than {}", n, cutoff),
+                // Transient DB trouble skips the sweep, never kills the loop.
+                Err(e) => tracing::error!("traffic-history: prune failed: {}", e),
+            }
+        }
+    });
+}

--- a/crates/panel/src/service/mod.rs
+++ b/crates/panel/src/service/mod.rs
@@ -1,5 +1,6 @@
 pub mod auto_restart;
 pub mod groups;
+pub mod history_prune;
 pub mod node_config;
 pub mod node_watch;
 pub mod notify;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -92,6 +92,23 @@ export interface ForwardRule {
   created_at: string;
 }
 
+/** v1.2.0: one traffic-history bucket. `bucket` is 'YYYY-MM-DD HH:00:00' UTC;
+ *  the chart converts to the viewer's timezone. `billed_total` is the exact
+ *  number charged against quota in that hour. */
+export interface TrafficHistoryBucket {
+  bucket: string;
+  real_upload: number;
+  real_download: number;
+  billed_total: number;
+}
+
+export interface TrafficHistoryResponse {
+  granularity: string;
+  /** Inclusive UTC lower bound, for zero-filling leading buckets. */
+  since: string;
+  buckets: TrafficHistoryBucket[];
+}
+
 /** v1.2.0: notification settings as returned by the API.
  *
  *  Credentials are NEVER included — only `*_set` booleans saying whether one is

--- a/frontend/src/components/TrafficChart.tsx
+++ b/frontend/src/components/TrafficChart.tsx
@@ -1,0 +1,145 @@
+import { Card, Segmented, Select, Space, Spin, Empty, message } from 'antd';
+import { Column } from '@ant-design/charts';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope, TrafficHistoryResponse } from '../api/types';
+import { useI18n } from '../i18n/context';
+import { formatBytes } from '../utils/format';
+import { foldBuckets } from '../utils/trafficBuckets';
+import type { TrafficPoint } from '../utils/trafficBuckets';
+
+/** The panel's indigo accent (--rp-primary). Validated against the light
+ *  surface with the palette checker: lightness band, chroma floor and 3:1
+ *  contrast all pass. Single series → one hue, no legend (the title names it). */
+const SERIES_COLOR = '#6366f1';
+
+type Range = '1d' | '7d' | '30d';
+
+interface Props {
+  /** Rules for the admin drill-down Select. Omit to hide the filter (the
+   *  Account page: the API pins non-admins to their own uid anyway). */
+  rules?: { id: number; name: string }[];
+}
+
+/**
+ * v1.2.0: traffic-history chart (1d hourly / 7d / 30d daily).
+ *
+ * The primary series is BILLED traffic — the same number the quota deducts, so
+ * this chart can never disagree with "已用流量". Real (unrated) up/down live in
+ * the tooltip; on a rate≠1 line the two visibly differ, and showing only the
+ * real bytes would read as the panel over-charging.
+ *
+ * Buckets are stored in UTC; grouping into days happens HERE, in the viewer's
+ * timezone — a server-side UTC day starts at 08:00 for a CST viewer and would
+ * misfile "yesterday's" traffic.
+ */
+export default function TrafficChart({ rules }: Props) {
+  const { t } = useI18n();
+  const [range, setRange] = useState<Range>('7d');
+  const [ruleId, setRuleId] = useState<number | undefined>(undefined);
+  const [resp, setResp] = useState<TrafficHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({ range });
+      if (ruleId !== undefined) qs.set('rule_id', String(ruleId));
+      const res = await api.get<unknown, ApiEnvelope<TrafficHistoryResponse>>(
+        `/stats/traffic?${qs}`,
+      );
+      if (res.code !== 0 || !res.data) {
+        message.error(res.message || t('loadFailed'));
+        return;
+      }
+      setResp(res.data);
+    } catch {
+      message.error(t('loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [range, ruleId, t]);
+
+  useEffect(() => { load(); }, [load]);
+
+  /** Zero-fill + viewer-timezone bucketing. Lives in utils/trafficBuckets so
+   *  the timezone handling — the part that actually breaks — is unit-tested
+   *  rather than only observable by squinting at a rendered canvas. */
+  const points: TrafficPoint[] = useMemo(
+    () => (resp ? foldBuckets(resp.buckets, resp.since, range === '1d') : []),
+    [resp, range],
+  );
+
+  const hasData = points.some((p) => p.billed > 0 || p.real_upload > 0 || p.real_download > 0);
+
+  return (
+    <Card
+      title={t('trafficHistory')}
+      style={{ marginTop: 16 }}
+      extra={
+        <Space wrap>
+          {rules && rules.length > 0 && (
+            <Select
+              style={{ minWidth: 160 }}
+              allowClear
+              placeholder={t('allRules')}
+              value={ruleId}
+              onChange={(v: number | undefined) => setRuleId(v)}
+              options={rules.map((r) => ({ value: r.id, label: r.name }))}
+            />
+          )}
+          <Segmented
+            value={range}
+            onChange={(v) => setRange(v as Range)}
+            options={[
+              { value: '1d', label: t('range1d') },
+              { value: '7d', label: t('range7d') },
+              { value: '30d', label: t('range30d') },
+            ]}
+          />
+        </Space>
+      }
+    >
+      <Spin spinning={loading}>
+        {!loading && !hasData ? (
+          <Empty description={t('noTrafficYet')} image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        ) : (
+          <Column
+            /* @ant-design/charts v2 (G2 v5) options — NOT the v1 G2Plot shape
+               (columnStyle/xAxis/yAxis), which v2 ignores. Note for anyone
+               debugging "the chart is blank" in an embedded/背景 tab: G2 v5
+               renders on requestAnimationFrame, and a hidden tab never fires
+               rAF — the canvas stays empty with zero errors. Check
+               document.visibilityState before suspecting this config. */
+            height={260}
+            data={points}
+            xField="label"
+            yField="billed"
+            legend={false}
+            style={{ fill: SERIES_COLOR, radiusTopLeft: 4, radiusTopRight: 4 }}
+            axis={{
+              // 30 days of labels don't fit; let the axis thin them out.
+              x: { labelAutoHide: true, labelAutoRotate: false, title: false },
+              y: {
+                title: false,
+                labelFormatter: (v: number) => formatBytes(v),
+              },
+            }}
+            tooltip={{
+              title: (d: TrafficPoint) => d.label,
+              items: [
+                (d: TrafficPoint) => ({
+                  name: t('billedTraffic'),
+                  value: formatBytes(d.billed),
+                  color: SERIES_COLOR,
+                }),
+                (d: TrafficPoint) => ({ name: t('realUpload'), value: formatBytes(d.real_upload) }),
+                (d: TrafficPoint) => ({ name: t('realDownload'), value: formatBytes(d.real_download) }),
+              ],
+            }}
+          />
+        )}
+      </Spin>
+    </Card>
+  );
+}

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -514,6 +514,17 @@ export const enUS: Dict = {
   batchPartial: '{ok} succeeded, {fail} failed (unauthorized lines can\'t be resumed)',
   selectedCount: '{count} selected',
 
+  // ── v1.2.0: traffic history ──
+  trafficHistory: 'Traffic',
+  range1d: '24 hours',
+  range7d: '7 days',
+  range30d: '30 days',
+  allRules: 'All rules',
+  billedTraffic: 'Billed traffic',
+  realUpload: 'Real upload',
+  realDownload: 'Real download',
+  noTrafficYet: 'No traffic recorded in this window (recording starts after the panel upgrade)',
+
   // ── v1.2.0: node offline notifications ──
   notifySettings: 'Notifications',
   notifyIntro: 'Node offline alerts',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -513,6 +513,17 @@ export const zhCN = {
   batchPartial: '成功 {ok} 条，失败 {fail} 条（无权限的线路无法启动）',
   selectedCount: '已选 {count} 条',
 
+  // ── v1.2.0: 流量历史 ──
+  trafficHistory: '流量趋势',
+  range1d: '24 小时',
+  range7d: '7 天',
+  range30d: '30 天',
+  allRules: '全部规则',
+  billedTraffic: '计费流量',
+  realUpload: '真实上行',
+  realDownload: '真实下行',
+  noTrafficYet: '该时间段内暂无流量记录(升级面板后开始记录)',
+
   // ── v1.2.0: 节点掉线通知 ──
   notifySettings: '通知设置',
   notifyIntro: '节点掉线告警',

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '../i18n/context';
 import { formatBytes } from '../utils/format';
 import { makePasswordValidator } from '../utils/password';
 import { useAuth } from '../auth/useAuth';
+import TrafficChart from '../components/TrafficChart';
 
 const { Text } = Typography;
 
@@ -211,6 +212,10 @@ export default function Account() {
           </Descriptions.Item>
         </Descriptions>
       </Card>
+
+      {/* v1.2.0: the user's own traffic trend. No rule filter here — the API
+          pins non-admins to their own uid, so the total IS their usage. */}
+      <TrafficChart />
 
       <Modal
         title={t('changePassword')}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import api from '../api/client';
 import type { ApiEnvelope, User, ForwardRule, DeviceGroup, NodeStatus } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { aggregateNodesByGroup } from '../components/nodes/aggregate';
+import TrafficChart from '../components/TrafficChart';
 import { formatBps, formatBytes } from '../utils/format';
 
 const { Text } = Typography;
@@ -39,6 +40,8 @@ export default function Dashboard() {
   const { t } = useI18n();
   const navigate = useNavigate();
   const [stats, setStats] = useState({ users: 0, rules: 0, groups: 0 });
+  // v1.2.0: kept whole (not just the count) for the traffic chart's drill-down.
+  const [ruleList, setRuleList] = useState<ForwardRule[]>([]);
   const [nodes, setNodes] = useState<NodeStatus[]>([]);
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const [showChangelog, setShowChangelog] = useState(false);
@@ -56,6 +59,7 @@ export default function Dashboard() {
         rules: rules.data?.length || 0,
         groups: groups.data?.length || 0,
       });
+      setRuleList(rules.data || []);
     } catch { /* ignore */ }
 
     try {
@@ -268,6 +272,9 @@ export default function Dashboard() {
           <Card className="rp-stat-card"><Statistic title={t('deviceGroups')} value={stats.groups} prefix={<CloudServerOutlined style={{ color: 'var(--rp-primary)' }} />} /></Card>
         </Col>
       </Row>
+
+      {/* v1.2.0: fleet-wide traffic trend, with per-rule drill-down. */}
+      <TrafficChart rules={ruleList.map(r => ({ id: r.id, name: r.name }))} />
 
       <Card title={t('nodeStatus')} extra={<Text type="secondary" style={{ fontSize: 12 }}>{t('autoRefresh10s')}</Text>}>
         {groups.length === 0

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -45,6 +45,15 @@ const _origGetComputedStyle = window.getComputedStyle.bind(window);
 window.getComputedStyle = ((elt: Element) =>
   _origGetComputedStyle(elt)) as typeof window.getComputedStyle;
 
+// v1.2.0: @ant-design/charts renders on <canvas>, which jsdom does not
+// implement — mounting any page that embeds a chart (Dashboard, Account) would
+// crash with "Not implemented: HTMLCanvasElement.prototype.getContext". A
+// chart is visual output jsdom could never assert on anyway, so stub the
+// library; the page tests keep testing the page around it.
+vi.mock('@ant-design/charts', () => ({
+  Column: () => null,
+}));
+
 // Unmount rendered components between tests so each test starts from a clean
 // DOM (otherwise multiple StateProbe instances accumulate and getByTestId finds
 // duplicates). @testing-library/react auto-cleans when globals are enabled; we

--- a/frontend/src/utils/trafficBuckets.test.ts
+++ b/frontend/src/utils/trafficBuckets.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { foldBuckets, localDayKey, parseUtcBucket } from './trafficBuckets';
+import type { TrafficHistoryBucket } from '../api/types';
+
+const b = (bucket: string, billed: number, up = 0, down = 0): TrafficHistoryBucket => ({
+  bucket,
+  billed_total: billed,
+  real_upload: up,
+  real_download: down,
+});
+
+describe('traffic bucket folding', () => {
+  it('parses a stored bucket as UTC, not local time', () => {
+    // Without the trailing Z this would be read as local time and shift by the
+    // viewer's offset — the root cause of every "my traffic is on the wrong
+    // day" report.
+    expect(parseUtcBucket('2026-07-20 10:00:00').toISOString()).toBe('2026-07-20T10:00:00.000Z');
+  });
+
+  it('zero-fills quiet hours instead of collapsing the gap', () => {
+    const points = foldBuckets(
+      [b('2026-07-20 12:00:00', 500)],
+      '2026-07-20 10:00:00',
+      true,
+      new Date('2026-07-20T13:00:00Z'),
+    );
+    // 10,11,12,13 → four columns, only one with data. A collapsed axis would
+    // imply continuous usage.
+    expect(points).toHaveLength(4);
+    expect(points.filter((p) => p.billed > 0)).toHaveLength(1);
+    expect(points.map((p) => p.billed)).toEqual([0, 0, 500, 0]);
+  });
+
+  it('sums several hours of the same day into one daily column', () => {
+    const points = foldBuckets(
+      [b('2026-07-20 10:00:00', 100, 10, 1), b('2026-07-20 11:00:00', 200, 20, 2)],
+      '2026-07-20 09:00:00',
+      false,
+      new Date('2026-07-20T12:00:00Z'),
+    );
+    const total = points.reduce((n, p) => n + p.billed, 0);
+    expect(total).toBe(300);
+    expect(points.reduce((n, p) => n + p.real_upload, 0)).toBe(30);
+    expect(points.reduce((n, p) => n + p.real_download, 0)).toBe(3);
+  });
+
+  it('keeps real and billed independent (rate != 1 lines)', () => {
+    // A x3 line: billed is 3x real. If the chart derived one from the other,
+    // the tooltip would contradict the quota.
+    const points = foldBuckets(
+      [b('2026-07-20 10:00:00', 3000, 500, 500)],
+      '2026-07-20 10:00:00',
+      true,
+      new Date('2026-07-20T10:00:00Z'),
+    );
+    expect(points[0].billed).toBe(3000);
+    expect(points[0].real_upload + points[0].real_download).toBe(1000);
+  });
+
+  it('surfaces a bucket that falls outside the skeleton (clock skew)', () => {
+    const points = foldBuckets(
+      [b('2026-07-21 05:00:00', 42)],
+      '2026-07-20 10:00:00',
+      true,
+      new Date('2026-07-20T11:00:00Z'),
+    );
+    // Dropping it would silently hide real usage.
+    expect(points.reduce((n, p) => n + p.billed, 0)).toBe(42);
+  });
+});
+
+// The whole reason day-grouping is client-side. Pin the behaviour with a real
+// non-UTC timezone rather than trusting the CI machine's locale.
+describe('daily grouping uses the VIEWER timezone, not UTC', () => {
+  const realOffset = Date.prototype.getTimezoneOffset;
+  const realDay = Date.prototype.getDate;
+  const realMonth = Date.prototype.getMonth;
+  const realFullYear = Date.prototype.getFullYear;
+
+  beforeAll(() => {
+    // Simulate UTC+8 (CST): local time = UTC + 8h.
+    const shifted = function (this: Date) {
+      return new Date(this.getTime() + 8 * 3600_000);
+    };
+    Date.prototype.getTimezoneOffset = function () { return -480; };
+    Date.prototype.getDate = function () { return shifted.call(this).getUTCDate(); };
+    Date.prototype.getMonth = function () { return shifted.call(this).getUTCMonth(); };
+    Date.prototype.getFullYear = function () { return shifted.call(this).getUTCFullYear(); };
+  });
+  afterAll(() => {
+    Date.prototype.getTimezoneOffset = realOffset;
+    Date.prototype.getDate = realDay;
+    Date.prototype.getMonth = realMonth;
+    Date.prototype.getFullYear = realFullYear;
+  });
+
+  it('files 23:00 UTC as the NEXT local day for a UTC+8 viewer', () => {
+    // 2026-07-20 23:00 UTC is 2026-07-21 07:00 in UTC+8. A server-side UTC
+    // grouping would put it on the 20th — visibly wrong to the operator.
+    expect(localDayKey(parseUtcBucket('2026-07-20 23:00:00'))).toBe('2026-07-21');
+  });
+
+  it('splits one UTC day across two local days', () => {
+    const points = foldBuckets(
+      [
+        b('2026-07-20 10:00:00', 100), // 18:00 local, 20th
+        b('2026-07-20 23:00:00', 700), // 07:00 local, 21st
+      ],
+      '2026-07-20 10:00:00',
+      false,
+      new Date('2026-07-20T23:00:00Z'),
+    );
+    const byLabel = Object.fromEntries(points.map((p) => [p.label, p.billed]));
+    expect(byLabel['07-20']).toBe(100);
+    expect(byLabel['07-21']).toBe(700);
+  });
+});

--- a/frontend/src/utils/trafficBuckets.ts
+++ b/frontend/src/utils/trafficBuckets.ts
@@ -1,0 +1,84 @@
+import type { TrafficHistoryBucket } from '../api/types';
+
+/** One plotted point, already in the viewer's timezone. */
+export interface TrafficPoint {
+  /** X label. "MM-DD HH:00" hourly, "MM-DD" daily. */
+  label: string;
+  billed: number;
+  real_upload: number;
+  real_download: number;
+}
+
+/** Parse a stored 'YYYY-MM-DD HH:00:00' UTC bucket into a Date. */
+export function parseUtcBucket(s: string): Date {
+  return new Date(s.replace(' ', 'T') + 'Z');
+}
+
+/** Local-timezone day key, YYYY-MM-DD. */
+export function localDayKey(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/** Local hour label, "MM-DD HH:00". */
+export function localHourLabel(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:00`;
+}
+
+/**
+ * Fold UTC hour buckets into the plotted series, in the VIEWER'S timezone.
+ *
+ * This is the part that actually goes wrong, so it lives outside the component
+ * and is unit-tested: the API stores UTC hours, but a UTC "day" starts at 08:00
+ * for a UTC+8 viewer — grouping server-side would visibly misfile yesterday's
+ * traffic for every non-UTC operator.
+ *
+ * Also zero-fills: an honest time axis shows quiet hours as empty columns
+ * rather than silently collapsing the gap and implying continuous usage.
+ *
+ * @param since  inclusive UTC lower bound ('YYYY-MM-DD HH:00:00') from the API
+ * @param now    upper bound (injectable for tests)
+ */
+export function foldBuckets(
+  buckets: TrafficHistoryBucket[],
+  since: string,
+  hourly: boolean,
+  now: Date = new Date(),
+): TrafficPoint[] {
+  const byKey = new Map<string, TrafficPoint>();
+  const order: string[] = [];
+
+  const keyOf = (d: Date) => (hourly ? d.toISOString().slice(0, 13) : localDayKey(d));
+  const labelOf = (d: Date) => (hourly ? localHourLabel(d) : localDayKey(d).slice(5));
+
+  const upsert = (d: Date) => {
+    const key = keyOf(d);
+    let p = byKey.get(key);
+    if (!p) {
+      p = { label: labelOf(d), billed: 0, real_upload: 0, real_download: 0 };
+      byKey.set(key, p);
+      order.push(key);
+    }
+    return p;
+  };
+
+  // 1) Skeleton: every hour from `since` to `now`, all zeros. Stepping by hour
+  //    (not by day) is what makes the daily path land each hour in the right
+  //    LOCAL day — a day boundary in local time falls mid-UTC-day.
+  const start = parseUtcBucket(since);
+  for (let d = new Date(start); d <= now; d = new Date(d.getTime() + 3600_000)) {
+    upsert(d);
+  }
+
+  // 2) Fold the data in. A bucket outside the skeleton (clock skew) still
+  //    appears rather than being dropped.
+  for (const b of buckets) {
+    const p = upsert(parseUtcBucket(b.bucket));
+    p.billed += b.billed_total;
+    p.real_upload += b.real_upload;
+    p.real_download += b.real_download;
+  }
+
+  return order.map((k) => byKey.get(k)!);
+}


### PR DESCRIPTION
> 独立 PR,和 #70(卡密)、#71(掉线告警)互不依赖,三个可以并行合。

## 为什么做这个

`forward_rules.traffic_used` 只是个**累计总数,没有时间维度**。所以没人答得上来两个最关键的问题:

- 用户:「我这周用了多少?」
- 你:「哪条规则昨晚突然跑了 500G?」

而这恰恰是转发面板最容易出事的地方 —— **跑量异常、被盗用、突发流量,事后完全无法追溯**。

现在按小时记录,仪表盘看全局(可下钻到单条规则),个人中心看自己的。

## 图表画的是「计费流量」,不是真实流量

这是最重要的取舍。图表主序列 = **额度实际扣减的那个数字**,并且和扣费在**同一个事务里**累加。

因为线路有倍率:真实 100G 在 3 倍线路上扣 300G。如果图表只画真实字节,用户会看到「图上 100G,额度掉了 300G」—— 那读起来就是面板在乱扣费。真实上/下行放 tooltip 里,倍率≠1 时两者可见地不同。

有测试钉死这条对账不变量:x2 线路跑一批之后,`history.billed_total` 必须**等于** `users.traffic_used`。

## 每条规则每小时一行

节点按 poll 间隔上报(默认 **10 秒**),每次上报插一行的话是 **~8600 行/规则/天**。所以写入是 UPSERT 累加到当前小时桶,100 条规则存 35 天约 8.4 万行。

## 按天分组在**浏览器时区**做,不在服务端

桶按 UTC 存储。而 **UTC 的一天对 UTC+8 的你来说是从早上 8 点开始的** —— 服务端按 UTC 分组会把「昨天的流量」明显归错天。

所以 API **始终返回小时桶**,由前端折叠。这个折叠逻辑抽成了纯函数 `utils/trafficBuckets` 并写了单测,**包括模拟 UTC+8 视角**:

```
23:00 UTC → 本地 2026-07-21(第二天)✓
一个 UTC 日被拆进两个本地日 ✓
```

时区才是真正会出 bug 的地方,盯着画布看是永远看不出来的。

## 历史表故意不加外键

删规则**不能**让「最近 7 天」缩水。行只由保留策略(35 天,每小时清理)删除,没有别的路径。

顺带:安静时段**零填充**而不是压缩,否则坐标轴会暗示一段并不存在的连续用量。

## 验证

**走真实节点上报接口**验的,不是直接写库:

| 检查 | 结果 |
|---|---|
| Migration 40 / 清理任务启动 | ✓ 日志确认 |
| 3 次上报(rate=2.0 分组) | ✓ 折叠成 **1 个**小时桶 |
| 对账 | ✓ `billed_total` = `traffic_used` = 3774873600 |
| 真实字节不受倍率影响 | ✓ 314572800 / 1572864000 |
| `range=99d` | ✓ 400 拒绝 |
| 时区折叠 | ✓ 7 个单测,含 UTC+8 |

- Rust **578** 测试通过,clippy `-D warnings` 零告警,双库奇偶校验通过
- 前端 typecheck / lint / **166** 测试 / build 全过

## ⚠️ 有一件我没能验证,请你过目

**图表画布的实际渲染我没能确认。** 我的浏览器 tab 始终是 `visibilityState: "hidden"`,而 G2 v5 靠 `requestAnimationFrame` 渲染 —— 隐藏 tab 不触发 rAF,画布保持空白**且不报任何错**。

我验证到的极限是:API 返回正确数据 → 组件判定有数据(渲染 canvas 而非空状态)→ canvas 元素挂载且尺寸正确(947x260)。**但画布像素为 0。**

过程中我确实发现并修了一个真问题:初版用的是 `@ant-design/charts` **v1 的配置语法**(`columnStyle`/`xAxis`/`yAxis`),而项目装的是 v2(G2 v5)—— v2 会**静默忽略** v1 的属性。已改成 v2 语法(`style`/`axis`/`tooltip`),代码注释里也写了这个坑。

**但改完之后我没能在这个环境里看到它真的画出来。** 请你在真实浏览器里打开仪表盘看一眼图表长得对不对。如果是空白,大概率还是配置语法问题,不是数据问题(数据链路上面已经验证过了)。

## 说明

「面板还缺什么」三件的最后一件。三个 PR 都是独立的。

发布提醒仍然有效:节点必须打 `node-v1.2.0`(重启功能门槛硬编码 `>=1.2.0`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
