### PR TITLE
chore(release): 1.2.0(面板 + 节点)

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
-## [Unreleased]
+## [1.2.0] - 2026-07-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
-## [Unreleased]
+## [1.2.0] - 2026-07-21
 
 ### Added
 
@@ -135,6 +135,13 @@ independent `v*` / `node-v*` tracks since this release).
 
 ### Fixed
 
+- **The redeem-code entry is now findable.** The control existed only on the
+  account page, as a small text-link button beside the balance number — users
+  reported there was no way to top up at all. It now also sits on the shop's
+  balance card (where you actually discover you can't afford a plan, so you no
+  longer have to leave the purchase flow), and reads as a button in both places.
+  Redeeming re-reads the account rather than patching the number locally, so the
+  displayed balance can't drift from what the backend recorded.
 - **The traffic chart no longer appears twice for admins.** It was on both the
   dashboard (fleet-wide) and the account page (personal); an admin's "personal"
   traffic is a near-meaningless number, so the duplicate card was just noise.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.1.2"
+version = "1.2.0"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.1.3";
+const COMPILED_APP_VERSION: &str = "1.2.0";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.1.3}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.0}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -57,7 +57,7 @@ services:
     # v1.2: the node image tag is INDEPENDENT of the panel tag. Override
     # RELAYPANEL_NODE_TAG in .env to pin a node version that differs from the
     # panel version.
-    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.1.2}
+    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.0}
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.1.2"
+SCRIPT_VERSION="1.2.0"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
## 发版内容

自 v1.1.3 攒的一批,共 7 个 PR:#65 #69 #70 #71 #72 #73 #74

- 规则连接数上限 + 手动/批量/定时重启
- 卡密充值(含 #74 的入口可见性修复)
- 节点掉线 TG / 邮件告警
- 流量历史 1d / 7d / 30d,按线路堆叠

## 为什么面板和节点必须一起发 1.2.0

面板对 `restart_rule` **硬编码要求节点 >= 1.2.0**。只发面板不打 `node-v1.2.0`,规则重启在所有已部署节点上会永久失效,而且**没有任何报错**——功能看着在,点了没反应。

## 验证

- `release-check.sh panel 1.2.0` → 78 OK / 0 FAIL
- `release-check.sh node 1.2.0` → 77 OK / 0 FAIL
- `cargo fmt --check` / `clippy` 干净
- Rust 588 用例、前端 174 用例全过
- `check-repo-test-parity.sh` OK(sqlite 119 / pg 118)
- 前端构建通过

合并后打 `v1.2.0` 和 `node-v1.2.0` 两个 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)