### PR TITLE
fix(rules): 「转发」页四个字段宽度统一为 252,目标地址加宽到 320

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -741,7 +741,7 @@ const IMPORT_DEFAULTS = {
         extra={udpOnly ? t('maxConnectionsUdpUnsupported') : t('maxConnectionsHint')}
         initialValue={0}
       >
-        <InputNumber min={0} style={{ width: '100%' }} placeholder="0" disabled={udpOnly} />
+        <InputNumber min={0} style={{ width: '100%', maxWidth: 252 }} placeholder="0" disabled={udpOnly} />
       </Form.Item>
       <Form.Item
         name="auto_restart_minutes"
@@ -794,7 +794,7 @@ const IMPORT_DEFAULTS = {
         </span>
       }
     >
-      <Select options={strategyOptions} />
+      <Select options={strategyOptions} style={{ maxWidth: 252 }} />
     </Form.Item>
   );
 
@@ -814,7 +814,7 @@ const IMPORT_DEFAULTS = {
               >
                 {/* Wide enough for a full IPv6 literal (up to 39 chars) — 180px
                     truncated them mid-address. */}
-                <Input placeholder={t('targetAddress')} style={{ width: 300 }} />
+                <Input placeholder={t('targetAddress')} style={{ width: 320, maxWidth: 320 }} />
               </Form.Item>
               <Form.Item
                 {...field}
@@ -949,7 +949,7 @@ const IMPORT_DEFAULTS = {
       />
 
       <Modal title={t('addRule')} open={createOpen} onCancel={() => setCreateOpen(false)} onOk={() => createForm.submit()} okText={t('create')} cancelText={t('cancel')} width={620}>
-        <Form form={createForm} onFinish={handleCreate} layout="vertical">
+        <Form form={createForm} onFinish={handleCreate} layout="vertical" className="rp-rule-form">
           <Tabs items={[
             {
               key: 'basic',
@@ -1009,7 +1009,7 @@ const IMPORT_DEFAULTS = {
       </Modal>
 
       <Modal title={t('editRule')} open={editOpen} onCancel={() => setEditOpen(false)} onOk={() => editForm.submit()} okText={t('save')} cancelText={t('cancel')} width={620}>
-        <Form form={editForm} onFinish={handleUpdate} layout="vertical">
+        <Form form={editForm} onFinish={handleUpdate} layout="vertical" className="rp-rule-form">
           <Tabs items={[
             {
               key: 'basic',

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -185,3 +185,25 @@ html, body, #root {
   border-radius: 2px;
   background-size: cover;
 }
+
+/* v1.2.3: give the forwarding tab one field width.
+
+   The four controls there used to disagree. 负载策略 and 最大连接数 are a
+   plain Select / InputNumber, so width:100% made them span the form (572px
+   in the 620px dialog). 限速 and 自动重启间隔 carry addons (上行/下行, Mbps,
+   分钟) and antd wraps those in a Space.Compact group — width:100% then
+   applies to the number box INSIDE the group, leaving the group sized to its
+   content (~252px). Two long rows and two short ones in the same column.
+
+   All four are now 252: the addon groups keep their natural size and the two
+   plain controls are capped to match (their cap is inline, on the component).
+   A rule name or a strategy dropdown does not need half the dialog anyway.
+
+   Scoped to the rule dialogs and to addon groups only, so nothing else moves:
+   the basic tab stays full-width, and the targets row keeps its explicit
+   widths (address 320, port 110) — which is what keeps that row on one line. */
+.rp-rule-form .ant-form-item-control-input-content .ant-space-compact,
+.rp-rule-form .ant-form-item-control-input-content .ant-input-number-group-wrapper {
+  width: 100%;
+  max-width: 252px;
+}


### PR DESCRIPTION
## 问题

「转发」页那四个控件宽度不一致,实测:

| 字段 | 改前 |
|---|---|
| 负载策略 | 572 |
| 最大连接数 | 572 |
| **限速** | **~252** |
| **自动重启间隔** | **252** |

原因:负载策略和最大连接数是普通 Select / InputNumber,`width:100%` 直接撑满表单(620 弹窗里是 572)。而限速和自动重启间隔带附加标签(上行/下行、Mbps、分钟),antd 把它们包进 `Space.Compact` 组,`width:100%` 只作用到组**内部**的数字框,外层按内容收缩 —— 于是同一列里两长两短。

## 改动

**四个统一为 252。** 252 是附加标签组的自然宽度,所以是把另外两个收下来对齐它,而不是反过来 —— 一个装「故障转移」的下拉框本来也不需要占半个弹窗。

**目标地址 300 → 320。** 完整 IPv6 在两个宽度下都显示得全,但 320 是这一行的上限:实测 **320 不换行、330 会把删除按钮挤到单独一行**。多目标时,删除按钮离它要删的那行太远容易点错。

**刻意限制了作用范围**,其它地方一动不动:CSS 只匹配规则弹窗内的附加标签组,「基础」页保持全宽,目标行保留各自的显式宽度。

## 验证

每次改动都在浏览器里实测(宽度 + 用左边距是否回退判断换行)。前端 180 用例全过。

> 过程中一个坑记在提交信息里了:vite 的 HMR 两次发了旧模块,改动在磁盘上但浏览器拿到的是旧的 —— 量宽度前先重启 dev server,否则数据会误导。

🤖 Generated with [Claude Code](https://claude.com/claude-code)