### PR TITLE
fix(admin): 卡密删除按钮常驻工具栏(补 #79 漏掉的跟进提交)

### DIFF
--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -592,7 +592,6 @@ export const enUS: Dict = {
   dismiss: 'Dismiss',
   copied: 'Copied',
   deleteCodesConfirm: 'Delete {count} selected codes?',
-  deleteCodeConfirm: 'Delete this code?',
   deleteCodesDesc: 'Used codes are never deleted — they are the record of money that entered the system.',
   codesDeleted: 'Deleted {count}',
   codesDeletedPartial: 'Deleted {ok}, skipped {skipped} (used codes cannot be deleted)',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -591,7 +591,6 @@ export const zhCN = {
   dismiss: '关闭',
   copied: '已复制',
   deleteCodesConfirm: '确定删除选中的 {count} 张卡密?',
-  deleteCodeConfirm: '确定删除这张卡密?',
   deleteCodesDesc: '已使用的卡密不会被删除 —— 它是资金入账的凭证,必须保留。',
   codesDeleted: '已删除 {count} 张',
   codesDeletedPartial: '已删除 {ok} 张,跳过 {skipped} 张(已使用的卡密不可删除)',

--- a/frontend/src/pages/RedeemCodes.test.tsx
+++ b/frontend/src/pages/RedeemCodes.test.tsx
@@ -69,33 +69,44 @@ describe('RedeemCodes', () => {
     expect(within(rowFor('GONE-GONE-GONE-GONE')).getByText('#7')).toBeInTheDocument();
   });
 
-  it('offers a per-row delete on unused and void codes, but no actions on a used code', async () => {
+  it('shows only VOID per row (delete is a toolbar action), and nothing on a used code', async () => {
     await renderPage();
-    // used → the money-in record: neither void nor delete.
+    // used → the money-in record: no per-row action.
     const used = rowFor('USED-USED-USED-USED');
-    expect(within(used).queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
     expect(within(used).queryByRole('button', { name: /void/i })).not.toBeInTheDocument();
-    // unused → void + delete.
+    // unused → void only.
     const unused = rowFor('UNUS-0000-0000-000A');
     expect(within(unused).getByRole('button', { name: /void/i })).toBeInTheDocument();
-    expect(within(unused).getByRole('button', { name: /delete/i })).toBeInTheDocument();
-    // void → delete only (can't void an already-void code).
+    expect(within(unused).queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    // void → no per-row action (can't re-void; delete is the toolbar button).
     const voided = rowFor('VOID-VOID-VOID-VOID');
     expect(within(voided).queryByRole('button', { name: /void/i })).not.toBeInTheDocument();
-    expect(within(voided).getByRole('button', { name: /delete/i })).toBeInTheDocument();
   });
 
-  it('per-row delete sends exactly that one id', async () => {
+  it('keeps a delete button in the toolbar, disabled until rows are ticked', async () => {
     const user = userEvent.setup();
-    mockDelete.mockResolvedValue(ok(1));
+    mockDelete.mockResolvedValue(ok(2));
     await renderPage();
 
+    // Always present so the affordance is discoverable, but disabled with no
+    // selection — the discoverability fix that prompted this. (The accessible
+    // name is "delete delete": the DeleteOutlined icon's aria-label plus the
+    // button text, both the raw i18n key in this provider-less harness.)
+    const delBtn = screen.getByRole('button', { name: /^delete delete$/i });
+    expect(delBtn).toBeDisabled();
+
+    // Tick two rows via their row checkboxes, then the button enables.
     const unused = rowFor('UNUS-0000-0000-000A');
-    await user.click(within(unused).getByRole('button', { name: /delete/i }));
-    // Confirm in the popconfirm.
+    const voided = rowFor('VOID-VOID-VOID-VOID');
+    await user.click(within(unused).getByRole('checkbox'));
+    await user.click(within(voided).getByRole('checkbox'));
+
+    const enabled = screen.getByRole('button', { name: /delete.*\(2\)/i });
+    expect(enabled).toBeEnabled();
+    await user.click(enabled);
     const confirm = await screen.findByRole('button', { name: /^OK$/i });
     await user.click(confirm);
 
-    expect(mockDelete).toHaveBeenCalledWith('/admin/redeem-codes', { data: { ids: [3] } });
+    expect(mockDelete).toHaveBeenCalledWith('/admin/redeem-codes', { data: { ids: [3, 5] } });
   });
 });

--- a/frontend/src/pages/RedeemCodes.tsx
+++ b/frontend/src/pages/RedeemCodes.tsx
@@ -159,30 +159,16 @@ export default function RedeemCodes() {
     { title: t('batch'), dataIndex: 'batch_id', key: 'batch_id' },
     { title: t('remark'), dataIndex: 'remark', key: 'remark', render: (v: string) => v || '-' },
     {
-      title: t('action'), key: 'action', width: 160,
+      // Per-row shows VOID only (deletion is done in bulk via the toolbar
+      // button, after ticking rows). A used code is the money-in record — it
+      // can be neither voided nor deleted, so it shows nothing.
+      title: t('action'), key: 'action',
       render: (_: unknown, r: RedeemCode) => (
-        // A used code is the money-in record: it can be neither voided nor
-        // deleted, so it shows no actions. Unused codes can be voided first;
-        // both unused and voided codes can be deleted outright.
-        r.status === 'used' ? (
-          <Text type="secondary">-</Text>
-        ) : (
-          <Space size={0}>
-            {r.status === 'unused' && (
-              <Popconfirm title={t('voidCodeConfirm')} onConfirm={() => handleVoid(r.id)} okButtonProps={{ danger: true }}>
-                <Button size="small" type="text" danger icon={<StopOutlined />}>{t('void')}</Button>
-              </Popconfirm>
-            )}
-            <Popconfirm
-              title={t('deleteCodeConfirm')}
-              description={t('deleteCodesDesc')}
-              onConfirm={() => deleteCodes([r.id])}
-              okButtonProps={{ danger: true }}
-            >
-              <Button size="small" type="text" danger icon={<DeleteOutlined />}>{t('delete')}</Button>
-            </Popconfirm>
-          </Space>
-        )
+        r.status === 'unused' ? (
+          <Popconfirm title={t('voidCodeConfirm')} onConfirm={() => handleVoid(r.id)} okButtonProps={{ danger: true }}>
+            <Button size="small" type="text" danger icon={<StopOutlined />}>{t('void')}</Button>
+          </Popconfirm>
+        ) : <Text type="secondary">-</Text>
       ),
     },
   ];
@@ -203,16 +189,21 @@ export default function RedeemCodes() {
               { value: 'void', label: t('codeVoid') },
             ]}
           />
-          {selectedRowKeys.length > 0 && (
-            <Popconfirm
-              title={t('deleteCodesConfirm').replace('{count}', String(selectedRowKeys.length))}
-              description={t('deleteCodesDesc')}
-              onConfirm={() => deleteCodes(selectedRowKeys)}
-              okButtonProps={{ danger: true }}
-            >
-              <Button danger icon={<DeleteOutlined />}>{t('delete')} ({selectedRowKeys.length})</Button>
-            </Popconfirm>
-          )}
+          {/* Always visible so the delete affordance is discoverable — it was
+              previously hidden until rows were selected, which read as "there is
+              no way to delete". Disabled (and its confirm suppressed) when the
+              selection is empty. Tick the rows to delete, then click. */}
+          <Popconfirm
+            title={t('deleteCodesConfirm').replace('{count}', String(selectedRowKeys.length))}
+            description={t('deleteCodesDesc')}
+            onConfirm={() => deleteCodes(selectedRowKeys)}
+            okButtonProps={{ danger: true }}
+            disabled={selectedRowKeys.length === 0}
+          >
+            <Button danger icon={<DeleteOutlined />} disabled={selectedRowKeys.length === 0}>
+              {selectedRowKeys.length > 0 ? `${t('delete')} (${selectedRowKeys.length})` : t('delete')}
+            </Button>
+          </Popconfirm>
           <Button icon={<ReloadOutlined />} onClick={load}>{t('refresh')}</Button>
           <Button type="primary" icon={<PlusOutlined />} onClick={() => { createForm.resetFields(); setCreateOpen(true); }}>
             {t('generateCodes')}


### PR DESCRIPTION
## 这个 PR 做什么

让卡密管理的**删除按钮常驻工具栏**,实现你要的"上面一个删除按钮"的效果。

- 删除按钮一直显示在工具栏(状态筛选、刷新旁边),**没勾选任何卡密时置灰**(确认弹窗一并禁用)。
- 勾选一张或多张后按钮启用,并显示数量,例如"删除 (3)"。点击 → 确认 → 删除。
- 每行只保留"作废"操作;已使用的卡密不显示任何操作,因为它是资金入账凭证,后端拒删。

## 为什么需要

批量删除功能其实早就有,但按钮**只在勾选之后才出现** —— 什么都没选时工具栏看不到删除入口,这就是你之前觉得"没地方删除"的原因。现在常驻+置灰,入口一眼可见。

> 补充:这块改动本该在 #79 里,但 #79 合并时只 squash 进了第一版(逐行删除),这个跟进提交没赶上。所以本 PR 顺带把 #79 里加的逐行删除去掉 —— 有了常驻按钮就冗余了。

## 验证

本地面板端到端验过:没选时置灰、勾一行变"删除 (1)"并启用、删掉后已使用的那张保留。前端 RedeemCodes 4 个用例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)