### PR TITLE
chore(release): 1.2.2(仅面板)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.2.2] - 2026-07-25
+
+Admin-console usability. Panel only — no node release, no schema change, and
+nothing to reconfigure: upgrade the panel image and you're done.
+
+### Added
+
+- **Search users by username or ID** on the user-management page. The list was
+  unfiltered, so finding one account on a populated panel meant scrolling. The
+  filter runs client-side over the list already fetched, so it responds as you
+  type without a round-trip.
+
+### Changed
+
+- **Redeem codes show WHO redeemed them, by username rather than `#id`.** An id
+  is only useful if you already know who it is. The name is resolved server-side
+  in one lookup per page (not one per row), and only when the page actually
+  contains a used code. A code whose account was later deleted still shows the
+  id — that row is the money-in record and outlives the account.
+
+- **The redeem-code delete button is always visible**, disabled until rows are
+  ticked. It previously appeared only *after* a selection was made, so with
+  nothing selected the page looked like it had no way to delete at all — the
+  feature existed and was simply invisible.
+
+- **The target address field is wide enough for IPv6.** At its old width a full
+  IPv6 literal was cut off mid-address, which is exactly when you need to read
+  it carefully.
+
+- **The load-balancing explanation moved into a "?" tooltip** on the strategy
+  field. It used to be an always-open info panel — four lines of standing text
+  for something you read once and then scroll past forever.
+
+### Docs
+
+- Node upgrade now leads with **one-click upgrade from the panel** instead of
+  re-running the install script, which is the fallback path. Both node docs and
+  both READMEs. Also documents two things that were missing everywhere: an
+  upgrade **drops that node's live forwarding connections**, and one-click is
+  **systemd-only** (Docker shows an "update the image" hint; a manually-run node
+  has nothing to restart it).
+- The feature highlights list features instead of implementation details, and
+  covers the v1.2.0 additions that were missing from it.
+
 ## [1.2.1] - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.1";
+const COMPILED_APP_VERSION: &str = "1.2.2";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.1}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.2}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)


### PR DESCRIPTION
## 这次发什么

v1.2.1 以来的后台易用性改进,共 5 个 PR:#77 #78 #79 #80 #81

**新增**
- 用户管理页可按用户名 / ID 搜索

**改进**
- 卡密的「使用者」显示用户名,不再是 `#2`
- 卡密删除按钮常驻工具栏(之前勾选后才出现,等于看不见)
- 目标地址框加宽,IPv6 不再被截断
- 负载策略说明收进「?」悬浮提示,表单清爽了

**文档**
- 节点升级改为以「面板一键升级」为主,脚本降为备选;补上了两件到处都没写的事:升级会断开该节点的转发连接、一键升级仅支持 systemd
- 功能亮点只讲功能不讲实现,并补上 v1.2.0 的新功能

## 为什么只发面板

diff 里**没有节点代码、没有 schema 变更、没有新增 API 路由**。后端唯一的改动是把卡密使用者的 id 解析成用户名,属于响应字段新增。

所以:**不用迁移数据库、不卡节点版本、不用发 node tag**。拉新面板镜像重启即可。节点保持 1.2.0,release-check 在节点轨道上照样 0 FAIL。

## 版本号为什么是 1.2.2 而不是 1.3.0

虽然有个新功能(用户搜索),但它是对已经拉回来的列表做纯前端过滤 —— 不新增接口、不改部署、不改数据。对运营者来说这次升级「什么都不用做」,所以按补丁号走。如果你希望对外强调"有新功能",改成 1.3.0 我再调一版。

## 验证

- `release-check.sh panel 1.2.2` → 80 OK / 0 FAIL
- `release-check.sh node 1.2.0` → 79 OK / 0 FAIL(节点轨道未受影响)
- `cargo fmt --check` / `clippy` 干净
- Rust 589 用例、前端 180 用例全过
- 仓库测试对等性 OK(sqlite 119 / pg 118)
- 前端构建通过

合并后打 `v1.2.2` 一个 tag 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)