### PR TITLE
feat(rules): 规则页增加搜索(名称 / 端口 / 目标)

### DIFF
--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -89,6 +89,7 @@ export const enUS: Dict = {
 
   // Rules page
   addRule: 'Add Rule',
+  searchRulePlaceholder: 'Search name / port / target',
   listenIp: 'Listen IP',
   listenPort: 'Listen Port',
   notConfigured: 'Not configured',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -88,6 +88,7 @@ export const zhCN = {
 
   // Rules page
   addRule: '新增规则',
+  searchRulePlaceholder: '搜索名称 / 端口 / 目标',
   listenIp: '监听 IP',
   listenPort: '监听端口',
   notConfigured: '未配置',

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -1,6 +1,6 @@
 import { Table, Button, Modal, Form, Input, InputNumber, Select, Space, message, Popconfirm, Tag, Alert, Typography, Dropdown, Switch, Tabs, Spin, Tooltip } from 'antd';
 import type { MenuProps } from 'antd';
-import { PlusOutlined, ReloadOutlined, EditOutlined, ApiOutlined, CopyOutlined, DownloadOutlined, UploadOutlined, PauseCircleOutlined, PlayCircleOutlined, DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, MedicineBoxOutlined, QuestionCircleOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { PlusOutlined, ReloadOutlined, EditOutlined, ApiOutlined, CopyOutlined, DownloadOutlined, UploadOutlined, PauseCircleOutlined, PlayCircleOutlined, DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, MedicineBoxOutlined, QuestionCircleOutlined, ThunderboltOutlined, SearchOutlined } from '@ant-design/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import api from '../api/client';
@@ -90,6 +90,9 @@ export default function Rules() {
   // v0.4.9: group-name column + filter. selectedGroup === null means "all".
   // (Explicit null, not !selectedGroup, so a future id of 0 wouldn't be falsy.)
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
+  // Client-side filter over the already-loaded rules — /rules returns the whole
+  // (owner-scoped) set, so searching needs no round-trip.
+  const [ruleSearch, setRuleSearch] = useState('');
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
 
   const load = useCallback(async () => {
@@ -188,12 +191,26 @@ export default function Rules() {
     }
     return m;
   }, [groups, sharedGroups]);
-  // The rules actually shown: filtered by the selected inbound group, or all
-  // when selectedGroup === null. Computed once so the table + count stay in sync.
-  const visibleRules = useMemo(
-    () => rules.filter(r => selectedGroup === null || r.device_group_in === selectedGroup),
-    [rules, selectedGroup],
-  );
+  // The rules actually shown: the group filter and the search box compose, so
+  // "this group, port 443" works. Computed once so the table + count stay in
+  // sync.
+  //
+  // Search matches name, listen port and target address. Targets are read via
+  // ruleTargets() rather than target_addr alone: a multi-target rule keeps the
+  // first target in that column, and searching for a backup target should still
+  // find the rule.
+  const visibleRules = useMemo(() => {
+    const q = ruleSearch.trim().toLowerCase();
+    return rules.filter(r => {
+      if (selectedGroup !== null && r.device_group_in !== selectedGroup) return false;
+      if (!q) return true;
+      if (r.name.toLowerCase().includes(q)) return true;
+      if (String(r.listen_port).includes(q)) return true;
+      return ruleTargets(r).some(
+        tgt => tgt.host.toLowerCase().includes(q) || String(tgt.port).includes(q),
+      );
+    });
+  }, [rules, selectedGroup, ruleSearch]);
 
   const handleCreate = async (values: {
     name: string; listen_port: number | null; protocol: string;
@@ -864,7 +881,15 @@ const IMPORT_DEFAULTS = {
     <>
       <div className="rp-page-header">
         <h2 className="rp-page-title"><ApiOutlined /> {t('forwardRules')}</h2>
-        <Space>
+        <Space wrap>
+          <Input
+            allowClear
+            prefix={<SearchOutlined />}
+            placeholder={t('searchRulePlaceholder')}
+            value={ruleSearch}
+            onChange={(e) => { setRuleSearch(e.target.value); setSelectedRowKeys([]); }}
+            style={{ width: 220 }}
+          />
           {/* v0.4.9: filter by inbound group. Only groups that actually have
               rules are offered, so the list stays short for large fleets. */}
           <Select


### PR DESCRIPTION
## 问题

规则页只有分组筛选。规则数量通常比用户多得多,找一条只能靠滚 —— 用户页刚补了搜索,而规则页才是更长的那个列表。

## 改动

工具栏最左加搜索框,匹配**名称 / 监听端口 / 目标**。

**目标用 `ruleTargets()` 读取,而不是只看 `target_addr`** —— 多目标规则在列表里只显示第一个目标,但搜备用目标时也应该能找到这条规则。

**搜索和分组筛选在同一个 filter 里叠加**,所以「这个分组 + 端口 443」是收窄而不是互相覆盖。纯前端过滤(`/rules` 本来就返回该用户可见的全量),输入即出结果,无请求。

## 验证

浏览器实测 4 条规则:

| 查询 | 结果 |
|---|---|
| `beta`(名称) | 1 条 ✓ |
| `40003`(端口) | 1 条 ✓ |
| `1.1.1.1`(目标) | 1 条 ✓ |
| `zzzz` | 0 条 ✓ |
| 清空 | 4 条全回 ✓ |

工具栏原有控件(分组筛选 / 刷新 / 导入导出 / 新增规则)位置未受影响。前端 180 用例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)