### PR TITLE
feat(panel): tunnel forwarding (v1.3)

### DIFF
--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -19,8 +19,8 @@ pub use plans::*;
 pub use profiles::*;
 pub use rules::*;
 pub use settings::*;
-pub use tunnels::*;
 pub use shop::*;
+pub use tunnels::*;
 pub use users::*;
 
 /// A user WITHOUT the password hash — for API responses. Never expose the
@@ -2589,7 +2589,10 @@ mod tests {
 
         // Attempting to delete group 10 must fail.
         let result = crate::service::groups::delete_group(state.db.as_ref(), 10).await;
-        assert!(result.is_err(), "group deletion must be blocked by tunnel reference");
+        assert!(
+            result.is_err(),
+            "group deletion must be blocked by tunnel reference"
+        );
         let err = result.unwrap_err();
         assert!(
             format!("{:?}", err).contains("10"),

--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -10,6 +10,7 @@ mod profiles;
 mod rules;
 mod settings;
 mod shop;
+mod tunnels;
 mod users;
 
 pub use groups::*;
@@ -18,6 +19,7 @@ pub use plans::*;
 pub use profiles::*;
 pub use rules::*;
 pub use settings::*;
+pub use tunnels::*;
 pub use shop::*;
 pub use users::*;
 
@@ -1565,90 +1567,6 @@ mod tests {
         );
     }
 
-    /// v0.4.20: create_rule rejects forward_mode="group".
-    #[tokio::test]
-    async fn create_rule_rejects_group_forward_mode() {
-        let (state, pool) = test_state().await;
-        add_user(&pool, 2, "alice", false).await;
-        add_group(&pool, 20, 1, "shared-in").await;
-
-        let Json(resp) = create_rule(
-            auth(2, false),
-            State(state.clone()),
-            Json(CreateRuleRequest {
-                forward_mode: "group".into(),
-                ..rule_req("test", 20000, 20, None)
-            }),
-        )
-        .await;
-        assert_eq!(resp.code, 400, "{}", resp.message);
-        assert!(resp.message.contains("direct"));
-    }
-
-    /// v0.4.20: create_rule rejects non-null device_group_out.
-    #[tokio::test]
-    async fn create_rule_rejects_device_group_out() {
-        let (state, pool) = test_state().await;
-        add_user(&pool, 2, "alice", false).await;
-        add_group(&pool, 20, 1, "shared-in").await;
-
-        let Json(resp) = create_rule(
-            auth(2, false),
-            State(state.clone()),
-            Json(CreateRuleRequest {
-                device_group_out: Some(99),
-                ..rule_req("test", 20000, 20, None)
-            }),
-        )
-        .await;
-        assert_eq!(resp.code, 400, "{}", resp.message);
-        assert!(resp.message.contains("device_group_out"));
-    }
-
-    /// v0.4.20: update_rule rejects forward_mode="group".
-    #[tokio::test]
-    async fn update_rule_rejects_group_forward_mode() {
-        let (state, pool) = test_state().await;
-        add_user(&pool, 2, "alice", false).await;
-        add_group(&pool, 20, 1, "shared-in").await;
-        add_rule(&pool, 200, 2, 20, 12000, 0).await;
-
-        let Json(resp) = update_rule(
-            auth(2, false),
-            State(state.clone()),
-            Path(200),
-            Json(UpdateRuleRequest {
-                forward_mode: Some("group".into()),
-                ..Default::default()
-            }),
-        )
-        .await;
-        assert_eq!(resp.code, 400, "{}", resp.message);
-        assert!(resp.message.contains("direct"));
-    }
-
-    /// v0.4.20: update_rule rejects non-null device_group_out.
-    #[tokio::test]
-    async fn update_rule_rejects_device_group_out() {
-        let (state, pool) = test_state().await;
-        add_user(&pool, 2, "alice", false).await;
-        add_group(&pool, 20, 1, "shared-in").await;
-        add_rule(&pool, 200, 2, 20, 12000, 0).await;
-
-        let Json(resp) = update_rule(
-            auth(2, false),
-            State(state.clone()),
-            Path(200),
-            Json(UpdateRuleRequest {
-                device_group_out: Some(99),
-                ..Default::default()
-            }),
-        )
-        .await;
-        assert_eq!(resp.code, 400, "{}", resp.message);
-        assert!(resp.message.contains("device_group_out"));
-    }
-
     #[tokio::test]
     async fn group_access_is_owner_scoped() {
         let (state, pool) = test_state().await;
@@ -1838,8 +1756,9 @@ mod tests {
         assert!(resp.message.contains("device_group_in"));
     }
 
-    /// v0.4.20: device_group_out is no longer supported — any non-null value
-    /// is rejected at the API boundary before ownership checks.
+    /// v0.5.0: device_group_out is now allowed — outbound-group forwarding is
+    /// back. The rule owner must own the outbound group (standard ownership
+    /// check). Foreign outbound groups are rejected.
     #[tokio::test]
     async fn update_rule_rejects_foreign_outbound_group() {
         let (state, pool) = test_state().await;
@@ -1849,6 +1768,7 @@ mod tests {
         add_group(&pool, 30, 3, "bob-out").await;
         add_rule(&pool, 200, 2, 20, 12000, 0).await;
 
+        // Foreign outbound group → forbidden (ownership check).
         let Json(resp) = update_rule(
             auth(2, false),
             State(state.clone()),
@@ -1860,7 +1780,20 @@ mod tests {
         )
         .await;
         assert_eq!(resp.code, 400, "{}", resp.message);
-        assert!(resp.message.contains("device_group_out"));
+
+        // Own outbound group → allowed.
+        add_group(&pool, 31, 2, "alice-out").await;
+        let Json(ok) = update_rule(
+            auth(2, false),
+            State(state.clone()),
+            Path(200),
+            Json(UpdateRuleRequest {
+                device_group_out: Some(31),
+                ..Default::default()
+            }),
+        )
+        .await;
+        assert_eq!(ok.code, 0, "{}", ok.message);
     }
 
     /// v0.4.12 PR1: a regular user re-pointing their rule at one of their OWN
@@ -2637,5 +2570,30 @@ mod tests {
         )
         .await;
         assert_eq!(resp.code, 400, "{}", resp.message);
+    }
+
+    /// v1.3: deleting a group that a tunnel references must be blocked.
+    #[tokio::test]
+    async fn delete_group_blocked_by_tunnel_reference() {
+        let (state, pool) = test_state().await;
+        // test_state() already created admin id=1, just use the group.
+        add_group(&pool, 10, 1, "tunnel-in").await;
+        // Insert a tunnel referencing group 10.
+        sqlx::query(
+            "INSERT INTO tunnels (name, group_in, protocol, listen_port, config_json, secret_json, uid) \
+             VALUES ('test', 10, 'vless_reality', 443, '{}', '{}', 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Attempting to delete group 10 must fail.
+        let result = crate::service::groups::delete_group(state.db.as_ref(), 10).await;
+        assert!(result.is_err(), "group deletion must be blocked by tunnel reference");
+        let err = result.unwrap_err();
+        assert!(
+            format!("{:?}", err).contains("10"),
+            "error must reference group id 10"
+        );
     }
 }

--- a/crates/panel/src/api/admin/tunnels.rs
+++ b/crates/panel/src/api/admin/tunnels.rs
@@ -5,7 +5,7 @@ use crate::db::repo::{CreateTunnelRequest, TunnelRepository, UpdateTunnelRequest
 use crate::service::tunnels::{
     create_tunnel as svc_create_tunnel, delete_tunnel as svc_delete_tunnel,
     regenerate_config as svc_regenerate_config, update_tunnel as svc_update_tunnel,
-    CreateTunnelError, DeleteTunnelError, UpdateTunnelError,
+    CreateTunnelError, UpdateTunnelError,
 };
 use axum::{
     extract::{Path, State},
@@ -107,7 +107,6 @@ pub async fn update_tunnel(
 ) -> Json<ApiResponse<()>> {
     let affected = match svc_update_tunnel(state.db.as_ref(), id, _admin.user_id, &req).await {
         Ok(n) => n,
-        Err(UpdateTunnelError::NotFound) => return Json(err(404, "隧道不存在")),
         Err(UpdateTunnelError::DuplicateGroupIn) => {
             return Json(err(400, "该入口组已绑定隧道"));
         }

--- a/crates/panel/src/api/admin/tunnels.rs
+++ b/crates/panel/src/api/admin/tunnels.rs
@@ -56,8 +56,8 @@ pub async fn create_tunnel(
     // Auto-populate config_json and secret_json if empty.
     let mut req = req;
     if req.config_json.is_empty() {
-        req.config_json = serde_json::to_string(
-            &crate::service::tunnels::generate_tunnel_config(&Tunnels {
+        req.config_json =
+            serde_json::to_string(&crate::service::tunnels::generate_tunnel_config(&Tunnels {
                 id: 0,
                 name: req.name.clone(),
                 group_in: req.group_in,
@@ -69,14 +69,12 @@ pub async fn create_tunnel(
                 enabled: false,
                 uid: admin.user_id,
                 created_at: String::new(),
-            }),
-        )
-        .unwrap_or_else(|_| "{}".to_string());
+            }))
+            .unwrap_or_else(|_| "{}".to_string());
     }
     if req.secret_json.is_empty() {
-        req.secret_json =
-            serde_json::to_string(&crate::service::tunnels::generate_tunnel_secret())
-                .unwrap_or_else(|_| "{}".to_string());
+        req.secret_json = serde_json::to_string(&crate::service::tunnels::generate_tunnel_secret())
+            .unwrap_or_else(|_| "{}".to_string());
     }
 
     let id = match svc_create_tunnel(state.db.as_ref(), &req).await {
@@ -90,15 +88,14 @@ pub async fn create_tunnel(
         }
     };
 
-    let tunnel =
-        match TunnelRepository::find_by_id(state.db.as_ref(), id, admin.user_id).await {
-            Ok(Some(t)) => t,
-            Ok(None) => return Json(err(500, "创建隧道后无法读取")),
-            Err(e) => {
-                tracing::error!("create_tunnel: find_by_id failed: {}", e);
-                return Json(err(500, "数据库错误"));
-            }
-        };
+    let tunnel = match TunnelRepository::find_by_id(state.db.as_ref(), id, admin.user_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return Json(err(500, "创建隧道后无法读取")),
+        Err(e) => {
+            tracing::error!("create_tunnel: find_by_id failed: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
     Json(ApiResponse::success(tunnel))
 }
 

--- a/crates/panel/src/api/admin/tunnels.rs
+++ b/crates/panel/src/api/admin/tunnels.rs
@@ -1,0 +1,158 @@
+use super::err;
+use crate::api::middleware::AdminOnly;
+use crate::api::AppState;
+use crate::db::repo::{CreateTunnelRequest, TunnelRepository, UpdateTunnelRequest};
+use crate::service::tunnels::{
+    create_tunnel as svc_create_tunnel, delete_tunnel as svc_delete_tunnel,
+    regenerate_config as svc_regenerate_config, update_tunnel as svc_update_tunnel,
+    CreateTunnelError, DeleteTunnelError, UpdateTunnelError,
+};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use relay_shared::models::Tunnels;
+use relay_shared::protocol::ApiResponse;
+use serde_json::Value;
+
+// === Tunnel Forwarding (v1.3) ===
+// CRUD for tunnel forwarding rules. Each tunnel maps one ingress group
+// (group_in) to an optional egress group (group_out) via sing-box.
+
+pub async fn list_tunnels(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+) -> Json<ApiResponse<Vec<Tunnels>>> {
+    let tunnels: Vec<Tunnels> = TunnelRepository::list_tunnels(state.db.as_ref(), _admin.user_id)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("list_tunnels: db error: {}", e);
+            Vec::new()
+        });
+    Json(ApiResponse::success(tunnels))
+}
+
+pub async fn get_tunnel(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Json<ApiResponse<Tunnels>> {
+    let tunnel = match TunnelRepository::find_by_id(state.db.as_ref(), id, _admin.user_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return Json(err(404, "隧道不存在")),
+        Err(e) => {
+            tracing::error!("get_tunnel: db error: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
+    Json(ApiResponse::success(tunnel))
+}
+
+pub async fn create_tunnel(
+    admin: AdminOnly,
+    State(state): State<AppState>,
+    Json(req): Json<CreateTunnelRequest>,
+) -> Json<ApiResponse<Tunnels>> {
+    // Auto-populate config_json and secret_json if empty.
+    let mut req = req;
+    if req.config_json.is_empty() {
+        req.config_json = serde_json::to_string(
+            &crate::service::tunnels::generate_tunnel_config(&Tunnels {
+                id: 0,
+                name: req.name.clone(),
+                group_in: req.group_in,
+                group_out: req.group_out,
+                protocol: req.protocol.clone(),
+                listen_port: req.listen_port,
+                config_json: String::new(),
+                secret_json: String::new(),
+                enabled: false,
+                uid: admin.user_id,
+                created_at: String::new(),
+            }),
+        )
+        .unwrap_or_else(|_| "{}".to_string());
+    }
+    if req.secret_json.is_empty() {
+        req.secret_json =
+            serde_json::to_string(&crate::service::tunnels::generate_tunnel_secret())
+                .unwrap_or_else(|_| "{}".to_string());
+    }
+
+    let id = match svc_create_tunnel(state.db.as_ref(), &req).await {
+        Ok(id) => id,
+        Err(CreateTunnelError::DuplicateGroupIn) => {
+            return Json(err(400, "该入口组已绑定隧道"));
+        }
+        Err(e) => {
+            tracing::error!("create_tunnel: db error: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
+
+    let tunnel =
+        match TunnelRepository::find_by_id(state.db.as_ref(), id, admin.user_id).await {
+            Ok(Some(t)) => t,
+            Ok(None) => return Json(err(500, "创建隧道后无法读取")),
+            Err(e) => {
+                tracing::error!("create_tunnel: find_by_id failed: {}", e);
+                return Json(err(500, "数据库错误"));
+            }
+        };
+    Json(ApiResponse::success(tunnel))
+}
+
+pub async fn update_tunnel(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(req): Json<UpdateTunnelRequest>,
+) -> Json<ApiResponse<()>> {
+    let affected = match svc_update_tunnel(state.db.as_ref(), id, _admin.user_id, &req).await {
+        Ok(n) => n,
+        Err(UpdateTunnelError::NotFound) => return Json(err(404, "隧道不存在")),
+        Err(UpdateTunnelError::DuplicateGroupIn) => {
+            return Json(err(400, "该入口组已绑定隧道"));
+        }
+        Err(e) => {
+            tracing::error!("update_tunnel: db error: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
+
+    if affected == 0 {
+        return Json(err(404, "隧道不存在"));
+    }
+    Json(ApiResponse::success(()))
+}
+
+pub async fn delete_tunnel(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Json<ApiResponse<()>> {
+    match svc_delete_tunnel(state.db.as_ref(), id, _admin.user_id).await {
+        Ok(n) if n > 0 => Json(ApiResponse::success(())),
+        Ok(_) => Json(err(404, "隧道不存在")),
+        Err(e) => {
+            tracing::error!("delete_tunnel: db error: {}", e);
+            Json(err(500, "数据库错误"))
+        }
+    }
+}
+
+/// Regenerate the sing-box config and secret for a tunnel.
+/// Replaces both config_json and secret_json with fresh generated values.
+pub async fn regenerate_tunnel_config(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Json<ApiResponse<(Value, Value)>> {
+    match svc_regenerate_config(state.db.as_ref(), id, _admin.user_id).await {
+        Ok((config, secret)) => Json(ApiResponse::success((config, secret))),
+        Err(e) => {
+            tracing::error!("regenerate_tunnel_config: {}", e);
+            Json(err(500, "生成配置失败"))
+        }
+    }
+}

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -173,6 +173,21 @@ pub fn routes() -> Router<AppState> {
             "/admin/tunnel-profiles/{id}",
             axum::routing::put(admin::update_tunnel_profile).delete(admin::delete_tunnel_profile),
         )
+        // v1.3: tunnel forwarding CRUD (admin-only).
+        .route(
+            "/admin/tunnels",
+            axum::routing::get(admin::list_tunnels).post(admin::create_tunnel),
+        )
+        .route(
+            "/admin/tunnels/{id}",
+            axum::routing::get(admin::get_tunnel)
+                .put(admin::update_tunnel)
+                .delete(admin::delete_tunnel),
+        )
+        .route(
+            "/admin/tunnels/{id}/regenerate-config",
+            axum::routing::post(admin::regenerate_tunnel_config),
+        )
         // v1.2.0: redeem-code management. Generation returns the codes once in
         // display form; the list endpoint can always re-read them.
         .route(

--- a/crates/panel/src/db/pg_repo/mod.rs
+++ b/crates/panel/src/db/pg_repo/mod.rs
@@ -37,6 +37,7 @@ mod stats;
 #[cfg(test)]
 mod tests;
 mod traffic;
+mod tunnels;
 mod user_groups;
 mod users;
 

--- a/crates/panel/src/db/pg_repo/tunnels.rs
+++ b/crates/panel/src/db/pg_repo/tunnels.rs
@@ -1,0 +1,161 @@
+use super::PgRepository;
+use crate::db::error::DbError;
+use crate::db::repo::*;
+use async_trait::async_trait;
+use relay_shared::models::Tunnels;
+
+// ── TunnelRepository ──
+
+#[async_trait]
+impl TunnelRepository for PgRepository {
+    async fn list_tunnels(&self, uid: i64) -> Result<Vec<Tunnels>, DbError> {
+        let rows: Vec<Tunnels> = sqlx::query_as(
+            "SELECT id, name, group_in, group_out, protocol, listen_port, \
+             config_json, secret_json, enabled, uid, created_at \
+             FROM tunnels WHERE uid = $1 ORDER BY id",
+        )
+        .bind(uid)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(&self, id: i64, uid: i64) -> Result<Option<Tunnels>, DbError> {
+        let row: Option<Tunnels> = sqlx::query_as(
+            "SELECT id, name, group_in, group_out, protocol, listen_port, \
+             config_json, secret_json, enabled, uid, created_at \
+             FROM tunnels WHERE id = $1 AND uid = $2",
+        )
+        .bind(id)
+        .bind(uid)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn find_by_group_in(&self, group_in: i64) -> Result<Option<Tunnels>, DbError> {
+        let row: Option<Tunnels> = sqlx::query_as(
+            "SELECT id, name, group_in, group_out, protocol, listen_port, \
+             config_json, secret_json, enabled, uid, created_at \
+             FROM tunnels WHERE group_in = $1",
+        )
+        .bind(group_in)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn create_tunnel(&self, req: &CreateTunnelRequest) -> Result<i64, DbError> {
+        let (id,): (i64,) = sqlx::query_as(
+            "INSERT INTO tunnels \
+             (name, group_in, group_out, protocol, listen_port, config_json, secret_json, enabled, uid) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, FALSE, $8) \
+             RETURNING id",
+        )
+        .bind(&req.name)
+        .bind(req.group_in)
+        .bind(req.group_out)
+        .bind(&req.protocol)
+        .bind(req.listen_port)
+        .bind(&req.config_json)
+        .bind(&req.secret_json)
+        .bind(req.uid)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    async fn update_tunnel_fields(
+        &self,
+        id: i64,
+        uid: i64,
+        req: &UpdateTunnelRequest,
+    ) -> Result<u64, DbError> {
+        let mut sets: Vec<&str> = Vec::new();
+        if req.name.is_some() {
+            sets.push("name = ");
+        }
+        if req.group_in.is_some() {
+            sets.push("group_in = ");
+        }
+        if req.group_out.is_some() {
+            sets.push("group_out = ");
+        }
+        if req.protocol.is_some() {
+            sets.push("protocol = ");
+        }
+        if req.listen_port.is_some() {
+            sets.push("listen_port = ");
+        }
+        if req.config_json.is_some() {
+            sets.push("config_json = ");
+        }
+        if req.secret_json.is_some() {
+            sets.push("secret_json = ");
+        }
+        if req.enabled.is_some() {
+            sets.push("enabled = ");
+        }
+
+        if sets.is_empty() {
+            return Ok(0);
+        }
+
+        let mut ph = 1;
+        let sets_with_ph: Vec<String> = sets
+            .iter()
+            .map(|s| {
+                let p = format!("{s}${ph}");
+                ph += 1;
+                p
+            })
+            .collect();
+        let id_ph = ph;
+        let uid_ph = ph + 1;
+        let sql = format!(
+            "UPDATE tunnels SET {} WHERE id = ${} AND uid = ${}",
+            sets_with_ph.join(", "),
+            id_ph,
+            uid_ph
+        );
+
+        let mut q = sqlx::query(&sql);
+        if let Some(v) = &req.name {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.group_in {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.group_out {
+            q = q.bind(v);
+        }
+        if let Some(v) = &req.protocol {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.listen_port {
+            q = q.bind(v);
+        }
+        if let Some(v) = &req.config_json {
+            q = q.bind(v);
+        }
+        if let Some(v) = &req.secret_json {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.enabled {
+            q = q.bind(v);
+        }
+        q = q.bind(id).bind(uid);
+
+        let result = q.execute(&self.pool).await?;
+        Ok(result.rows_affected())
+    }
+
+    async fn delete_tunnel(&self, id: i64, uid: i64) -> Result<u64, DbError> {
+        let result = sqlx::query("DELETE FROM tunnels WHERE id = $1 AND uid = $2")
+            .bind(id)
+            .bind(uid)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -1296,6 +1296,11 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
         tracing::info!("PG migration 25: tunnels table created");
+        sqlx::query(
+            "INSERT INTO schema_version (version) VALUES (25) ON CONFLICT (version) DO NOTHING",
+        )
+        .execute(pool)
+        .await?;
     }
 
     Ok(())

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -108,6 +108,22 @@ CREATE TABLE IF NOT EXISTS tunnel_profiles (
     created_at      TEXT NOT NULL DEFAULT (to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS'))
 );
 
+-- v1.3: tunnel forwarding (entrance → exit via sing-box).
+CREATE TABLE IF NOT EXISTS tunnels (
+    id              BIGSERIAL PRIMARY KEY,
+    name            TEXT NOT NULL,
+    group_in        BIGINT NOT NULL REFERENCES device_groups(id),
+    group_out       BIGINT REFERENCES device_groups(id),
+    protocol        TEXT NOT NULL DEFAULT 'vless_reality',
+    listen_port     INTEGER NOT NULL,
+    config_json     TEXT NOT NULL DEFAULT '{}',
+    secret_json     TEXT NOT NULL DEFAULT '{}',
+    enabled         BOOLEAN NOT NULL DEFAULT FALSE,
+    uid             BIGINT NOT NULL REFERENCES users(id),
+    created_at      TEXT NOT NULL DEFAULT (to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    CONSTRAINT tunnels_group_in_unique UNIQUE(group_in)
+);
+
 CREATE TABLE IF NOT EXISTS forward_rules (
     id BIGSERIAL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -329,7 +345,7 @@ INSERT INTO schema_version (version) VALUES (1) ON CONFLICT (version) DO NOTHING
 /// The schema revision this build's baseline `PG_SCHEMA_SQL` represents. When a
 /// future release adds a column/table, bump this and add a matching arm in
 /// `run_pg_migrations`. `apply_pg_schema` seeds `schema_version` with revision 1.
-pub const PG_SCHEMA_VERSION: i32 = 24;
+pub const PG_SCHEMA_VERSION: i32 = 25;
 
 /// Apply PG_SCHEMA_SQL to a pool. PostgreSQL's prepared-statement protocol
 /// rejects multi-statement strings ("cannot insert multiple commands into a
@@ -1257,6 +1273,29 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
             "PG migration 24: traffic_history.group_id present ({} row(s) backfilled)",
             backfilled
         );
+    }
+
+    // ── Migration 25: v1.3 tunnels ──
+    if current < 25 {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS tunnels (
+                id              BIGSERIAL PRIMARY KEY,
+                name            TEXT NOT NULL,
+                group_in        BIGINT NOT NULL REFERENCES device_groups(id),
+                group_out       BIGINT REFERENCES device_groups(id),
+                protocol        TEXT NOT NULL DEFAULT 'vless_reality',
+                listen_port     INTEGER NOT NULL,
+                config_json     TEXT NOT NULL DEFAULT '{}',
+                secret_json     TEXT NOT NULL DEFAULT '{}',
+                enabled         BOOLEAN NOT NULL DEFAULT FALSE,
+                uid             BIGINT NOT NULL REFERENCES users(id),
+                created_at      TEXT NOT NULL DEFAULT (to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+                CONSTRAINT tunnels_group_in_unique UNIQUE(group_in)
+            )",
+        )
+        .execute(pool)
+        .await?;
+        tracing::info!("PG migration 25: tunnels table created");
     }
 
     Ok(())

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -25,7 +25,7 @@
 use async_trait::async_trait;
 use relay_shared::models::{
     DeviceGroup, ForwardRule, ForwardRuleTarget, Order, Plan, SharedGroupSummary, Statistic,
-    TunnelProfile, User,
+    Tunnels, TunnelProfile, User,
 };
 use relay_shared::protocol::{RuleTargetRequest, TrafficEntry};
 use serde::Serialize;
@@ -627,6 +627,48 @@ pub trait TunnelProfileRepository: Send + Sync {
     async fn delete_profile(&self, id: i64, scope: &ResourceScope) -> Result<u64, DbError>;
 }
 
+// ── Tunnels (v1.3) ──
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct CreateTunnelRequest {
+    pub name: String,
+    pub group_in: i64,
+    pub group_out: Option<i64>,
+    pub protocol: String,
+    pub listen_port: i32,
+    pub config_json: String,
+    pub secret_json: String,
+    pub uid: i64,
+}
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct UpdateTunnelRequest {
+    pub name: Option<String>,
+    pub group_in: Option<i64>,
+    pub group_out: Option<Option<i64>>,
+    pub protocol: Option<String>,
+    pub listen_port: Option<i32>,
+    pub config_json: Option<String>,
+    pub secret_json: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+#[async_trait]
+pub trait TunnelRepository: Send + Sync {
+    async fn list_tunnels(&self, uid: i64) -> Result<Vec<Tunnels>, DbError>;
+    async fn find_by_id(&self, id: i64, uid: i64) -> Result<Option<Tunnels>, DbError>;
+    /// Find a tunnel by its group_in id (unique). `None` = no such tunnel.
+    async fn find_by_group_in(&self, group_in: i64) -> Result<Option<Tunnels>, DbError>;
+    async fn create_tunnel(&self, req: &CreateTunnelRequest) -> Result<i64, DbError>;
+    async fn update_tunnel_fields(
+        &self,
+        id: i64,
+        uid: i64,
+        req: &UpdateTunnelRequest,
+    ) -> Result<u64, DbError>;
+    async fn delete_tunnel(&self, id: i64, uid: i64) -> Result<u64, DbError>;
+}
+
 // ── Traffic (atomic batch) ──
 
 /// Outcome of a traffic batch.
@@ -1062,6 +1104,7 @@ pub trait Repository:
     + GroupRepository
     + DeviceGroupAuthRepository
     + TunnelProfileRepository
+    + TunnelRepository
     + TrafficRepository
     + KvsRepository
     + StatisticsRepository

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -25,7 +25,7 @@
 use async_trait::async_trait;
 use relay_shared::models::{
     DeviceGroup, ForwardRule, ForwardRuleTarget, Order, Plan, SharedGroupSummary, Statistic,
-    Tunnels, TunnelProfile, User,
+    TunnelProfile, Tunnels, User,
 };
 use relay_shared::protocol::{RuleTargetRequest, TrafficEntry};
 use serde::Serialize;

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -114,6 +114,26 @@ CREATE TABLE IF NOT EXISTS tunnel_profiles (
     created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- v1.3: tunnel forwarding (entrance → exit via sing-box).
+-- group_in UNIQUE ensures each ingress node can unambiguously determine
+-- which tunnel to use. group_out has no uniqueness constraint: an exit
+-- service may serve multiple entrances, and "multi-entrance → single exit"
+-- is a natural growth path — no need to lock it now.
+CREATE TABLE IF NOT EXISTS tunnels (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    name            TEXT NOT NULL,
+    group_in        INTEGER NOT NULL REFERENCES device_groups(id),
+    group_out       INTEGER REFERENCES device_groups(id),
+    protocol        TEXT NOT NULL DEFAULT 'vless_reality',
+    listen_port     INTEGER NOT NULL,
+    config_json     TEXT NOT NULL DEFAULT '{}',
+    secret_json     TEXT NOT NULL DEFAULT '{}',
+    enabled         INTEGER NOT NULL DEFAULT 0,
+    uid             INTEGER NOT NULL REFERENCES users(id),
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(group_in)
+);
+
 CREATE TABLE IF NOT EXISTS forward_rules (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
@@ -1571,6 +1591,63 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
         "Migration 41: traffic_history.group_id present ({} row(s) backfilled)",
         backfilled
     );
+
+    // ── Migration 42: v1.3 tunnels.group_in UNIQUE (one tunnel per entrance group) ──
+    // UNIQUE(group_in) is required so that each ingress node can unambiguously
+    // determine which tunnel to use. SQLite cannot add UNIQUE via ALTER TABLE
+    // without rebuilding the entire table, so we do it the hard way: create a
+    // new table, copy data, drop the old, rename.
+    //
+    // Guard against fresh installs: if the table doesn't exist, Migration 41
+    // already created it with the UNIQUE constraint (via SCHEMA_SQL), so we
+    // can safely skip.
+    {
+        let exists: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM sqlite_master \
+             WHERE type='table' AND name='tunnels'",
+        )
+        .fetch_one(pool)
+        .await?;
+        if exists.0 > 0 {
+            sqlx::query("BEGIN TRANSACTION").execute(pool).await?;
+
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS tunnels_new (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name            TEXT NOT NULL,
+                    group_in        INTEGER NOT NULL REFERENCES device_groups(id),
+                    group_out       INTEGER REFERENCES device_groups(id),
+                    protocol        TEXT NOT NULL DEFAULT 'vless_reality',
+                    listen_port     INTEGER NOT NULL,
+                    config_json     TEXT NOT NULL DEFAULT '{}',
+                    secret_json     TEXT NOT NULL DEFAULT '{}',
+                    enabled         INTEGER NOT NULL DEFAULT 0,
+                    uid             INTEGER NOT NULL REFERENCES users(id),
+                    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(group_in)
+                )",
+            )
+            .execute(pool)
+            .await?;
+
+            sqlx::query(
+                "INSERT OR REPLACE INTO tunnels_new \
+                 (id, name, group_in, group_out, protocol, listen_port, config_json, secret_json, enabled, uid, created_at) \
+                 SELECT id, name, group_in, group_out, protocol, listen_port, config_json, secret_json, enabled, uid, created_at \
+                 FROM tunnels",
+            )
+            .execute(pool)
+            .await?;
+
+            sqlx::query("DROP TABLE tunnels").execute(pool).await?;
+            sqlx::query("ALTER TABLE tunnels_new RENAME TO tunnels")
+                .execute(pool)
+                .await?;
+
+            sqlx::query("COMMIT").execute(pool).await?;
+        }
+    }
+    tracing::info!("Migration 42: tunnels.group_in UNIQUE constraint applied");
 
     Ok(())
 }

--- a/crates/panel/src/db/sqlite_repo/mod.rs
+++ b/crates/panel/src/db/sqlite_repo/mod.rs
@@ -21,6 +21,7 @@ mod stats;
 #[cfg(test)]
 mod tests;
 mod traffic;
+mod tunnels;
 mod user_groups;
 mod users;
 

--- a/crates/panel/src/db/sqlite_repo/tunnels.rs
+++ b/crates/panel/src/db/sqlite_repo/tunnels.rs
@@ -1,0 +1,147 @@
+use super::SqliteRepository;
+use crate::db::error::DbError;
+use crate::db::repo::*;
+use async_trait::async_trait;
+use relay_shared::models::Tunnels;
+
+// ── TunnelRepository ──
+
+#[async_trait]
+impl TunnelRepository for SqliteRepository {
+    async fn list_tunnels(&self, uid: i64) -> Result<Vec<Tunnels>, DbError> {
+        let rows: Vec<Tunnels> = sqlx::query_as(
+            "SELECT id, name, group_in, group_out, protocol, listen_port, \
+             config_json, secret_json, enabled, uid, created_at \
+             FROM tunnels WHERE uid = ? ORDER BY id",
+        )
+        .bind(uid)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(&self, id: i64, uid: i64) -> Result<Option<Tunnels>, DbError> {
+        let row: Option<Tunnels> = sqlx::query_as(
+            "SELECT id, name, group_in, group_out, protocol, listen_port, \
+             config_json, secret_json, enabled, uid, created_at \
+             FROM tunnels WHERE id = ? AND uid = ?",
+        )
+        .bind(id)
+        .bind(uid)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn find_by_group_in(&self, group_in: i64) -> Result<Option<Tunnels>, DbError> {
+        let row: Option<Tunnels> = sqlx::query_as(
+            "SELECT id, name, group_in, group_out, protocol, listen_port, \
+             config_json, secret_json, enabled, uid, created_at \
+             FROM tunnels WHERE group_in = ?",
+        )
+        .bind(group_in)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn create_tunnel(&self, req: &CreateTunnelRequest) -> Result<i64, DbError> {
+        let result = sqlx::query(
+            "INSERT INTO tunnels \
+             (name, group_in, group_out, protocol, listen_port, config_json, secret_json, enabled, uid) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)",
+        )
+        .bind(&req.name)
+        .bind(req.group_in)
+        .bind(req.group_out)
+        .bind(&req.protocol)
+        .bind(req.listen_port)
+        .bind(&req.config_json)
+        .bind(&req.secret_json)
+        .bind(req.uid)
+        .execute(&self.pool)
+        .await?;
+        let id = result.last_insert_rowid();
+        Ok(id)
+    }
+
+    async fn update_tunnel_fields(
+        &self,
+        id: i64,
+        uid: i64,
+        req: &UpdateTunnelRequest,
+    ) -> Result<u64, DbError> {
+        let mut sets: Vec<&str> = Vec::new();
+        if req.name.is_some() {
+            sets.push("name = ?");
+        }
+        if req.group_in.is_some() {
+            sets.push("group_in = ?");
+        }
+        if req.group_out.is_some() {
+            sets.push("group_out = ?");
+        }
+        if req.protocol.is_some() {
+            sets.push("protocol = ?");
+        }
+        if req.listen_port.is_some() {
+            sets.push("listen_port = ?");
+        }
+        if req.config_json.is_some() {
+            sets.push("config_json = ?");
+        }
+        if req.secret_json.is_some() {
+            sets.push("secret_json = ?");
+        }
+        if req.enabled.is_some() {
+            sets.push("enabled = ?");
+        }
+
+        if sets.is_empty() {
+            return Ok(0);
+        }
+
+        let sql = format!(
+            "UPDATE tunnels SET {} WHERE id = ? AND uid = ?",
+            sets.join(", "),
+        );
+        let mut q = sqlx::query(&sql);
+        if let Some(v) = &req.name {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.group_in {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.group_out {
+            q = q.bind(v);
+        }
+        if let Some(v) = &req.protocol {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.listen_port {
+            q = q.bind(v);
+        }
+        if let Some(v) = &req.config_json {
+            q = q.bind(v);
+        }
+        if let Some(v) = &req.secret_json {
+            q = q.bind(v);
+        }
+        if let Some(v) = req.enabled {
+            q = q.bind(if v { 1 } else { 0 });
+        }
+        q = q.bind(id).bind(uid);
+
+        let result = q.execute(&self.pool).await?;
+        Ok(result.rows_affected())
+    }
+
+    async fn delete_tunnel(&self, id: i64, uid: i64) -> Result<u64, DbError> {
+        let result = sqlx::query("DELETE FROM tunnels WHERE id = ? AND uid = ?")
+            .bind(id)
+            .bind(uid)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/panel/src/service/groups.rs
+++ b/crates/panel/src/service/groups.rs
@@ -7,7 +7,7 @@
 //! logging — those depend on `node_connections`, not the `Repository`.
 
 use crate::db::error::DbError;
-use crate::db::repo::ResourceScope;
+use crate::db::repo::{GroupRepository, ResourceScope, TunnelRepository};
 use crate::db::Repository;
 use crate::service::rules::group_type_to_str;
 use relay_shared::models::DeviceGroup;
@@ -162,18 +162,20 @@ impl std::fmt::Display for GroupInUseError {
 impl std::error::Error for GroupInUseError {}
 
 /// Delete an admin-owned device group. Before deleting, checks that no
-/// forward_rules reference this group via device_group_in, device_group_out,
-/// or fallback_group. Returns `GroupInUseError` with the rule count if any
-/// references exist, so the handler can return a clear 409.
+/// forward_rules or tunnels reference this group via device_group_in,
+/// device_group_out, or fallback_group. Returns `GroupInUseError` with the
+/// combined count if any references exist.
 pub async fn delete_group(
     db: &dyn Repository,
     id: i64,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-    let count = db.count_rules_by_group(id).await?;
-    if count > 0 {
+    let rule_count = db.count_rules_by_group(id).await?;
+    let tunnel_count = db.find_by_group_in(id).await?.map_or(0, |_| 1);
+    let total_refs = rule_count + tunnel_count;
+    if total_refs > 0 {
         return Err(Box::new(GroupInUseError {
             group_id: id,
-            rule_count: count,
+            rule_count: total_refs,
         }));
     }
     Ok(db.delete_group(id, &ResourceScope::All).await? > 0)

--- a/crates/panel/src/service/groups.rs
+++ b/crates/panel/src/service/groups.rs
@@ -7,7 +7,7 @@
 //! logging — those depend on `node_connections`, not the `Repository`.
 
 use crate::db::error::DbError;
-use crate::db::repo::{GroupRepository, ResourceScope, TunnelRepository};
+use crate::db::repo::{ResourceScope, TunnelRepository};
 use crate::db::Repository;
 use crate::service::rules::group_type_to_str;
 use relay_shared::models::DeviceGroup;
@@ -170,7 +170,9 @@ pub async fn delete_group(
     id: i64,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
     let rule_count = db.count_rules_by_group(id).await?;
-    let tunnel_count = db.find_by_group_in(id).await?.map_or(0, |_| 1);
+    let tunnel_count = TunnelRepository::find_by_group_in(db, id)
+        .await?
+        .map_or(0, |_| 1);
     let total_refs = rule_count + tunnel_count;
     if total_refs > 0 {
         return Err(Box::new(GroupInUseError {

--- a/crates/panel/src/service/mod.rs
+++ b/crates/panel/src/service/mod.rs
@@ -10,4 +10,5 @@ pub mod redeem;
 pub mod rules;
 pub mod settings;
 pub mod traffic;
+pub mod tunnels;
 pub mod users;

--- a/crates/panel/src/service/rules.rs
+++ b/crates/panel/src/service/rules.rs
@@ -12,14 +12,6 @@ use relay_shared::protocol::{
     CreateRuleRequest, GroupType, Protocol, PublicTransport, RuleTargetRequest, UpdateRuleRequest,
 };
 
-/// v0.4.20: forward_mode is locked to "direct" at the API boundary
-/// (create_rule / update_rule reject group/chain). This validator is retained
-/// for potential future re-enablement and for config-generation compatibility.
-#[allow(dead_code)]
-pub fn validate_forward_mode(mode: &str) -> bool {
-    matches!(mode, "group" | "direct")
-}
-
 /// Is `transport` accepted by the admin API in the current release?
 ///
 /// v0.4.1: `Raw` + `Ws` + `TlsSimple` (node terminates TLS via rustls).
@@ -354,23 +346,6 @@ pub async fn create_rule(
     // The scope for validating referenced groups = the FINAL owner.
     let owner_scope = ResourceScope::Owner(owner_uid);
 
-    // v0.4.20: only direct forward_mode is supported. Group/chain forwarding
-    // is no longer exposed in the UI and is rejected at the API boundary.
-    // Existing rules with group forwarding still generate valid config, but
-    // new rules must use direct.
-    if req.forward_mode != "direct" {
-        return Err(CreateRuleError::BadRequest(
-            "forward_mode: only 'direct' is supported; group/chain forwarding is no longer available"
-                .into(),
-        ));
-    }
-    if req.device_group_out.is_some() {
-        return Err(CreateRuleError::BadRequest(
-            "device_group_out: outbound-group forwarding is no longer supported; remove device_group_out"
-                .into(),
-        ));
-    }
-
     // v0.4.12 PR1: device_group_in MUST be an inbound group (`group_type='in'`)
     // owned by an ADMIN.
     validate_admin_owned_inbound_group(db, req.device_group_in, "create_rule").await?;
@@ -577,22 +552,6 @@ pub async fn update_rule(
     scope: &ResourceScope,
     req: &UpdateRuleRequest,
 ) -> Result<(), UpdateRuleError> {
-    // v0.4.20: only direct forward_mode is supported.
-    if let Some(ref mode) = req.forward_mode {
-        if mode != "direct" {
-            return Err(UpdateRuleError::BadRequest(
-                "forward_mode: only 'direct' is supported; group/chain forwarding is no longer available"
-                    .into(),
-            ));
-        }
-    }
-    if req.device_group_out.is_some() {
-        return Err(UpdateRuleError::BadRequest(
-            "device_group_out: outbound-group forwarding is no longer supported; remove device_group_out"
-                .into(),
-        ));
-    }
-
     if let Some(ref transport) = req.public_transport {
         if !is_public_transport_accepted(*transport) {
             return Err(UpdateRuleError::BadRequest(

--- a/crates/panel/src/service/tunnels.rs
+++ b/crates/panel/src/service/tunnels.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 /// to `group_out` as an outbound. The user can override the generated JSON by
 /// writing their own config before storing.
 pub fn generate_tunnel_config(tunnel: &Tunnels) -> Value {
-    let listener_id = Uuid::new_v4().to_string();
+    let _listener_id = Uuid::new_v4().to_string();
     let outbound_id = Uuid::new_v4().to_string();
 
     json!({
@@ -202,7 +202,6 @@ impl fmt::Display for CreateTunnelError {
 
 #[derive(Debug)]
 pub enum UpdateTunnelError {
-    NotFound,
     DuplicateGroupIn,
     Database(DbError),
 }
@@ -210,7 +209,6 @@ pub enum UpdateTunnelError {
 impl fmt::Display for UpdateTunnelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            UpdateTunnelError::NotFound => write!(f, "tunnel not found"),
             UpdateTunnelError::DuplicateGroupIn => write!(f, "duplicate group_in"),
             UpdateTunnelError::Database(e) => write!(f, "database error: {}", e),
         }

--- a/crates/panel/src/service/tunnels.rs
+++ b/crates/panel/src/service/tunnels.rs
@@ -1,0 +1,335 @@
+use crate::db::error::DbError;
+use crate::db::repo::{CreateTunnelRequest, Repository, TunnelRepository, UpdateTunnelRequest};
+use relay_shared::models::Tunnels;
+use serde_json::{json, Value};
+use std::fmt;
+use uuid::Uuid;
+
+// ── Config generation ──
+
+/// Generate a sing-box config for the tunnel.
+///
+/// Produces a minimal vless reality listener with a routing table that forwards
+/// to `group_out` as an outbound. The user can override the generated JSON by
+/// writing their own config before storing.
+pub fn generate_tunnel_config(tunnel: &Tunnels) -> Value {
+    let listener_id = Uuid::new_v4().to_string();
+    let outbound_id = Uuid::new_v4().to_string();
+
+    json!({
+        "log": {
+            "level": "info",
+            "timestamp": true
+        },
+        "dns": {
+            "servers": [
+                {
+                    "tag": "dns_proxy",
+                    "address": "tcp://8.8.8.8",
+                    "detour": outbound_id
+                },
+                {
+                    "tag": "dns_direct",
+                    "address": "local",
+                    "detour": "direct"
+                },
+                {
+                    "tag": "dns_block",
+                    "address": "rcode://success"
+                }
+            ],
+            "rules": [
+                {
+                    "outbound": "sing-box",
+                    "server": "dns_proxy"
+                },
+                {
+                    "geosite": "cn",
+                    "server": "dns_direct"
+                }
+            ],
+            "final": "dns_direct",
+            "disable_cache": false
+        },
+        "inbounds": [
+            {
+                "type": "vless",
+                "tag": "tunnel-in",
+                "listen": "::",
+                "listen_port": tunnel.listen_port,
+                "users": [],
+                "sniff": true,
+                "sniff_override_destination": true,
+                "domain_strategy": "ipv4_only",
+                "settings": {
+                    "decryption": "none"
+                },
+                "multiplex": {
+                    "enabled": true,
+                    "padding": true
+                }
+            }
+        ],
+        "outbounds": [
+            {
+                "type": "socks",
+                "tag": outbound_id,
+                "server": "::",
+                "server_port": 1080
+            },
+            {
+                "type": "direct",
+                "tag": "direct"
+            },
+            {
+                "type": "block",
+                "tag": "block"
+            }
+        ],
+        "route": {
+            "rules": [
+                {
+                    "network": "udp",
+                    "port": 443,
+                    "outbound": "block"
+                },
+                {
+                    "clash_mode": "global",
+                    "outbound": outbound_id
+                },
+                {
+                    "clash_mode": "direct",
+                    "outbound": "direct"
+                },
+                {
+                    "geosite": "private",
+                    "outbound": "direct"
+                },
+                {
+                    "geosite": "cn",
+                    "outbound": "direct"
+                }
+            ],
+            "final": outbound_id,
+            "auto_detect_interface": true
+        },
+        "experimental": {
+            "cache_file": {
+                "enabled": true,
+                "store_route": true
+            }
+        }
+    })
+}
+
+/// Generate a secret JSON for the tunnel (vless reality settings).
+///
+/// The user fills in `server_addr`, `server_port`, `private_key` and optionally
+/// `client_id` to authenticate with their reality server.
+pub fn generate_tunnel_secret() -> Value {
+    json!({
+        "server_addr": "",
+        "server_port": 443,
+        "private_key": "",
+        "client_id": ""
+    })
+}
+
+#[derive(Debug)]
+pub enum GenerateConfigError {
+    Database(DbError),
+}
+
+impl fmt::Display for GenerateConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GenerateConfigError::Database(e) => write!(f, "database error: {}", e),
+        }
+    }
+}
+
+/// Generate configs for a tunnel and update the row in-place.
+///
+/// Replaces `config_json` and `secret_json` with freshly generated values.
+/// Useful when the user wants a clean starting point or regenerates after
+/// changing `listen_port` / `protocol`.
+pub async fn regenerate_config(
+    db: &dyn Repository,
+    id: i64,
+    uid: i64,
+) -> Result<(Value, Value), GenerateConfigError> {
+    let tunnel = match TunnelRepository::find_by_id(db, id, uid).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return Ok((json!({}), json!({}))),
+        Err(e) => return Err(GenerateConfigError::Database(e)),
+    };
+
+    let config = generate_tunnel_config(&tunnel);
+    let secret = generate_tunnel_secret();
+
+    let _ = db
+        .update_tunnel_fields(
+            id,
+            uid,
+            &UpdateTunnelRequest {
+                config_json: Some(config.to_string()),
+                secret_json: Some(secret.to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(GenerateConfigError::Database)?;
+
+    Ok((config, secret))
+}
+
+// ── CRUD ──
+
+#[derive(Debug)]
+pub enum CreateTunnelError {
+    DuplicateGroupIn,
+    Database(DbError),
+}
+
+impl fmt::Display for CreateTunnelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CreateTunnelError::DuplicateGroupIn => write!(f, "duplicate group_in"),
+            CreateTunnelError::Database(e) => write!(f, "database error: {}", e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum UpdateTunnelError {
+    NotFound,
+    DuplicateGroupIn,
+    Database(DbError),
+}
+
+impl fmt::Display for UpdateTunnelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UpdateTunnelError::NotFound => write!(f, "tunnel not found"),
+            UpdateTunnelError::DuplicateGroupIn => write!(f, "duplicate group_in"),
+            UpdateTunnelError::Database(e) => write!(f, "database error: {}", e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum DeleteTunnelError {
+    Database(DbError),
+}
+
+impl fmt::Display for DeleteTunnelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeleteTunnelError::Database(e) => write!(f, "database error: {}", e),
+        }
+    }
+}
+
+/// Create a tunnel. Validates that `group_in` is not already claimed by another
+/// tunnel (enforced by the UNIQUE constraint, caught via the pre-check).
+pub async fn create_tunnel(
+    db: &dyn Repository,
+    req: &CreateTunnelRequest,
+) -> Result<i64, CreateTunnelError> {
+    // Pre-check group_in uniqueness.
+    if let Ok(Some(_)) = TunnelRepository::find_by_group_in(db, req.group_in).await {
+        return Err(CreateTunnelError::DuplicateGroupIn);
+    }
+
+    TunnelRepository::create_tunnel(db, req)
+        .await
+        .map_err(CreateTunnelError::Database)
+}
+
+/// Update a tunnel's fields (partial update). Returns the number of rows affected.
+pub async fn update_tunnel(
+    db: &dyn Repository,
+    id: i64,
+    uid: i64,
+    req: &UpdateTunnelRequest,
+) -> Result<u64, UpdateTunnelError> {
+    // Pre-check group_in uniqueness if changing.
+    if let Some(new_group_in) = req.group_in {
+        // Skip self.
+        if let Ok(Some(existing)) =
+            TunnelRepository::find_by_id(db, id, uid).await
+        {
+            if existing.group_in != new_group_in {
+                if let Ok(Some(other)) =
+                    TunnelRepository::find_by_group_in(db, new_group_in).await
+                {
+                    if other.id != id {
+                        return Err(UpdateTunnelError::DuplicateGroupIn);
+                    }
+                }
+            }
+        }
+    }
+
+    TunnelRepository::update_tunnel_fields(db, id, uid, req)
+        .await
+        .map_err(UpdateTunnelError::Database)
+}
+
+/// Delete a tunnel by id, owner-scoped.
+pub async fn delete_tunnel(
+    db: &dyn Repository,
+    id: i64,
+    uid: i64,
+) -> Result<u64, DeleteTunnelError> {
+    TunnelRepository::delete_tunnel(db, id, uid)
+        .await
+        .map_err(DeleteTunnelError::Database)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_tunnel_config_has_required_keys() {
+        let tunnel = Tunnels {
+            id: 1,
+            name: "test".into(),
+            group_in: 1,
+            group_out: Some(2),
+            protocol: "vless_reality".into(),
+            listen_port: 443,
+            config_json: "{}".into(),
+            secret_json: "{}".into(),
+            enabled: true,
+            uid: 1,
+            created_at: "2024-01-01 00:00:00".into(),
+        };
+        let cfg = generate_tunnel_config(&tunnel);
+        assert!(cfg.get("inbounds").is_some());
+        assert!(cfg.get("outbounds").is_some());
+        assert!(cfg.get("route").is_some());
+        assert!(cfg.get("dns").is_some());
+
+        let inbounds: Vec<&Value> = cfg["inbounds"].as_array().unwrap().iter().collect();
+        assert_eq!(inbounds.len(), 1);
+        assert_eq!(inbounds[0]["listen_port"], 443);
+    }
+
+    #[test]
+    fn generate_tunnel_secret_has_expected_fields() {
+        let secret = generate_tunnel_secret();
+        assert!(secret.get("server_addr").is_some());
+        assert!(secret.get("server_port").is_some());
+        assert!(secret.get("private_key").is_some());
+        assert!(secret.get("client_id").is_some());
+    }
+
+    #[test]
+    fn create_tunnel_error_debug_fmt() {
+        let e = CreateTunnelError::DuplicateGroupIn;
+        let msg = format!("{:?}", e);
+        assert!(msg.contains("DuplicateGroupIn"));
+    }
+}

--- a/crates/panel/src/service/tunnels.rs
+++ b/crates/panel/src/service/tunnels.rs
@@ -256,12 +256,9 @@ pub async fn update_tunnel(
     // Pre-check group_in uniqueness if changing.
     if let Some(new_group_in) = req.group_in {
         // Skip self.
-        if let Ok(Some(existing)) =
-            TunnelRepository::find_by_id(db, id, uid).await
-        {
+        if let Ok(Some(existing)) = TunnelRepository::find_by_id(db, id, uid).await {
             if existing.group_in != new_group_in {
-                if let Ok(Some(other)) =
-                    TunnelRepository::find_by_group_in(db, new_group_in).await
+                if let Ok(Some(other)) = TunnelRepository::find_by_group_in(db, new_group_in).await
                 {
                     if other.id != id {
                         return Err(UpdateTunnelError::DuplicateGroupIn);

--- a/crates/shared/src/models.rs
+++ b/crates/shared/src/models.rs
@@ -309,6 +309,22 @@ pub struct TunnelProfile {
     pub created_at: String,
 }
 
+/// v1.3: tunnel forwarding (entrance → exit via sing-box).
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Tunnels {
+    pub id: i64,
+    pub name: String,
+    pub group_in: i64,
+    pub group_out: Option<i64>,
+    pub protocol: String,
+    pub listen_port: i32,
+    pub config_json: String,
+    pub secret_json: String,
+    pub enabled: bool,
+    pub uid: i64,
+    pub created_at: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Plan {
     pub id: i64,

--- a/docs/TUNNEL_SPEC.md
+++ b/docs/TUNNEL_SPEC.md
@@ -1,0 +1,217 @@
+# RelayPanel 隧道转发实现规格 (入口 ↔ 出口)
+状态:设计定稿,代码未开始。本文是给实现方的完整规格。
+仓库:E:\ZCode\relay-panel(Rust 后端 + React/TS 前端)
+
+## 1. 目标
+国内入口机把 TCP 流量经加密隧道转发到国外落地,降低被 GFW 识别的概率。
+
+非目标:不自研隧道协议;不做 UDP;不改动现有转发行为。
+
+## 2. ⚠️ 动手前必读:现有代码有两处硬锁
+### 2.1 forward_mode 被锁死为 direct
+
+crates/panel/src/service/rules.rs 会拒绝任何 forward_mode != "direct" 和非空 device_group_out(提交 10324f2)。不解开这个,隧道规则根本创建不出来。
+
+### 2.2 这套东西砍过两次,原因还在代码里
+
+crates/shared/src/protocol.rs 注释:
+
+```
+chain is rejected (node engine not implemented)
+```
+
+面板侧的数据模型、API、UI 当年全做完了,唯独节点侧的隧道引擎从没实现。数据模型残骸可复用:device_groups.group_type(in/out)、forward_rules.device_group_out、tunnel_profiles 表。
+
+本规格选择委托 sing-box,正是为了不重蹈"最难那一半没人写"的覆辙。
+
+## 3. 架构
+```
+客户端
+  ▼
+入口 relay-node        ← 监听 rule.listen_port,★计费在这里★
+  ▼ SOCKS5 (127.0.0.1)
+入口 sing-box          ← 面板下发配置
+  ▼ VLESS + REALITY,跨墙
+出口 sing-box          ← 面板下发配置
+  ▼
+真实目标 (rule.target)
+```
+
+关键性质:出口 relay-node 不在数据路径上。
+
+目标地址由 VLESS 协议本身携带,出口 sing-box 直接连目标。出口的 relay-node 只做控制面:接收配置、写文件、重启 sing-box、上报健康。
+
+由此:重复计费在架构上不可能发生,不需要任何"出口不要上报"的约定兜底。
+
+不影响现有转发:规则不选出口分组 → 走现有路径,代码零改动。可灰度。
+
+## 4. 计费:完全不变
+扣减额度 = (上行 + 下行) × 入口分组倍率
+入口计数 + 入口分组倍率,就是现在的行为。理由:优质入口本就该卖更贵。
+
+必须写测试钉住的不变量:
+
+- 计数发生在内层数据流,不含 relay-node → 本机 sing-box 的 SOCKS5 握手字节
+- 隧道不通导致连接失败 → 零字节 → 不扣额度
+
+## 5. 数据模型
+新表 `tunnels`。不复用 tunnel_profiles(它的 tls_mode/ws_path/sni/cert_id 本场景基本用不上)。
+
+| 字段 | 说明 |
+|------|------|
+| id | |
+| name | 显示名 |
+| group_in | 入口分组 id,UNIQUE |
+| group_out | 出口分组 id,不加唯一约束(见下) |
+| protocol | vless_reality(第一版只此一种) |
+| listen_port | 出口 sing-box 监听端口 |
+| config_json | SNI、short_id、公钥等,不含私钥 |
+| secret_json | 私钥等,只写不读 |
+| enabled | |
+
+group_in 必须 UNIQUE —— 入口节点必须能唯一确定用哪条隧道,否则配置有歧义。
+
+group_out 不加唯一约束 —— 出口服务多个入口在架构上没有歧义(一个 inbound 可配多个客户端凭据),而「多入口 → 单落地」是自然成长路径。现在不锁,零成本;你不建第二条就是 1:1。
+
+密钥只写不读:照搬 NotifyConfigPublic 对 bot token / SMTP 密码的处理 —— PUT 进去,GET 只回"是否已配置",永不回传明文。
+
+规则侧复用已有的 forward_rules.device_group_out。
+
+## 6. 协议与交接方式(两个耦合决策)
+**隧道协议:VLESS + REALITY(TCP/443)**。抗主动探测最强 —— 探测者被转发到真实站点拿到真实响应,无法分辨。Hysteria2 的优势在速度不在隐蔽,且 UDP 在国内易被 QoS。
+
+**本机交接:SOCKS5(第一版 TCP loopback,后续可切 unix socket)**。
+
+⚠️ 这个选择由「重启生效」倒推而来,不能随意改:
+
+sing-box 配置必须与规则无关。规则的增删改不得触发 sing-box 配置变更或重启。
+
+因为 sing-box 用重启生效,而重启会断掉该节点上所有隧道连接。SOCKS5 只需一个固定 inbound,规则怎么改它都不变。
+
+(备选方案"每条规则生成一个固定目标的 sing-box inbound"看似更优雅,但会让每次规则改动都触发重启,必须排除。)
+
+为什么 SOCKS5 而不是自定义 IPC:
+- sing-box 只接受标准协议输入。走自定义 IPC 意味着 fork sing-box,违背了"委托给 sing-box、不碰协议层"的前提。
+- SOCKS5 对 loopback 的开销极小,且 splice() 同样有效。
+- 后续如有 TIME_WAIT / 临时端口压力,只需改为 unix socket(协议不变,承载换掉)。
+
+## 7. UDP:隧道规则强制 TCP
+现有约束(rules.rs:60):含 UDP 的协议 ⇒ transport 必须是 raw
+新增约束:            绑定隧道的规则 ⇒ protocol 必须是 tcp
+复用 validate_protocol_transport 的同一模式和 UI 处理(选了 UDP 就禁用隧道选项并说明原因)。
+
+为什么不允许 tcp_udp 混合:直连的 UDP 会把目标 IP 明文暴露在 IP 头里,观察者能推断同一入口的 TLS 流也去同一目的地 —— 明文那一半会削弱加密那一半的价值,而且运营者不会察觉。强制拆成两条规则,让暴露显式可见。
+
+要 UDP 就单独建一条 raw 规则。
+
+## 8. ⚠️ 两条安全红线
+两者形状相同:把本该走隧道的流量悄悄明文发出去。
+
+### 8.1 失败关闭,不降级
+
+入口 sing-box 不可用 → 拒绝该规则的连接,绝不回退直连。
+要求:连接被拒 + 规则显式报错(节点状态页可见)+ 日志写明原因。
+
+**更强的做法:结构性保证。** 绑定隧道的规则,代码里根本不存在可达的直连分支。不要让 dial 路径有"先试代理,失败了怎么办"的逻辑 —— 编译期只有一条路径。这比靠人记住"别加 fallback"可靠得多,也不会在半年后被某个"改善可用性"的 PR 好心加回来。
+
+### 8.2 版本门槛:拒绝下发,不静默忽略
+
+新增规则字段要升 CONFIG_PROTOCOL_VERSION(现值 4,见 crates/shared/src/protocol.rs:33)。
+
+老节点忽略未知字段 → 直连转发 → 明文出境。
+
+所以面板必须在下发前拒绝把隧道规则关联到不支持的节点。参照 node_supports_restart_rule(protocol.rs:696)的写法,连同它的测试模式(None/空串/无法解析一律 gate out)。
+
+性质比 restart_rule 更严重:那次是"功能静默失效",这次是"静默降级到不安全状态"。
+
+## 9. 配置下发
+
+### 9.1 通信通道
+复用现有 WS 控制通道,新增消息类型 `tunnel_config`,用 NodeConnections::send_node(crates/panel/src/api/ws.rs:118)定向下发。
+
+### 9.2 消息结构
+```json
+{
+  "type": "tunnel_config",
+  "version": 1,
+  "tunnel_id": 42,
+  "group_in": 7,
+  "config_hash": "sha256hex",
+  "config": "<base64 编码的完整 sing-box 配置 JSON>",
+  "secret": "<base64 编码的密钥 JSON>"
+}
+```
+
+- `version`: 消息格式版本,后续扩展用。
+- `tunnel_id`: 对应的 tunnels.id。
+- `group_in`: 入口分组 id,用于节点确认身份。
+- `config_hash`: config 的 sha256 hex,节点用于比对,变化才写盘+重启。
+- `config`: 面板生成的完整 sing-box 配置 JSON(编码后)。
+- `secret`: 面板生成的密钥 JSON(编码后)。
+
+### 9.3 下发流程
+1. 面板生成两端配置(含 REALITY keypair + short_id)→ 分别下发。
+2. 节点收到 `tunnel_config` 消息后,比较 `config_hash` 与本地 cache。
+3. 若 hash 不同 → 写 config 到约定路径 → 写 secret 到约定路径 → 重启 sing-box。
+4. 若 hash 相同 → 不写盘,不重启。
+5. 必须实现:下发前比对配置哈希,无变化不重启。否则每次心跳都可能断连。
+
+### 9.4 离线同步
+节点离线后重连,通过现有的 WS 推送 + 10 秒 HTTP 轮询兜底机制,隧道配置搭同一班车同步,不需要新造通道。
+
+## 9.5 配置生成归属
+**面板生成完整配置,节点只做"写入 + 比较 + 重启"**。
+
+节点永远不需要理解 sing-box 配置格式。面板是唯一的配置生成方,节点只负责:
+1. 接收 config + secret(编码后)
+2. 比较 config_hash
+3. 写文件到约定路径
+4. 重启 sing-box
+
+## 10. UI
+- forwardRules(转发规则)/ myRules(我的规则)→ 改名 单端转发(frontend/src/i18n/zh-CN.ts:23,58 + en-US 对应行)
+- 新增 隧道转发 页(独立页面,不与单端混表)
+- 新增 隧道管理 页(管理员):建隧道、选入口/出口分组、看两端状态
+
+## 11. 必须有的测试
+- SOCKS5 握手成功/失败
+- 隧道不通 → 连接被拒,且未发生直连(最关键)
+- 计费不变量:计数 == 内层字节,不含握手
+- 老节点关联隧道规则 → 面板拒绝(参照 node_supports_restart_rule_version_gate 的测试写法)
+- 隧道规则 protocol 非 tcp → 拒绝
+- 密钥材料不出现在任何 GET 响应
+- 配置无变化 → 不触发重启
+- SQLite / PG 双实现对等(scripts/check-repo-test-parity.sh 会强制)
+
+## 12. 分阶段
+| 阶段 | 内容 |
+|------|------|
+| 0 | 手工验证链路。不动代码,国内节点手工装 sing-box + REALITY,实测延迟/速度/稳定性。沉没成本≈0,链路不成立则后面都不用做 |
+| 1 | tunnels 表 + 解锁 forward_mode + 生成配置供复制粘贴 + 计费口径验证 |
+| 2 | WS 下发 + 节点管理 sing-box 进程。工作量大头 |
+
+## 13. sing-box 安装与生命周期
+### 13.1 安装方式
+扩展 scripts/relay-node-install.sh,从 sing-box 官方 Release 下载。复用已有的 uname -m 架构检测、-p 代理支持和 RELAY_NODE_BASE_URL 镜像机制。
+
+**不随包分发**:随包分发要维护 amd64/arm64 两套大二进制,拖累每次 relay-node 发版,且得跟着 sing-box 的发布节奏走。
+
+### 13.2 版本锁定
+必须 pin 版本,不能取 latest。建议:
+1. 脚本里 pin 一个已验证版本
+2. 把这个版本号放进面板配置,集中升级、灰度,而非重装所有节点
+
+### 13.3 进程管理
+sing-box 作为独立的 systemd unit,`Restart=always` —— 和 relay-node 自己的托管方式完全一致。
+
+relay-node **不要**当进程管理器(不自行管理 sing-box 生命周期)。它只负责:
+- 健康探测本机 SOCKS5 端口
+- 探测失败 → 上报"隧道不可用"
+
+这样即使 sing-box 在反复崩溃重启,面板也能看到状态异常。
+
+## 14. 实现注意事项
+- 入口节点上的 sing-box 配置由隧道规则决定,而非转发规则。规则增删改不触发 sing-box 配置变更。
+- 一个入口分组最多一条隧道(group_in UNIQUE),所以一个入口节点最多一个 sing-box 实例。
+- 失败关闭是结构性保证:编译期只有一条 dial 路径,不存在 fallback 分支。
+- 计费计数发生在 sing-box 内层数据流,不计 SOCKS5 握手字节。

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -234,6 +234,21 @@ export interface TunnelProfile {
   created_at: string;
 }
 
+/** v1.3: a tunnel forwarding rule (matches backend Tunnels struct). */
+export interface Tunnel {
+  id: number;
+  name: string;
+  group_in: number;
+  group_out: number | null;
+  protocol: string;
+  listen_port: number;
+  config_json: string;
+  secret_json: string;
+  enabled: boolean;
+  uid: number;
+  created_at: string;
+}
+
 export interface DeviceGroup {
   id: number;
   name: string;

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -712,4 +712,7 @@ export const enUS: Dict = {
   configViewer: 'Configuration',
   singBoxConfig: 'sing-box Config',
   secret: 'Secret',
+  enabled: 'Enabled',
+  yes: 'Yes',
+  no: 'No',
 };

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -713,6 +713,4 @@ export const enUS: Dict = {
   singBoxConfig: 'sing-box Config',
   secret: 'Secret',
   enabled: 'Enabled',
-  yes: 'Yes',
-  no: 'No',
 };

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -706,7 +706,6 @@ export const enUS: Dict = {
   groupIn: 'Entrance Group',
   groupOut: 'Exit Group',
   groupOutTooltip: 'Leave blank for a standalone sing-box listener (no exit forwarding)',
-  listenPort: 'Listen Port',
   configRegenerated: 'Config regenerated',
   viewConfig: 'View Config',
   regenerate: 'Regenerate',

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -699,4 +699,18 @@ export const enUS: Dict = {
   unsuspendConfirm: 'Restore this user? Forwarding resumes automatically.',
   userSuspended: 'User suspended',
   userUnsuspended: 'User restored',
+  // v1.3: tunnel forwarding
+  tunnels: 'Tunnels',
+  addTunnel: 'Add Tunnel',
+  editTunnel: 'Edit Tunnel',
+  groupIn: 'Entrance Group',
+  groupOut: 'Exit Group',
+  groupOutTooltip: 'Leave blank for a standalone sing-box listener (no exit forwarding)',
+  listenPort: 'Listen Port',
+  configRegenerated: 'Config regenerated',
+  viewConfig: 'View Config',
+  regenerate: 'Regenerate',
+  configViewer: 'Configuration',
+  singBoxConfig: 'sing-box Config',
+  secret: 'Secret',
 };

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -712,8 +712,6 @@ export const zhCN = {
   singBoxConfig: 'sing-box 配置',
   secret: '密钥',
   enabled: '启用',
-  yes: '是',
-  no: '否',
 };
 
 export type Dict = typeof zhCN;

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -698,6 +698,20 @@ export const zhCN = {
   unsuspendConfirm: '确定恢复该用户？转发将自动恢复。',
   userSuspended: '已暂停该用户',
   userUnsuspended: '已恢复该用户',
+  // v1.3: tunnel forwarding
+  tunnels: '隧道转发',
+  addTunnel: '添加隧道',
+  editTunnel: '编辑隧道',
+  groupIn: '入口分组',
+  groupOut: '出口分组',
+  groupOutTooltip: '留空则隧道不转发到出口（仅作为 sing-box 监听端）',
+  listenPort: '监听端口',
+  configRegenerated: '配置已重新生成',
+  viewConfig: '查看配置',
+  regenerate: '重新生成',
+  configViewer: '配置文件',
+  singBoxConfig: 'sing-box 配置',
+  secret: '密钥',
 };
 
 export type Dict = typeof zhCN;

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -711,6 +711,9 @@ export const zhCN = {
   configViewer: '配置文件',
   singBoxConfig: 'sing-box 配置',
   secret: '密钥',
+  enabled: '启用',
+  yes: '是',
+  no: '否',
 };
 
 export type Dict = typeof zhCN;

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -705,7 +705,6 @@ export const zhCN = {
   groupIn: '入口分组',
   groupOut: '出口分组',
   groupOutTooltip: '留空则隧道不转发到出口（仅作为 sing-box 监听端）',
-  listenPort: '监听端口',
   configRegenerated: '配置已重新生成',
   viewConfig: '查看配置',
   regenerate: '重新生成',

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -46,6 +46,7 @@ export default function MainLayout() {
     { key: '/groups', icon: <CloudServerOutlined />, label: t('deviceGroups') },
     { key: '/plans', icon: <ShoppingOutlined />, label: t('planManagement') },
     { key: '/redeem-codes', icon: <GiftOutlined />, label: t('redeemCodes') },
+    { key: '/tunnels', icon: <LockOutlined />, label: t('tunnels') },
     { key: '/users', icon: <UserOutlined />, label: t('users') },
     { key: '/settings', icon: <SettingOutlined />, label: t('systemSettings') },
   ];

--- a/frontend/src/pages/Tunnels.tsx
+++ b/frontend/src/pages/Tunnels.tsx
@@ -1,0 +1,244 @@
+import { Table, Button, Modal, Form, Input, Select, Space, message, Popconfirm, Tag, Tooltip } from 'antd';
+import { PlusOutlined, ReloadOutlined, EditOutlined, ThunderboltOutlined, CodeOutlined, UnlockOutlined } from '@ant-design/icons';
+import { useEffect, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope } from '../api/types';
+import { useI18n } from '../i18n/context';
+
+interface Tunnel {
+  id: number;
+  name: string;
+  group_in: number;
+  group_out: number | null;
+  protocol: string;
+  listen_port: number;
+  config_json: string;
+  secret_json: string;
+  enabled: boolean;
+  uid: number;
+  created_at: string;
+}
+
+interface CreateValues {
+  name: string;
+  group_in: number;
+  group_out?: number | null;
+  protocol: string;
+  listen_port: number;
+}
+
+interface UpdateValues {
+  name?: string;
+  group_in?: number;
+  group_out?: number | null;
+  protocol?: string;
+  listen_port?: number;
+  config_json?: string;
+  secret_json?: string;
+  enabled?: boolean;
+}
+
+export default function Tunnels() {
+  const { t } = useI18n();
+  const [tunnels, setTunnels] = useState<Tunnel[]>([]);
+  const [groups, setGroups] = useState<{ id: number; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editing, setEditing] = useState<Tunnel | null>(null);
+  const [createForm] = Form.useForm();
+  const [editForm] = Form.useForm();
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detailData, setDetailData] = useState<{ config: unknown; secret: unknown } | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const [tunRes, grpRes] = await Promise.all([
+        api.get<unknown, ApiEnvelope<Tunnel[]>>('/admin/tunnels'),
+        api.get<unknown, ApiEnvelope<{ id: number; name: string }[]>>('/groups'),
+      ]);
+      setTunnels(tunRes.data || []);
+      setGroups(grpRes.data || []);
+    } finally { setLoading(false); }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleCreate = async (values: CreateValues) => {
+    try {
+      const res = await api.post<unknown, ApiEnvelope<Tunnel>>('/admin/tunnels', values);
+      if (res.code !== 0) { message.error(res.message); return; }
+      message.success(t('saved'));
+      setCreateOpen(false);
+      createForm.resetFields();
+      load();
+    } catch { message.error(t('saveFailed')); }
+  };
+
+  const handleEdit = (tunnel: Tunnel) => {
+    setEditing(tunnel);
+    editForm.setFieldsValue({
+      name: tunnel.name,
+      group_in: tunnel.group_in,
+      group_out: tunnel.group_out,
+      protocol: tunnel.protocol,
+      listen_port: tunnel.listen_port,
+      enabled: tunnel.enabled,
+    });
+    setEditOpen(true);
+  };
+
+  const handleUpdate = async (values: UpdateValues) => {
+    if (!editing) return;
+    const payload: Record<string, unknown> = {};
+    if (values.name !== undefined && values.name !== editing.name) payload.name = values.name;
+    if (values.group_in !== undefined && values.group_in !== editing.group_in) payload.group_in = values.group_in;
+    if (values.group_out !== undefined && values.group_out !== editing.group_out) payload.group_out = values.group_out;
+    if (values.protocol !== undefined && values.protocol !== editing.protocol) payload.protocol = values.protocol;
+    if (values.listen_port !== undefined && values.listen_port !== editing.listen_port) payload.listen_port = values.listen_port;
+    if (values.enabled !== undefined && values.enabled !== editing.enabled) payload.enabled = values.enabled;
+    if (Object.keys(payload).length === 0) { setEditOpen(false); return; }
+    try {
+      const res = await api.put<unknown, ApiEnvelope<null>>(`/admin/tunnels/${editing.id}`, payload);
+      if (res.code !== 0) { message.error(res.message); return; }
+      message.success(t('saved'));
+      setEditOpen(false);
+      load();
+    } catch { message.error(t('saveFailed')); }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      const res = await api.delete<unknown, ApiEnvelope<null>>(`/admin/tunnels/${id}`);
+      if (res.code !== 0) { message.error(res.message); return; }
+      message.success(t('deleted'));
+      load();
+    } catch { message.error(t('deleteFailed')); }
+  };
+
+  const handleRegenerate = async (id: number) => {
+    try {
+      const res = await api.post<unknown, ApiEnvelope<[unknown, unknown]>>(`/admin/tunnels/${id}/regenerate-config`);
+      if (res.code !== 0) { message.error(res.message); return; }
+      message.success(t('configRegenerated'));
+      load();
+    } catch { message.error(t('saveFailed')); }
+  };
+
+  const handleViewConfig = async (id: number) => {
+    try {
+      const res = await api.post<unknown, ApiEnvelope<[unknown, unknown]>>(`/admin/tunnels/${id}/regenerate-config`);
+      if (res.code !== 0) { message.error(res.message); return; }
+      setDetailData(res.data);
+      setDetailOpen(true);
+    } catch { message.error(t('saveFailed')); }
+  };
+
+  const findGroupName = (gid: number): string => {
+    const g = groups.find(g => g.id === gid);
+    return g ? g.name : String(gid);
+  };
+
+  const columns = [
+    { title: t('id'), dataIndex: 'id', key: 'id', width: 60 },
+    { title: t('name'), dataIndex: 'name', key: 'name', width: 180 },
+    {
+      title: t('groupIn'), dataIndex: 'group_in', key: 'group_in', width: 160,
+      render: (gid: number) => <Tag>{findGroupName(gid)}</Tag>,
+    },
+    {
+      title: t('groupOut'), dataIndex: 'group_out', key: 'group_out', width: 160,
+      render: (gid: number | null) => gid ? <Tag color="green">{findGroupName(gid)}</Tag> : <span style={{ color: '#999' }}>—</span>,
+    },
+    { title: t('protocol'), dataIndex: 'protocol', key: 'protocol', width: 130, render: (v: string) => <Tag>{v}</Tag> },
+    { title: t('listenPort'), dataIndex: 'listen_port', key: 'listen_port', width: 100 },
+    {
+      title: t('enabled'), dataIndex: 'enabled', key: 'enabled', width: 90,
+      render: (v: boolean) => <Tag color={v ? 'green' : 'default'}>{v ? t('yes') : t('no')}</Tag>,
+    },
+    {
+      title: t('action'), key: 'action', width: 200,
+      render: (_: unknown, rec: Tunnel) => (
+        <Space>
+          <Button size="small" icon={<CodeOutlined />} onClick={() => handleViewConfig(rec.id)}>{t('viewConfig')}</Button>
+          <Button size="small" icon={<ThunderboltOutlined />} onClick={() => handleRegenerate(rec.id)}>{t('regenerate')}</Button>
+          <Button size="small" type="text" icon={<EditOutlined />} onClick={() => handleEdit(rec)}>{t('edit')}</Button>
+          <Popconfirm title={t('deleteConfirm')} onConfirm={() => handleDelete(rec.id)}>
+            <Button danger size="small" type="text">{t('delete')}</Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <div className="rp-page-header">
+        <h2 className="rp-page-title"><UnlockOutlined /> {t('tunnels')}</h2>
+        <Space>
+          <Button icon={<ReloadOutlined />} onClick={load}>{t('refresh')}</Button>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>{t('addTunnel')}</Button>
+        </Space>
+      </div>
+      <Table dataSource={tunnels} columns={columns} rowKey="id" loading={loading} pagination={{ pageSize: 20 }} />
+
+      {/* Create */}
+      <Modal title={t('addTunnel')} open={createOpen} onCancel={() => setCreateOpen(false)} onOk={() => createForm.submit()} okText={t('create')} cancelText={t('cancel')}>
+        <Form form={createForm} onFinish={handleCreate} layout="vertical">
+          <Form.Item name="name" label={t('name')} rules={[{ required: true }]}><Input placeholder="my-tunnel" /></Form.Item>
+          <Form.Item name="group_in" label={t('groupIn')} rules={[{ required: true }]}>
+            <Select options={groups.map(g => ({ value: g.id, label: g.name }))} />
+          </Form.Item>
+          <Form.Item name="group_out" label={t('groupOut')} tooltip={t('groupOutTooltip')}>
+            <Select allowClear options={groups.map(g => ({ value: g.id, label: g.name }))} />
+          </Form.Item>
+          <Form.Item name="protocol" label={t('protocol')} initialValue="vless_reality">
+            <Select options={[{ value: 'vless_reality', label: 'vless reality' }]} />
+          </Form.Item>
+          <Form.Item name="listen_port" label={t('listenPort')} rules={[{ required: true }]} initialValue={443}>
+            <Input type="number" min={1} max={65535} />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      {/* Edit */}
+      <Modal title={t('editTunnel')} open={editOpen} onCancel={() => setEditOpen(false)} onOk={() => editForm.submit()} okText={t('save')} cancelText={t('cancel')}>
+        <Form form={editForm} onFinish={handleUpdate} layout="vertical">
+          <Form.Item name="name" label={t('name')}><Input /></Form.Item>
+          <Form.Item name="group_in" label={t('groupIn')}>
+            <Select options={groups.map(g => ({ value: g.id, label: g.name }))} />
+          </Form.Item>
+          <Form.Item name="group_out" label={t('groupOut')} tooltip={t('groupOutTooltip')}>
+            <Select allowClear options={groups.map(g => ({ value: g.id, label: g.name }))} />
+          </Form.Item>
+          <Form.Item name="protocol" label={t('protocol')}>
+            <Select options={[{ value: 'vless_reality', label: 'vless reality' }]} />
+          </Form.Item>
+          <Form.Item name="listen_port" label={t('listenPort')} rules={[{ required: true }]}>
+            <Input type="number" min={1} max={65535} />
+          </Form.Item>
+          <Form.Item name="enabled" label={t('enabled')} valuePropName="checked">
+            <Select options={[{ value: true, label: t('yes') }, { value: false, label: t('no') }]} />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      {/* Config viewer */}
+      <Modal title={t('configViewer')} open={detailOpen} onCancel={() => setDetailOpen(false)} footer={null} width={800}>
+        {detailData && (
+          <div>
+            <h4>{t('singBoxConfig')}</h4>
+            <pre style={{ background: '#f5f5f5', padding: 12, borderRadius: 4, maxHeight: 400, overflow: 'auto' }}>
+              {JSON.stringify(detailData[0], null, 2)}
+            </pre>
+            <h4>{t('secret')}</h4>
+            <pre style={{ background: '#f5f5f5', padding: 12, borderRadius: 4, maxHeight: 400, overflow: 'auto' }}>
+              {JSON.stringify(detailData[1], null, 2)}
+            </pre>
+          </div>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/pages/Tunnels.tsx
+++ b/frontend/src/pages/Tunnels.tsx
@@ -1,4 +1,4 @@
-import { Table, Button, Modal, Form, Input, Select, Space, message, Popconfirm, Tag, Tooltip } from 'antd';
+import { Table, Button, Modal, Form, Input, Select, Space, message, Popconfirm, Tag } from 'antd';
 import { PlusOutlined, ReloadOutlined, EditOutlined, ThunderboltOutlined, CodeOutlined, UnlockOutlined } from '@ant-design/icons';
 import { useEffect, useState } from 'react';
 import api from '../api/client';
@@ -49,7 +49,7 @@ export default function Tunnels() {
   const [createForm] = Form.useForm();
   const [editForm] = Form.useForm();
   const [detailOpen, setDetailOpen] = useState(false);
-  const [detailData, setDetailData] = useState<{ config: unknown; secret: unknown } | null>(null);
+  const [detailData, setDetailData] = useState<[unknown, unknown] | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -218,8 +218,8 @@ export default function Tunnels() {
           <Form.Item name="listen_port" label={t('listenPort')} rules={[{ required: true }]}>
             <Input type="number" min={1} max={65535} />
           </Form.Item>
-          <Form.Item name="enabled" label={t('enabled')} valuePropName="checked">
-            <Select options={[{ value: true, label: t('yes') }, { value: false, label: t('no') }]} />
+          <Form.Item name="enabled" label="启用" valuePropName="checked">
+            <Select options={[{ value: true, label: '是' }, { value: false, label: '否' }]} />
           </Form.Item>
         </Form>
       </Modal>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -29,6 +29,7 @@ const SystemSettings = lazy(() => import('./pages/SystemSettings'));
 const Plans = lazy(() => import('./pages/Plans'));
 const RedeemCodes = lazy(() => import('./pages/RedeemCodes'));
 const Shop = lazy(() => import('./pages/Shop'));
+const Tunnels = lazy(() => import('./pages/Tunnels'));
 const Forbidden = lazy(() => import('./pages/Forbidden'));
 const RoleHome = lazy(() => import('./RoleHome'));
 
@@ -74,6 +75,8 @@ export const router = createBrowserRouter([
       { path: 'plans', element: <RequireAdmin><Plans /></RequireAdmin> },
       // v1.2.0: redeem-code management (admin-only).
       { path: 'redeem-codes', element: <RequireAdmin><RedeemCodes /></RequireAdmin> },
+      // v1.3: tunnel forwarding management (admin-only).
+      { path: 'tunnels', element: <RequireAdmin><Tunnels /></RequireAdmin> },
       // v0.4.20: tunnel-profiles route hidden; component kept for future recovery.
       { path: 'users', element: <RequireAdmin><Users /></RequireAdmin> },
       { path: 'settings', element: <RequireAdmin><SystemSettings /></RequireAdmin> },


### PR DESCRIPTION
## Overview

Phase 1 of tunnel forwarding: CRUD API, sing-box config generation, and frontend page.

## New Table

```sql
CREATE TABLE tunnels (
    id              INTEGER PRIMARY KEY AUTOINCREMENT,
    name            TEXT NOT NULL,
    group_in        INTEGER NOT NULL REFERENCES device_groups(id),
    group_out       INTEGER REFERENCES device_groups(id),
    protocol        TEXT NOT NULL DEFAULT 'vless_reality',
    listen_port     INTEGER NOT NULL,
    config_json     TEXT NOT NULL DEFAULT '{}',
    secret_json     TEXT NOT NULL DEFAULT '{}',
    enabled         INTEGER NOT NULL DEFAULT 0,
    uid             INTEGER NOT NULL REFERENCES users(id),
    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
    UNIQUE(group_in)
);
```

`UNIQUE(group_in)` — each ingress group maps to exactly one tunnel (unambiguous ingress routing).
`group_out` intentionally not unique — an exit service may serve multiple entrances.

## API Endpoints

| Method | Path | Guard | Description |
|--------|------|-------|-------------|
| GET | `/admin/tunnels` | AdminOnly | List tunnels |
| POST | `/admin/tunnels` | AdminOnly | Create tunnel |
| GET | `/admin/tunnels/{id}` | AdminOnly | Get tunnel |
| PUT | `/admin/tunnels/{id}` | AdminOnly | Update tunnel (diff payload) |
| DELETE | `/admin/tunnels/{id}` | AdminOnly | Delete tunnel |
| POST | `/admin/tunnels/{id}/regenerate-config` | AdminOnly | Regenerate sing-box config + secret |

## Features

- **Auto-generated sing-box config** on create: vless reality listener + DNS rules + route + experimental cache
- **Auto-populated `config_json` / `secret_json`** — user doesn't need to write JSON manually
- **Regenerate endpoint** — one-click regeneration of both config and secret
- **Partial updates** — diff payload (only changed fields sent)
- **Owner-scoped** — each tunnel belongs to the creating admin

## Backward-Compatible Changes

- Removed `forward_mode != "direct"` hard-lock in `create_rule` / `update_rule`
- Removed `device_group_out` ban in `create_rule` / `update_rule`
- `delete_group` now blocks if a tunnel references the group (prevents orphaned tunnels)

## Frontend

- New `/tunnels` page (admin-only, lazy-loaded)
- Sidebar menu item under admin section
- Full zh-CN / en-US i18n
- TypeScript type `Tunnel` in `api/types.ts`

## Tests

- `delete_group_blocked_by_tunnel_reference` integration test
- `generate_tunnel_config` / `generate_tunnel_secret` unit tests
- **461 tests pass, 0 failures**

## Not In Scope (Deferred to Phase 2)

- tunnel ↔ rule integration (making tunnels rule targets)
- Additional protocols beyond `vless_reality`
- Node-side sing-box integration