### PR TITLE
chore(release): 1.2.3(仅面板)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.2.3] - 2026-07-26
+
+Admin-console layout and a token-rotation button. Panel only — no node
+release, no schema change, nothing to reconfigure: pull the image and restart.
+
+### Added
+
+- **Rotate a device group's node token from the UI.** The endpoint has existed
+  since v0.3.9 but nothing ever called it. Rotation is a hard cutover, not a
+  handover: the panel cannot push a new token to a node over the existing
+  connection, because the token is exactly what that node authenticates with.
+  Every node in the group is disconnected until re-enrolled, so the button
+  states how many will drop, asks for the group name to be typed, and then
+  hands back the new token together with the ready-to-paste enrollment command.
+  Use it when a token has leaked.
+
+### Changed
+
+- **The forwarding tab now has one field width.** 负载策略 and 最大连接数 were
+  full-width while 限速 and 自动重启间隔 came out around half that — the latter
+  two carry addons, which antd wraps in a group that `width:100%` doesn't
+  stretch. All four now line up. The target address is a little wider, sized to
+  the most the row takes before the delete button wraps onto its own line.
+
+- **The notification settings are laid out in columns.** Thirteen full-width
+  fields in one stack meant a chat id got an 1800px input on a wide screen, and
+  configuring email meant scrolling past Telegram. Global settings and Telegram
+  now sit side by side, email spans the row beneath them, and each channel's
+  on/off moved into its card header. Everything collapses to a single column on
+  narrow screens.
+
+### Docs
+
+- **Troubleshooting is now maintained in one place — the site.** It had drifted
+  into three places that didn't cross-link and covered different problems: a
+  node showing offline had no answer on the site, and a panel failing with
+  PoolTimedOut had none in the repo. The site now covers both panel deployment
+  and node problems; `docs/DEPLOYMENT.md` and the node docs keep a short
+  first-resort list and link out. Two entries that existed only in
+  `DEPLOYMENT.md` were moved to the site rather than dropped.
+- The READMEs are down to what someone needs to decide whether the panel fits:
+  8 grouped feature bullets instead of 22, and the upgrade section no longer
+  repeats what the node docs already say.
+
 ## [1.2.2] - 2026-07-25
 
 Admin-console usability. Panel only — no node release, no schema change, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.2";
+const COMPILED_APP_VERSION: &str = "1.2.3";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.2}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.3}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)


### PR DESCRIPTION
## 这次发什么

v1.2.2 以来攒的 5 个 PR:#84 #86 #87 #88 #89

**新增**
- **设备分组「重置令牌」入口** —— 后端从 v0.3.9 就有,一直没人调用。轮换是硬切换:面板没法通过现有连接把新令牌推给节点(节点正是靠令牌认证的),所以该分组下所有节点会断开直到逐台重新对接。按钮会显示会断几个节点、要求输入分组名确认,成功后直接给出新令牌和可复制的对接命令。用于令牌泄漏。

**改进**
- **转发页字段宽度统一** —— 负载策略和最大连接数是满宽,限速和自动重启却只有一半:后两者带附加标签,antd 把它们包进一个 `width:100%` 撑不开的组。现在四个对齐了。目标地址略加宽,取的是「删除按钮不换行」的上限。
- **通知设置改为分栏** —— 13 个满宽字段一条竖列,宽屏上一个 Chat ID 输入框有 1800px,配邮件要滚过整个 Telegram。现在全局和 Telegram 并排、邮件铺满下面一行、渠道开关移进卡片标题栏,窄屏自动降为单列。

**文档**
- **故障排查统一到官网** —— 原来散在三处、互不知道对方存在且覆盖不同问题:节点离线在官网查不到,PoolTimedOut 在仓库查不到。现在官网覆盖面板部署 + 节点问题,仓库保留速查并指过去。`DEPLOYMENT.md` 里两条别处没有的内容**已先搬到官网**,没有丢失。
- README 精简到「够判断这个面板适不适合我」:功能亮点 22 条 → 8 条。

## 为什么只发面板

对 v1.2.2 的 diff **一行 Rust 都没动** —— 只有前端和文档。不动 schema、不动节点、不改 API,所以**不用迁移、不卡节点版本**。拉镜像重启即可,节点保持 1.2.0。

## 验证

- `release-check.sh panel 1.2.3` → 79 OK / 0 FAIL
- `release-check.sh node 1.2.0` → 78 OK / 0 FAIL(节点轨道未受影响)
- `cargo fmt --check` / `clippy` 干净
- Rust 589 用例、前端 180 用例全过
- 仓库测试对等性 OK(sqlite 119 / pg 118)
- 前端构建通过

合并后打 `v1.2.3` 一个 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)