### PR TITLE
fix(shop): 给用户一个看得见的卡密充值入口

### DIFF
--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Card, Descriptions, Spin, Button, Space, Modal, Form, Input, message, Typography, Result, Progress, Alert, Tag } from 'antd';
-import { LockOutlined, LogoutOutlined } from '@ant-design/icons';
+import { LockOutlined, LogoutOutlined, WalletOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import api from '../api/client';
 import type { ApiEnvelope, UserSelf } from '../api/types';
@@ -179,10 +179,16 @@ export default function Account() {
               <span className="rp-mono">{me.balance}</span>
               {/* v1.2.0: self-service top-up. It lives on the balance row
                   because that is exactly where a user looks when they find
-                  they can't afford a plan. */}
+                  they can't afford a plan.
+
+                  Ghost-primary with an icon, not a bare text link: as a `link`
+                  button beside a number it read as a label rather than a
+                  control, and users reported finding no way to top up at all. */}
               <Button
                 size="small"
-                type="link"
+                type="primary"
+                ghost
+                icon={<WalletOutlined />}
                 onClick={() => { redeemForm.resetFields(); setRedeemOpen(true); }}
               >
                 {t('redeem')}

--- a/frontend/src/pages/Shop.test.tsx
+++ b/frontend/src/pages/Shop.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Mock the api client before importing the page. Shop calls /plans,
+// /user/orders and /user/me on mount, and POSTs /user/redeem on top-up.
+const { mockGet, mockPost } = vi.hoisted(() => ({ mockGet: vi.fn(), mockPost: vi.fn() }));
+
+vi.mock('../api/client', () => ({
+  default: { get: mockGet, post: mockPost },
+}));
+
+import Shop from './Shop';
+
+const ok = <T,>(data: T) => ({ code: 0, message: 'ok', data });
+
+const me = (balance: string) => ({
+  username: 'u1',
+  balance,
+  admin: false,
+  suspended: false,
+  max_rules: 5,
+  current_rules: 0,
+  traffic_limit: 0,
+  traffic_used: 0,
+});
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockGet.mockImplementation((url: string) => {
+    if (url === '/plans') return Promise.resolve(ok([]));
+    if (url === '/user/orders') return Promise.resolve(ok([]));
+    if (url === '/user/me') return Promise.resolve(ok(me('0')));
+    return Promise.reject(new Error(`unmocked GET ${url}`));
+  });
+});
+
+const renderShop = async () => {
+  await act(async () => { render(<Shop />); });
+};
+
+/**
+ * The shop is where a user discovers they can't afford a plan. Users reported
+ * finding "nowhere to top up" when the only redeem entry lived on the account
+ * page, so the presence of this control is a product requirement, not styling.
+ */
+describe('Shop top-up entry', () => {
+  it('offers a redeem control next to the balance', async () => {
+    await renderShop();
+    // No I18nProvider in this harness, so t() yields the raw key — asserting
+    // on it keeps the test independent of translation wording.
+    expect(screen.getByRole('button', { name: /redeem/ })).toBeInTheDocument();
+  });
+
+  it('redeems a code and reflects the new balance without leaving the page', async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue(ok({ amount: '25.50', balance: '25.50' }));
+    await renderShop();
+
+    await user.click(screen.getByRole('button', { name: /redeem/ }));
+    // Deliberately lowercase + dashed: the server normalizes, and the client
+    // must not police the format or it would reject codes the server accepts.
+    await user.type(screen.getByRole('textbox'), 'test0-test0-test0-t');
+
+    // Balance is re-read from the server rather than patched client-side, so
+    // the displayed number can never drift from what the backend recorded.
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/plans') return Promise.resolve(ok([]));
+      if (url === '/user/orders') return Promise.resolve(ok([]));
+      if (url === '/user/me') return Promise.resolve(ok(me('25.50')));
+      return Promise.reject(new Error(`unmocked GET ${url}`));
+    });
+
+    await user.click(screen.getByRole('button', { name: /redeemConfirm/ }));
+
+    expect(mockPost).toHaveBeenCalledWith('/user/redeem', { code: 'test0-test0-test0-t' });
+    expect(await screen.findByText('25.50')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Shop.tsx
+++ b/frontend/src/pages/Shop.tsx
@@ -1,5 +1,5 @@
-import { Card, Row, Col, Button, Spin, Tag, Modal, Table, Typography, message, Result, Alert, Space } from 'antd';
-import { ShoppingOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Card, Row, Col, Button, Spin, Tag, Modal, Table, Typography, message, Result, Alert, Space, Form, Input } from 'antd';
+import { ShoppingOutlined, ReloadOutlined, WalletOutlined } from '@ant-design/icons';
 import { useCallback, useEffect, useState } from 'react';
 import api from '../api/client';
 import type { ApiEnvelope, Plan, Order, UserSelf } from '../api/types';
@@ -24,6 +24,11 @@ export default function Shop() {
   const [loadFailed, setLoadFailed] = useState(false);
   const [buying, setBuying] = useState<Plan | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // v1.2.0: redeem-code top-up, mirrored from the account page so a user who
+  // finds their balance short can fix it without leaving the shop.
+  const [redeemOpen, setRedeemOpen] = useState(false);
+  const [redeemForm] = Form.useForm();
+  const [redeeming, setRedeeming] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -59,6 +64,29 @@ export default function Shop() {
       message.error(t('purchaseFailed'));
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleRedeem = async (values: { code: string }) => {
+    setRedeeming(true);
+    try {
+      const res = await api.post<unknown, ApiEnvelope<{ amount: string; balance: string }>>(
+        '/user/redeem',
+        { code: values.code },
+      );
+      if (res.code !== 0) { message.error(res.message); return; }
+      message.success(
+        t('redeemSuccess')
+          .replace('{amount}', res.data?.amount ?? '')
+          .replace('{balance}', res.data?.balance ?? ''),
+      );
+      setRedeemOpen(false);
+      redeemForm.resetFields();
+      load(); // the balance shown above the plan cards must reflect the top-up
+    } catch {
+      message.error(t('redeemFailed'));
+    } finally {
+      setRedeeming(false);
     }
   };
 
@@ -101,12 +129,26 @@ export default function Shop() {
         />
       )}
 
-      {/* Balance + the "流量叠加" note. */}
+      {/* Balance + top-up + the "流量叠加" note.
+
+          v1.2.0: the redeem entry point lives HERE as well as on the account
+          page, because this is where a user actually discovers they can't
+          afford a plan. Making them go hunt for it on another page is the
+          difference between a sale and an abandoned one. */}
       {me && (
         <Card size="small" style={{ marginBottom: 16 }}>
-          <Space>
+          <Space wrap>
             <Text strong>{t('accountBalance')}:</Text>
             <span className="rp-mono">{me.balance}</span>
+            <Button
+              size="small"
+              type="primary"
+              ghost
+              icon={<WalletOutlined />}
+              onClick={() => { redeemForm.resetFields(); setRedeemOpen(true); }}
+            >
+              {t('redeem')}
+            </Button>
             <Text type="secondary" style={{ marginLeft: 16 }}>·</Text>
             <Text type="secondary">{t('shopTrafficStacksHint')}</Text>
           </Space>
@@ -192,6 +234,30 @@ export default function Shop() {
             )}
           </div>
         )}
+      </Modal>
+
+      {/* Same permissive field as the account page: the backend normalizes
+          case, dashes, whitespace and O/0 · I/L/1 confusions, so no
+          client-side format policing that would reject a valid code. */}
+      <Modal
+        title={t('redeem')}
+        open={redeemOpen}
+        onCancel={() => setRedeemOpen(false)}
+        onOk={() => redeemForm.submit()}
+        okText={t('redeemConfirm')}
+        cancelText={t('cancel')}
+        confirmLoading={redeeming}
+      >
+        <Form form={redeemForm} onFinish={handleRedeem} layout="vertical">
+          <Form.Item
+            name="code"
+            label={t('redeemCode')}
+            extra={t('redeemCodeHint')}
+            rules={[{ required: true, message: t('redeemCodeRequired') }]}
+          >
+            <Input placeholder="XXXX-XXXX-XXXX-XXXX" autoComplete="off" />
+          </Form.Item>
+        </Form>
       </Modal>
     </>
   );


### PR DESCRIPTION
## 问题

用户反馈「普通用户个人中心没地方充值卡密」。

排查后确认按钮其实是存在的,也确实部署上去了 —— 但它是余额数字旁边一个 `type="link"` 的小号文字按钮,看上去像标签而不是能点的控件。更关键的是:用户真正想充值的时刻是在**套餐商店**发现余额不够的时候,而不是在个人中心。

## 改动

- **商店页余额卡片加同一个充值入口**。充值成功后重新拉 `/user/me`,而不是本地改数字 —— 保证套餐卡片上方显示的余额永远不会和后端记录的对不上,同时用户不用离开购买流程。
- **个人中心按钮从 `type="link"` 改为 ghost primary + 钱包图标**,两处都读起来像个控件。

两处输入框都保持宽松:后端已经归一化了大小写、横杠、空格以及 O/0 · I/L/1 混淆,前端再做格式校验只会拒掉服务端本来能接受的卡密。

## 验证

本地面板端到端跑通:用小写带横杠的 `test0-test0-test0-t` 充值,余额 0 → 25.50,卡片原地刷新,没有跳页。

新增 `Shop.test.tsx` 钉住两件事:入口存在、充值往返正确。**去掉 Shop.tsx 的改动后这两个用例会挂**,不是白测。

`tsc --noEmit` / `eslint` / `vitest`(16 文件 168 用例)全绿。

## 说明

这个分支直接基于 `main`,和 #73 没有依赖关系,可以独立合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)