### PR TITLE
fix(rules): 收窄规则弹窗里过宽的输入框

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -952,7 +952,7 @@ const IMPORT_DEFAULTS = {
       />
 
       <Modal title={t('addRule')} open={createOpen} onCancel={() => setCreateOpen(false)} onOk={() => createForm.submit()} okText={t('create')} cancelText={t('cancel')} width={620}>
-        <Form form={createForm} onFinish={handleCreate} layout="vertical">
+        <Form form={createForm} onFinish={handleCreate} layout="vertical" className="rp-rule-form">
           <Tabs items={[
             {
               key: 'basic',
@@ -1012,7 +1012,7 @@ const IMPORT_DEFAULTS = {
       </Modal>
 
       <Modal title={t('editRule')} open={editOpen} onCancel={() => setEditOpen(false)} onOk={() => editForm.submit()} okText={t('save')} cancelText={t('cancel')} width={620}>
-        <Form form={editForm} onFinish={handleUpdate} layout="vertical">
+        <Form form={editForm} onFinish={handleUpdate} layout="vertical" className="rp-rule-form">
           <Tabs items={[
             {
               key: 'basic',

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -741,7 +741,10 @@ const IMPORT_DEFAULTS = {
         extra={udpOnly ? t('maxConnectionsUdpUnsupported') : t('maxConnectionsHint')}
         initialValue={0}
       >
-        <InputNumber min={0} style={{ width: '100%' }} placeholder="0" disabled={udpOnly} />
+        {/* Caps the width instead of filling the row: this holds a small
+            integer, and a 530px box for "0" reads as if something is missing.
+            maxWidth (not a fixed width) so it still shrinks on a narrow modal. */}
+        <InputNumber min={0} style={{ width: '100%', maxWidth: 200 }} placeholder="0" disabled={udpOnly} />
       </Form.Item>
       <Form.Item
         name="auto_restart_minutes"
@@ -760,7 +763,7 @@ const IMPORT_DEFAULTS = {
           },
         }]}
       >
-        <InputNumber min={0} style={{ width: '100%' }} addonAfter={t('minutes')} placeholder="0" />
+        <InputNumber min={0} style={{ width: '100%', maxWidth: 220 }} addonAfter={t('minutes')} placeholder="0" />
       </Form.Item>
     </>
     );
@@ -992,8 +995,8 @@ const IMPORT_DEFAULTS = {
                   extra={t('rateLimitsHint')}
                 >
                   <Space orientation="vertical" style={{ width: '100%' }}>
-                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
-                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
+                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: '100%', maxWidth: 300 }} placeholder="0" /></Form.Item>
+                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%', maxWidth: 300 }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
                 {/* v1.2.0: the connection cap / auto-restart controls are
@@ -1048,8 +1051,8 @@ const IMPORT_DEFAULTS = {
                   extra={t('rateLimitsHint')}
                 >
                   <Space orientation="vertical" style={{ width: '100%' }}>
-                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
-                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%' }} placeholder="0" /></Form.Item>
+                    <Form.Item name="upload_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('uploadLimit')} addonAfter="Mbps" style={{ width: '100%', maxWidth: 300 }} placeholder="0" /></Form.Item>
+                    <Form.Item name="download_limit_mbps" noStyle initialValue={0}><InputNumber min={0} addonBefore={t('downloadLimit')} addonAfter="Mbps" style={{ width: '100%', maxWidth: 300 }} placeholder="0" /></Form.Item>
                   </Space>
                 </Form.Item>
                 {renderConnectionControls(editProto)}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -185,3 +185,23 @@ html, body, #root {
   border-radius: 2px;
   background-size: cover;
 }
+
+/* v1.2.3: cap single-value form controls in the rule dialogs.
+   These forms sit in a 620px modal, so a control at the default width:100%
+   spans ~530px — a name, a port, or a strategy dropdown does not need that,
+   and a column of equally-long boxes reads as a wall.
+
+   Applied as ONE rule rather than a width on each Form.Item because the basic
+   fields are defined twice (create + edit dialog); a per-field width would be
+   a dozen edits that drift apart.
+
+   Only max-width, so anything with a deliberately narrower inline width keeps
+   it (inline wins): the target address stays 300 for a full IPv6 literal, and
+   the small integer fields stay 200-300. The targets row is unaffected — its
+   controls already carry explicit widths. */
+.rp-rule-form .ant-form-item-control-input-content > .ant-input,
+.rp-rule-form .ant-form-item-control-input-content > .ant-select,
+.rp-rule-form .ant-form-item-control-input-content > .ant-input-number,
+.rp-rule-form .ant-form-item-control-input-content > .ant-input-number-group-wrapper {
+  max-width: 320px;
+}


### PR DESCRIPTION
## 反馈

> 在 v1.2.2 中 目标地址框拉长了 但是所有的框框都变长了
>
> 负载策略、最大连接数、协议、监听端口、名称、入口分组 都不需要这么长吧

## 先查证:v1.2.2 并没有把别的框改宽

v1.2.1 → v1.2.2 **整个前端只有两处宽度改动**:

```
- <Input placeholder={t('targetAddress')} style={{ width: 180 }} />
+ <Input placeholder={t('targetAddress')} style={{ width: 300 }} />
```

外加一个新增的 220px 用户搜索框(新元素)。其余字段**一直都是 `width: 100%`**,在 620px 的弹窗里 ≈ 530px —— v1.2.1 时就这么宽。Modal 也一直固定 620,实测没变宽。

**真正变的是节奏**:#81 里地址框从明显偏短(180)变成接近满宽(300),同时那个常驻的「负载策略说明」信息框被收进了问号 —— 而它是这一列里唯一的视觉断点。两者一起没了,整页就变成一排等长的大框。

## 改动

一个规则名、一个端口号、一句「TCP + UDP」、一个线路名、一句「故障转移」,都不需要 530px:

| 字段 | 原 | 现 |
|---|---|---|
| 名称 / 监听端口 / 协议 / 入口分组 | 530 | **320** |
| 负载策略 | 530 | **320** |
| 最大连接数 / 自动重启间隔 | 530 | **200** |
| 限速 | 530 | **300**(带上行/下行 + Mbps 附加框) |
| 目标地址 | 300 | 300(保留 —— 完整 IPv6 字面量 39 字符) |

**用一条 CSS 规则**加在表单上,而不是给每个 `Form.Item` 单独写宽度 —— 基础页那几个字段在新增和编辑两个弹窗里各声明了一遍,逐个加宽度就是十几处改动,以后只改其中一处就会走样。

规则只设 `max-width`,所以刻意更窄的保持自己的宽度(地址 300、数字框 200),目标列表那一行完全不受影响(它的控件本来就带显式宽度)。窄屏时仍会自适应收缩。

## 验证

浏览器实测改前改后,Modal 保持 620。前端 180 用例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)