### PR TITLE
fix(schema): 基线不要给一个自己没建出来的列建索引(1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.2.1] - 2026-07-21
+
+### Fixed
+
+- **The panel no longer fails to start against a database whose
+  `traffic_history` predates `group_id`.** The baseline schema re-runs on every
+  boot and creates the table with `IF NOT EXISTS` — a no-op when the table is
+  already there. It then indexed `group_id`, which on such a database runs
+  *before* the migration that adds the column, so startup aborted with "column
+  group_id does not exist" and the container crash-looped.
+
+  The index now lives only in the migration that adds the column (SQLite
+  Migration 41 / PG revision 24). Migrations run on fresh installs too, so it is
+  still created exactly once either way — no schema version change.
+
+  A **released** 1.1.3 deployment is not affected: `traffic_history` did not
+  exist before 1.2.0, so an upgrade builds the table from the baseline with the
+  column already present. This only bites a database carrying the intermediate
+  shape, i.e. one running a pre-release build. Every fresh-install test passed
+  throughout, which is exactly why this reached a tag; there is now a test that
+  boots from the pre-`group_id` shape instead.
+
 ## [1.2.0] - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.0";
+const COMPILED_APP_VERSION: &str = "1.2.1";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -215,7 +215,13 @@ CREATE TABLE IF NOT EXISTS traffic_history (
 );
 CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts);
 CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts);
-CREATE INDEX IF NOT EXISTS idx_traffic_history_group ON traffic_history(group_id, hour_ts);
+-- NOTE: the index on group_id is deliberately NOT here — it lives in revision
+-- 24, next to the ALTER that adds the column. This whole file re-runs on every
+-- boot, and `CREATE TABLE IF NOT EXISTS` is a no-op against a database whose
+-- traffic_history predates group_id. Indexing the column here would then run
+-- BEFORE the ALTER that creates it and abort startup with "column group_id does
+-- not exist". Revisions run on fresh installs too, so the index is still
+-- created exactly once either way.
 
 -- v1.0.9: plan ↔ device_group grant map (mirrors SQLite baseline + Migration 35).
 CREATE TABLE IF NOT EXISTS plan_device_groups (

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -288,7 +288,13 @@ CREATE TABLE IF NOT EXISTS traffic_history (
 );
 CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts);
 CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts);
-CREATE INDEX IF NOT EXISTS idx_traffic_history_group ON traffic_history(group_id, hour_ts);
+-- NOTE: the index on group_id is deliberately NOT here — it lives in Migration
+-- 41, next to the ALTER that adds the column. This schema re-runs on every
+-- boot, and `CREATE TABLE IF NOT EXISTS` is a no-op against a database whose
+-- traffic_history predates group_id. Indexing the column here would then run
+-- BEFORE the ALTER that creates it and abort startup with "no such column:
+-- group_id". Migrations run on fresh installs too, so the index is still
+-- created exactly once either way.
 
 -- v1.0.9: plan ↔ device_group grant map. Buying a plan (with grant_all_groups=0)
 -- REPLACES the user's user_device_groups with these groups (v1.0.8: purchase is
@@ -2289,5 +2295,78 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(still_paused.0, 1);
+    }
+
+    /// A database whose `traffic_history` predates `group_id` must still boot.
+    ///
+    /// SCHEMA_SQL re-runs on every start, and `CREATE TABLE IF NOT EXISTS` is a
+    /// no-op when the table already exists — so any index in the baseline that
+    /// names a column added by a later migration executes BEFORE the ALTER that
+    /// creates it, and startup aborts with "no such column". That is not
+    /// hypothetical: it took the panel down on a box carrying a pre-release
+    /// traffic_history, crash-looping on every restart.
+    ///
+    /// Every fresh-install test passes in that situation, because a fresh
+    /// install builds the table from the baseline WITH the column. Only an
+    /// upgrade from the intermediate shape reproduces it, which is what this
+    /// test pins.
+    #[tokio::test]
+    async fn traffic_history_without_group_id_still_upgrades() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        // The table exactly as it existed BEFORE group_id was introduced.
+        sqlx::query(
+            r#"CREATE TABLE traffic_history (
+                rule_id INTEGER NOT NULL,
+                uid INTEGER NOT NULL,
+                hour_ts TEXT NOT NULL,
+                real_upload INTEGER NOT NULL DEFAULT 0,
+                real_download INTEGER NOT NULL DEFAULT 0,
+                billed_total INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (rule_id, hour_ts)
+            )"#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO traffic_history (rule_id, uid, hour_ts, billed_total) VALUES (1, 1, '2026-07-21 10:00:00', 4096)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Booting = applying the baseline, then the migrations. This is the
+        // step that used to fail.
+        sqlx::query(SCHEMA_SQL)
+            .execute(&pool)
+            .await
+            .expect("baseline must tolerate a pre-group_id traffic_history");
+        run_migrations(&pool)
+            .await
+            .expect("migrations must upgrade a pre-group_id traffic_history");
+
+        assert_column(&pool, "traffic_history", "group_id").await;
+
+        // The pre-existing row survives with the documented 0 = unknown default
+        // rather than being dropped or rewritten.
+        let (rows, billed, group): (i64, i64, i64) = sqlx::query_as(
+            "SELECT COUNT(*), MAX(billed_total), MAX(group_id) FROM traffic_history",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows, 1, "existing history must not be lost");
+        assert_eq!(billed, 4096);
+        assert_eq!(group, 0);
+
+        // And the whole thing is re-runnable, since it runs on every boot.
+        sqlx::query(SCHEMA_SQL)
+            .execute(&pool)
+            .await
+            .expect("re-run baseline");
+        run_migrations(&pool).await.expect("re-run migrations");
     }
 }

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.0}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.1}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)


### PR DESCRIPTION
## 问题

面板在 1.2.0 启动时崩溃重启循环:

```
column "group_id" does not exist   (PG)
no such column: group_id           (SQLite)
```

**在测试机上实测复现,面板起不来,已回滚到 1.1.3 保住服务。**

## 原因

基线 schema 每次启动都会重跑。`CREATE TABLE IF NOT EXISTS traffic_history (... group_id ...)` 在表已存在时是空操作,但下一行的 `CREATE INDEX ... (group_id, hour_ts)` **不是** —— 它跑在 Migration 41 / PG revision 24 的 ALTER **之前**,直接把启动打挂。面板压根到不了迁移那一步,所以重启也自愈不了。

两个后端都有这一行,所以两边都坏。

## 修法

索引挪到「加这一列的那个迁移」里,和 ALTER 挨着。全新库也会跑迁移(基线只 stamp version 1,之后每个 revision 都会执行),所以新库照样只建一次索引 —— **不动 schema 版本号**,已经在 1.2.0 上的库不需要重新迁移。

## 影响范围(重要)

**已发布的 1.1.3 用户碰不到这个问题**:1.2.0 之前根本没有 `traffic_history` 表,升级时基线是从零建表、列自带,不走这条路。只有携带「中间形态」的库才会中招 —— 也就是跑过预发布构建的机器。测试机正是这种情况(上次我把 #72 的本地构建部上去了)。

## 为什么会漏到打完 tag

现有测试全都从「全新基线」起步,而这个 bug 在全新库上**完全不可见**。新加的回归测试改成从 pre-`group_id` 形态启动 —— 把基线那行索引加回去,它会以**生产环境同一条报错**挂掉。

## 验证

- `release-check.sh panel 1.2.1` → 78 OK / 0 FAIL
- `cargo fmt` / `clippy` 干净,Rust 461 用例全过(+1)
- 仓库测试对等性 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)