### PR TITLE
fix(rules): 目标地址加宽以容纳 IPv6;负载策略说明改为问号悬浮提示

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -766,6 +766,38 @@ const IMPORT_DEFAULTS = {
     );
   };
 
+  // Load-balance strategy field. The per-strategy explanation used to sit in an
+  // always-open Alert below the select, which is a lot of standing text for
+  // something you read once. It now hangs off a "?" on the label — hover to
+  // read, out of the way otherwise. Same pattern as the rate-limits label.
+  const renderStrategyField = () => (
+    <Form.Item
+      name="load_balance_strategy"
+      initialValue="first"
+      label={
+        <span>
+          {t('loadBalanceStrategy')}{' '}
+          <Tooltip
+            overlayStyle={{ maxWidth: 360 }}
+            title={
+              <div style={{ fontSize: 12 }}>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>{t('lbStrategyBlockTitle')}</div>
+                <div>• {t('lbFirstDesc')}</div>
+                <div>• {t('lbRoundRobinDesc')}</div>
+                <div>• {t('lbFailoverDesc')}</div>
+                <div style={{ marginTop: 8, opacity: 0.75 }}>{t('lbStrategyBlockFooter')}</div>
+              </div>
+            }
+          >
+            <QuestionCircleOutlined style={{ color: '#999' }} />
+          </Tooltip>
+        </span>
+      }
+    >
+      <Select options={strategyOptions} />
+    </Form.Item>
+  );
+
   const renderTargetsEditor = () => (
     <Form.List name="targets" initialValue={[{ host: '', port: undefined as unknown as number, enabled: true }]}>
       {(fields, { add, remove, move }) => (
@@ -780,7 +812,9 @@ const IMPORT_DEFAULTS = {
                 rules={[{ required: true }]}
                 style={{ marginBottom: 8 }}
               >
-                <Input placeholder={t('targetAddress')} style={{ width: 180 }} />
+                {/* Wide enough for a full IPv6 literal (up to 39 chars) — 180px
+                    truncated them mid-address. */}
+                <Input placeholder={t('targetAddress')} style={{ width: 300 }} />
               </Form.Item>
               <Form.Item
                 {...field}
@@ -952,23 +986,7 @@ const IMPORT_DEFAULTS = {
               label: t('tabForward'),
               children: (<>
                 {renderTargetsEditor()}
-                <Form.Item name="load_balance_strategy" label={t('loadBalanceStrategy')} initialValue="first">
-                  <Select options={strategyOptions} />
-                </Form.Item>
-                <Alert
-                  type="info"
-                  showIcon
-                  style={{ fontSize: 12, marginBottom: 16 }}
-                  title={t('lbStrategyBlockTitle')}
-                  description={
-                    <div>
-                      <div>• {t('lbFirstDesc')}</div>
-                      <div>• {t('lbRoundRobinDesc')}</div>
-                      <div>• {t('lbFailoverDesc')}</div>
-                      <div style={{ marginTop: 8, color: '#888' }}>{t('lbStrategyBlockFooter')}</div>
-                    </div>
-                  }
-                />
+                {renderStrategyField()}
                 <Form.Item
                   label={<span>{t('rateLimits')} <Tooltip title={<span style={{ whiteSpace: 'pre-line' }}>{t('rateLimitsTooltip')}</span>} overlayStyle={{ maxWidth: 340 }}><QuestionCircleOutlined style={{ color: '#999' }} /></Tooltip></span>}
                   extra={t('rateLimitsHint')}
@@ -1024,23 +1042,7 @@ const IMPORT_DEFAULTS = {
               label: t('tabForward'),
               children: (<>
                 {renderTargetsEditor()}
-                <Form.Item name="load_balance_strategy" label={t('loadBalanceStrategy')} initialValue="first">
-                  <Select options={strategyOptions} />
-                </Form.Item>
-                <Alert
-                  type="info"
-                  showIcon
-                  style={{ fontSize: 12, marginBottom: 16 }}
-                  title={t('lbStrategyBlockTitle')}
-                  description={
-                    <div>
-                      <div>• {t('lbFirstDesc')}</div>
-                      <div>• {t('lbRoundRobinDesc')}</div>
-                      <div>• {t('lbFailoverDesc')}</div>
-                      <div style={{ marginTop: 8, color: '#888' }}>{t('lbStrategyBlockFooter')}</div>
-                    </div>
-                  }
-                />
+                {renderStrategyField()}
                 <Form.Item
                   label={<span>{t('rateLimits')} <Tooltip title={<span style={{ whiteSpace: 'pre-line' }}>{t('rateLimitsTooltip')}</span>} overlayStyle={{ maxWidth: 340 }}><QuestionCircleOutlined style={{ color: '#999' }} /></Tooltip></span>}
                   extra={t('rateLimitsHint')}


### PR DESCRIPTION
两处规则编辑器的小改动:

## 1. 目标地址框加宽

地址输入框原来是 180px,填 IPv6(最长 39 字符)会被截断看不全。加宽到 300px,那一行本来就会自动换行,所以和端口框排在一起也不挤。

## 2. 负载策略说明改成问号悬浮

原来是 select 下方一个常驻的 info 提示框,四行文字一直摆在那 —— 但这内容看一遍就够了。现在挂到"负载策略"字段标签的一个"?"上,鼠标悬上去才展开(和限速那栏标签用的是同一个 QuestionCircle + Tooltip 写法)。整体看着清爽,细节一悬即得。

新增和编辑两个弹窗本来是一模一样的 select+Alert,抽成了共用的 `renderStrategyField()`,避免两边各改一处走样。

## 验证

本地面板验过:地址框量到 300px,常驻提示框没了,悬浮"?"能弹出完整策略说明(默认/轮询/故障转移 + "只影响新连接、TCP 约 5 秒"那句footer)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)