### PR TITLE
docs: 故障排查以官网为准,仓库精简指过去

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -409,16 +409,22 @@ per-binary systemd service — both run inside containers.
 
 ## Troubleshooting
 
+The full, maintained troubleshooting guide lives at
+**[relaypanel.dev/troubleshooting](https://relaypanel.dev/troubleshooting.html)**
+— panel deployment (PoolTimedOut, PG auth, leftover networks, panel not
+reachable) and node problems (offline, forwarding broken, connection count
+stuck) with the actual commands to run. It is kept in one place so the two
+don't drift apart.
+
+The first-resort checks, for when you don't want to leave this file:
+
 | Symptom | Fix |
 |---------|-----|
 | `JWT_SECRET must be set` | You didn't create `.env` or it's empty. Run step 2. |
-| Panel unreachable | `docker compose logs panel` — check for binding errors. |
+| Panel unreachable | `docker compose logs panel` — the log names the actual cause. |
+| Node shows offline but the process is running | The node can't reach the panel over HTTP (firewall / `PUBLIC_PANEL_URL`). Check `journalctl -u relay-node` for `report_status` errors. |
 | Node not forwarding | Verify `NODE_TOKEN` matches a group token from the UI. |
 | Port already in use | Another process holds the listen port; pick a different one in the rule. |
-| Users kicked to login page repeatedly | The panel's DB is temporarily unreachable (lock contention / disk full). Check `docker compose logs panel` for `auth db lookup failed`. This is a 500, not a token problem — the page recovers once the DB is healthy. |
-| Node shows "离线" but process is running | The node can't reach the panel over HTTP (firewall / `PUBLIC_PANEL_URL`). Check `journalctl -u relay-node` for `report_status` errors. |
-| Traffic keeps growing without bounds | A rule's target is unreachable and connections are piling up. Check the node's listener errors column on the Nodes page. |
-| PostgreSQL connection failed | `deploy.sh` fails fast with "Cannot connect to external PostgreSQL". Check host, port, user, password, database name, and firewall. For embedded PG: `docker compose logs postgres`. |
 
 ### Logging
 

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -325,6 +325,8 @@ rm -rf /opt/relay-node
 
 ## Troubleshooting
 
+> The full guide, including panel-deployment issues, is at **[relaypanel.dev/troubleshooting](https://relaypanel.dev/en/troubleshooting.html)**. Below is the node-side quick reference.
+
 ### Node shows "offline" in the panel
 - Check `systemctl status relay-node` is `active (running)`
 - Check `PANEL_URL` is reachable from the node: `curl -sf $PANEL_URL/`

--- a/docs/NODE.zh-CN.md
+++ b/docs/NODE.zh-CN.md
@@ -268,6 +268,8 @@ rm -rf /opt/relay-node
 
 ## 故障排查
 
+> 完整版(含面板部署问题)在 **[relaypanel.dev/troubleshooting](https://relaypanel.dev/troubleshooting.html)**。下面是节点侧的速查。
+
 ### 节点在面板里显示「离线」
 - 检查 `systemctl status relay-node` 是否 `active (running)`
 - 检查节点能否访问面板：`curl -sf $PANEL_URL/`


### PR DESCRIPTION
## 问题

故障排查散在**三个地方,彼此不知道对方存在**,而且覆盖的是不同问题域:

| 位置 | 覆盖 |
|---|---|
| 官网 `troubleshooting.md` | 只有**面板部署**(PoolTimedOut、PG 密码、网络残留、60 秒起不来)—— 三份里最详细,且只此一份 |
| `docs/DEPLOYMENT.md` | 一个简短英文表格,一半面板一半节点 |
| `docs/NODE.zh-CN.md` | **节点侧**细节 —— 也是只此一份 |

结果:节点显示离线的用户**在官网翻不到任何东西**;踩到 PoolTimedOut 的人**在仓库里找不到**。而「节点离线」在其中两处都有、深浅不同,看到哪份全看运气。

## 改动

**官网成为完整版**,分成两块:面板部署 / 节点问题。

**动手前先保内容**:`DEPLOYMENT.md` 表格里有两条**别处都没有**的 —— 「反复跳登录」(数据库不可用)和「流量疯涨」(目标不可达导致连接堆积) —— 我先把它们搬到官网,再精简表格,**没有丢任何内容**。

`DEPLOYMENT.md` 只保留第一手速查(JWT_SECRET、面板不可达、节点离线、节点不转发、端口占用)+ 指向官网。节点文档保留节点侧速查,同样加指路。

## 验证

- 官网中英文两页:层级正确(面板部署/节点问题 下挂 `###`)、顶部两个锚点都能跳、无未渲染的 `:::` 语法
- 已构建并**部署上线**,线上两页均 200
- `release-check.sh` 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)