### PR TITLE
feat(site): 站点自定义(名称/公告/客服)+ 个人中心账目记录

### DIFF
--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -908,6 +908,55 @@ mod tests {
         }
     }
 
+    /// v1.3.0: the public site endpoint is reachable with NO token, so it must
+    /// carry branding only. The announcement and support contact were kept off
+    /// the login page deliberately; serving them to any unauthenticated caller
+    /// would make that choice meaningless.
+    #[tokio::test]
+    async fn public_site_endpoint_exposes_branding_but_not_the_announcement() {
+        let (state, _pool) = test_state().await;
+        let secret_notice = "内部维护通知-勿外传";
+        let Json(saved) = crate::api::site::update_site_settings(
+            AdminOnly { user_id: 1 },
+            State(state.clone()),
+            Json(crate::api::site::UpdateSiteRequest {
+                site_name: "我的中转".into(),
+                subtitle: "私有部署".into(),
+                announcement: secret_notice.into(),
+                contact: "tg:@someone".into(),
+            }),
+        )
+        .await;
+        assert_eq!(saved.code, 0, "save must succeed: {}", saved.message);
+
+        // The public view: no AuthUser / AdminOnly extractor at all.
+        let Json(public) = crate::api::site::get_public_site(State(state.clone())).await;
+        let body = serde_json::to_string(&public.data.expect("public site data")).unwrap();
+        assert!(body.contains("我的中转"), "branding must be public");
+        assert!(
+            !body.contains(secret_notice),
+            "public endpoint leaked the announcement"
+        );
+        assert!(
+            !body.contains("tg:@someone"),
+            "public endpoint leaked the support contact"
+        );
+
+        // The signed-in view does carry them — otherwise the feature is broken
+        // in the other direction and this test would pass vacuously.
+        let Json(notice) = crate::api::site::get_site_notice(
+            AuthUser {
+                user_id: 1,
+                admin: true,
+            },
+            State(state),
+        )
+        .await;
+        let notice = notice.data.expect("notice data");
+        assert_eq!(notice.announcement, secret_notice);
+        assert_eq!(notice.contact, "tg:@someone");
+    }
+
     /// An empty group can be deleted successfully.
     #[tokio::test]
     async fn delete_empty_group_succeeds() {

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -16,6 +16,7 @@ pub mod notify;
 pub mod redeem;
 pub mod restart;
 pub mod security_headers;
+pub mod site;
 pub mod stats;
 pub mod system;
 pub mod ws;
@@ -47,6 +48,16 @@ pub fn routes() -> Router<AppState> {
             "/auth/registration-status",
             axum::routing::get(auth::registration_status),
         )
+        // v1.3.0: public site branding. Unauthenticated because the login page
+        // renders the operator's name before anyone has a token. Carries ONLY
+        // name + subtitle — the announcement and support contact are behind
+        // /user/site-notice.
+        .route("/site", axum::routing::get(site::get_public_site))
+        // v1.3.0: the signed-in half of the site config.
+        .route(
+            "/user/site-notice",
+            axum::routing::get(site::get_site_notice),
+        )
         // Any authenticated user can change their own password
         .route("/user/password", axum::routing::put(admin::change_password))
         // Any authenticated user can read their own account info (no password)
@@ -58,6 +69,12 @@ pub fn routes() -> Router<AppState> {
         // from the token — there is no user_id in the body, so it can never
         // credit another account.
         .route("/user/redeem", axum::routing::post(redeem::redeem_code))
+        // v1.3.0: the caller's own top-up history, for the account page. Scoped
+        // to the token's uid — there is no id in the path.
+        .route(
+            "/user/redeem-records",
+            axum::routing::get(redeem::list_my_redeem_records),
+        )
         // v1.0.8: public plan list (hidden excluded) for the shop.
         .route("/plans", axum::routing::get(admin::list_public_plans))
         // Admin
@@ -199,6 +216,11 @@ pub fn routes() -> Router<AppState> {
             "/admin/settings/registration",
             axum::routing::get(admin::get_registration_settings)
                 .put(admin::update_registration_settings),
+        )
+        // v1.3.0: site identity (name / subtitle / announcement / contact).
+        .route(
+            "/admin/settings/site",
+            axum::routing::get(site::get_site_settings).put(site::update_site_settings),
         )
         // v1.2.0: node-offline notification settings. GET never returns the bot
         // token / SMTP password (only whether one is set); PUT treats an empty

--- a/crates/panel/src/api/redeem.rs
+++ b/crates/panel/src/api/redeem.rs
@@ -250,6 +250,65 @@ pub async fn list_codes(
     Json(ApiResponse::success(ListCodesResponse { items, total }))
 }
 
+/// One of the caller's own top-ups.
+#[derive(Debug, Serialize)]
+pub struct MyRedeemRecord {
+    pub id: i64,
+    /// Masked to the last group (`****-****-****-CDEF`).
+    ///
+    /// The user typed this code themselves, so showing it in full would not
+    /// leak anything they don't know — but it would put a live-looking
+    /// credential in a page that gets screenshotted and pasted into support
+    /// chats, and the last group is already enough to match a receipt against.
+    pub code: String,
+    pub amount: String,
+    pub used_at: Option<String>,
+}
+
+/// GET /api/v1/user/redeem-records — the caller's own top-up history.
+///
+/// Scoped to `user.user_id` from the token, exactly like /user/redeem: there is
+/// no id in the path or query, so this endpoint cannot read anyone else's.
+pub async fn list_my_redeem_records(
+    user: AuthUser,
+    State(state): State<AppState>,
+) -> Json<ApiResponse<Vec<MyRedeemRecord>>> {
+    match state.db.list_redeem_codes_by_user(user.user_id).await {
+        Ok(rows) => Json(ApiResponse::success(
+            rows.into_iter()
+                .map(|c| MyRedeemRecord {
+                    id: c.id,
+                    code: mask_code(&c.code),
+                    amount: c.amount,
+                    used_at: c.used_at,
+                })
+                .collect(),
+        )),
+        Err(e) => {
+            tracing::error!("list_my_redeem_records for user {}: {}", user.user_id, e);
+            Json(err(500, "数据库错误"))
+        }
+    }
+}
+
+/// `0123456789ABCDEF` -> `****-****-****-CDEF`.
+fn mask_code(stored: &str) -> String {
+    let display = redeem::to_display(stored);
+    match display.rsplit_once('-') {
+        // Keep the shape so it still reads as a code, not as a broken string.
+        Some((head, tail)) => {
+            let masked: String = head
+                .chars()
+                .map(|c| if c == '-' { '-' } else { '*' })
+                .collect();
+            format!("{masked}-{tail}")
+        }
+        // No dash at all (a code shorter than one group) — mask everything
+        // rather than falling through and printing it.
+        None => "*".repeat(display.chars().count()),
+    }
+}
+
 /// POST /api/v1/admin/redeem-codes/{id}/void — burn an unused code.
 pub async fn void_code(
     _admin: AdminOnly,
@@ -385,5 +444,38 @@ pub async fn redeem_code(
             tracing::error!("redeem_code failed for user {}: {}", user.user_id, e);
             Json(err(500, "数据库错误"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mask_code;
+
+    /// A used code is still credential-shaped. The account page shows only the
+    /// last group — enough to match against a receipt, not enough to retype.
+    #[test]
+    fn mask_keeps_only_the_last_group() {
+        assert_eq!(mask_code("0123456789ABCDEF"), "****-****-****-CDEF");
+    }
+
+    /// The masked prefix must contain none of the original characters — a
+    /// partial mask that left, say, the first group would defeat the point.
+    #[test]
+    fn mask_leaks_nothing_from_the_head() {
+        let masked = mask_code("ZZZZ1111222233CD");
+        let (head, _) = masked.rsplit_once('-').unwrap();
+        assert!(
+            head.chars().all(|c| c == '*' || c == '-'),
+            "head must be fully masked, got {head}"
+        );
+    }
+
+    /// A code too short to have a group separator must be masked entirely
+    /// rather than printed through the fallback branch.
+    #[test]
+    fn mask_hides_a_code_with_no_separator() {
+        let masked = mask_code("ABC");
+        assert_eq!(masked, "***");
+        assert!(!masked.contains('A'));
     }
 }

--- a/crates/panel/src/api/site.rs
+++ b/crates/panel/src/api/site.rs
@@ -1,0 +1,150 @@
+//! v1.3.0: site identity endpoints.
+//!
+//! Split across THREE auth levels on purpose:
+//!
+//!   * `GET /site` is public, because the login page renders the brand before
+//!     anyone has a token.
+//!   * `GET /user/site-notice` requires auth, because the announcement and the
+//!     support contact are for this operator's users — not for anyone who can
+//!     reach the port. Not displaying them on the login page would be hollow if
+//!     the API served them to the world anyway.
+//!   * `PUT /admin/settings/site` is admin-only, like every other setting.
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use super::middleware::{AdminOnly, AuthUser};
+use super::AppState;
+use crate::service::site::{SiteConfig, SITE_CONFIG_KEY};
+use relay_shared::protocol::ApiResponse;
+
+async fn load(state: &AppState) -> SiteConfig {
+    let raw = state.db.get(SITE_CONFIG_KEY).await.ok().flatten();
+    SiteConfig::from_json(raw.as_deref())
+}
+
+/// The public half: branding only. Deliberately does NOT carry `announcement`
+/// or `contact` — see the module comment.
+#[derive(Debug, Serialize)]
+pub struct PublicSite {
+    pub site_name: String,
+    pub subtitle: String,
+}
+
+/// GET /api/v1/site — unauthenticated.
+pub async fn get_public_site(State(state): State<AppState>) -> Json<ApiResponse<PublicSite>> {
+    let cfg = load(&state).await;
+    Json(ApiResponse::success(PublicSite {
+        site_name: cfg.site_name,
+        subtitle: cfg.subtitle,
+    }))
+}
+
+/// The signed-in half.
+#[derive(Debug, Serialize)]
+pub struct SiteNotice {
+    pub announcement: String,
+    pub contact: String,
+}
+
+/// GET /api/v1/user/site-notice — any authenticated user.
+pub async fn get_site_notice(
+    _user: AuthUser,
+    State(state): State<AppState>,
+) -> Json<ApiResponse<SiteNotice>> {
+    let cfg = load(&state).await;
+    Json(ApiResponse::success(SiteNotice {
+        announcement: cfg.announcement,
+        contact: cfg.contact,
+    }))
+}
+
+/// GET /api/v1/admin/settings/site — the full row, for the edit form.
+pub async fn get_site_settings(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+) -> Json<ApiResponse<SiteConfig>> {
+    Json(ApiResponse::success(load(&state).await))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateSiteRequest {
+    #[serde(default)]
+    pub site_name: String,
+    #[serde(default)]
+    pub subtitle: String,
+    #[serde(default)]
+    pub announcement: String,
+    #[serde(default)]
+    pub contact: String,
+}
+
+/// PUT /api/v1/admin/settings/site
+pub async fn update_site_settings(
+    _admin: AdminOnly,
+    State(state): State<AppState>,
+    Json(req): Json<UpdateSiteRequest>,
+) -> Json<ApiResponse<SiteConfig>> {
+    // Trim + clamp before storing, so every reader (including the public
+    // endpoint hit on every login page load) gets a bounded value.
+    let cfg = SiteConfig {
+        site_name: req.site_name,
+        subtitle: req.subtitle,
+        announcement: req.announcement,
+        contact: req.contact,
+    }
+    .sanitized();
+
+    let json = match serde_json::to_string(&cfg) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::error!("update_site_settings: serialize failed: {}", e);
+            return Json(ApiResponse {
+                code: 500,
+                message: "配置序列化失败".into(),
+                data: None,
+            });
+        }
+    };
+    if let Err(e) = state.db.set(SITE_CONFIG_KEY, &json).await {
+        tracing::error!("update_site_settings: save failed: {}", e);
+        return Json(ApiResponse {
+            code: 500,
+            message: "数据库错误".into(),
+            data: None,
+        });
+    }
+
+    tracing::info!(
+        action = "update_site_settings",
+        site_name = %cfg.site_name,
+        "site settings updated"
+    );
+    // Records WHICH fields are now set, not their contents: the announcement can
+    // be long, and the audit table is not the place to keep a copy of it.
+    crate::service::audit::record(
+        &state,
+        Some(_admin.user_id),
+        "update_site_settings",
+        "settings",
+        "site",
+        &format!(
+            "站点名称 {} / 公告 {} / 客服 {}",
+            cfg.site_name,
+            if cfg.announcement.is_empty() {
+                "已清空"
+            } else {
+                "已设置"
+            },
+            if cfg.contact.is_empty() {
+                "已清空"
+            } else {
+                "已设置"
+            },
+        ),
+    )
+    .await;
+
+    Json(ApiResponse::success(cfg))
+}

--- a/crates/panel/src/db/pg_repo/redeem.rs
+++ b/crates/panel/src/db/pg_repo/redeem.rs
@@ -138,6 +138,18 @@ impl RedeemRepository for PgRepository {
         Ok((amount, new_balance))
     }
 
+    async fn list_redeem_codes_by_user(&self, user_id: i64) -> Result<Vec<RedeemCode>, DbError> {
+        // status = 'used' as well as the uid: a code whose redeemer was later
+        // cleared would otherwise be invisible anyway, and this keeps the query
+        // honest about what it returns — the user's top-up history.
+        Ok(sqlx::query_as(
+            "SELECT * FROM redeem_codes              WHERE used_by = $1 AND status = 'used'              ORDER BY used_at DESC, id DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
     async fn list_redeem_codes(
         &self,
         filter: &RedeemCodeFilter,

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -5225,3 +5225,55 @@ async fn pg_audit_prune_keeps_the_cutoff_row() {
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|e| e.ts.as_str() >= "2026-07-10 10:00:00"));
 }
+
+// ── v1.3.0: per-user redeem history ──
+
+/// The account page is reachable by every user, so this query must be scoped by
+/// construction. If it ever returned another account's top-ups, one user could
+/// read another's payment history from their own page.
+#[tokio::test]
+async fn pg_redeem_history_is_scoped_to_the_asking_user() {
+    let Some(db) = repo("redeem_hist_scope").await else {
+        return;
+    };
+    db.insert_user("alice", "h", 1).await.unwrap();
+    db.insert_user("bob", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+    let bob = db.find_by_username("bob").await.unwrap().unwrap().id;
+
+    pg_seed_code(&db, "AAAAAAAAAAAAAAAA", "10.00", None).await;
+    pg_seed_code(&db, "BBBBBBBBBBBBBBBB", "20.00", None).await;
+    db.redeem_code("AAAAAAAAAAAAAAAA", alice, "2026-07-28 10:00:00")
+        .await
+        .unwrap();
+    db.redeem_code("BBBBBBBBBBBBBBBB", bob, "2026-07-28 10:00:01")
+        .await
+        .unwrap();
+
+    let mine = db.list_redeem_codes_by_user(alice).await.unwrap();
+    assert_eq!(mine.len(), 1, "alice must see exactly her own top-up");
+    assert_eq!(mine[0].code, "AAAAAAAAAAAAAAAA");
+    assert_eq!(mine[0].amount, "10.00");
+}
+
+/// Unused and voided codes are not top-ups and must not appear — the history is
+/// a record of money that actually moved.
+#[tokio::test]
+async fn pg_redeem_history_lists_only_used_codes() {
+    let Some(db) = repo("redeem_hist_used").await else {
+        return;
+    };
+    db.insert_user("alice", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+
+    pg_seed_code(&db, "CCCCCCCCCCCCCCCC", "5.00", None).await;
+    let unused = pg_seed_code(&db, "DDDDDDDDDDDDDDDD", "9.00", None).await;
+    db.redeem_code("CCCCCCCCCCCCCCCC", alice, "2026-07-28 10:00:00")
+        .await
+        .unwrap();
+    db.void_redeem_code(unused).await.unwrap();
+
+    let mine = db.list_redeem_codes_by_user(alice).await.unwrap();
+    assert_eq!(mine.len(), 1);
+    assert_eq!(mine[0].status, "used");
+}

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -1004,6 +1004,17 @@ pub trait RedeemRepository: Send + Sync {
         now: &str,
     ) -> Result<(String, String), RedeemCodeError>;
 
+    /// v1.3.0: the codes a given user redeemed, newest first.
+    ///
+    /// Separate from `list_redeem_codes` rather than another filter on it: this
+    /// one is reachable by a NON-admin (their own account page), so the uid
+    /// filter must be structural, not one more optional field that a future
+    /// caller could forget to set.
+    async fn list_redeem_codes_by_user(
+        &self,
+        user_id: i64,
+    ) -> Result<Vec<relay_shared::models::RedeemCode>, DbError>;
+
     /// List codes for the admin UI, newest first.
     async fn list_redeem_codes(
         &self,

--- a/crates/panel/src/db/sqlite_repo/redeem.rs
+++ b/crates/panel/src/db/sqlite_repo/redeem.rs
@@ -140,6 +140,18 @@ impl RedeemRepository for SqliteRepository {
         Ok((amount, new_balance))
     }
 
+    async fn list_redeem_codes_by_user(&self, user_id: i64) -> Result<Vec<RedeemCode>, DbError> {
+        // status = 'used' as well as the uid: a code whose redeemer was later
+        // cleared would otherwise be invisible anyway, and this keeps the query
+        // honest about what it returns — the user's top-up history.
+        Ok(sqlx::query_as(
+            "SELECT * FROM redeem_codes              WHERE used_by = ? AND status = 'used'              ORDER BY used_at DESC, id DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
     async fn list_redeem_codes(
         &self,
         filter: &RedeemCodeFilter,

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -5141,3 +5141,51 @@ async fn audit_prune_keeps_the_cutoff_row() {
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|e| e.ts.as_str() >= "2026-07-10 10:00:00"));
 }
+
+// ── v1.3.0: per-user redeem history ──
+
+/// The account page is reachable by every user, so this query must be scoped by
+/// construction. If it ever returned another account's top-ups, one user could
+/// read another's payment history from their own page.
+#[tokio::test]
+async fn redeem_history_is_scoped_to_the_asking_user() {
+    let db = repo().await;
+    db.insert_user("alice", "h", 1).await.unwrap();
+    db.insert_user("bob", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+    let bob = db.find_by_username("bob").await.unwrap().unwrap().id;
+
+    seed_code(&db, "AAAAAAAAAAAAAAAA", "10.00", None).await;
+    seed_code(&db, "BBBBBBBBBBBBBBBB", "20.00", None).await;
+    db.redeem_code("AAAAAAAAAAAAAAAA", alice, "2026-07-28 10:00:00")
+        .await
+        .unwrap();
+    db.redeem_code("BBBBBBBBBBBBBBBB", bob, "2026-07-28 10:00:01")
+        .await
+        .unwrap();
+
+    let mine = db.list_redeem_codes_by_user(alice).await.unwrap();
+    assert_eq!(mine.len(), 1, "alice must see exactly her own top-up");
+    assert_eq!(mine[0].code, "AAAAAAAAAAAAAAAA");
+    assert_eq!(mine[0].amount, "10.00");
+}
+
+/// Unused and voided codes are not top-ups and must not appear — the history is
+/// a record of money that actually moved.
+#[tokio::test]
+async fn redeem_history_lists_only_used_codes() {
+    let db = repo().await;
+    db.insert_user("alice", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+
+    seed_code(&db, "CCCCCCCCCCCCCCCC", "5.00", None).await;
+    let unused = seed_code(&db, "DDDDDDDDDDDDDDDD", "9.00", None).await;
+    db.redeem_code("CCCCCCCCCCCCCCCC", alice, "2026-07-28 10:00:00")
+        .await
+        .unwrap();
+    db.void_redeem_code(unused).await.unwrap();
+
+    let mine = db.list_redeem_codes_by_user(alice).await.unwrap();
+    assert_eq!(mine.len(), 1);
+    assert_eq!(mine[0].status, "used");
+}

--- a/crates/panel/src/service/mod.rs
+++ b/crates/panel/src/service/mod.rs
@@ -10,5 +10,6 @@ pub mod profiles;
 pub mod redeem;
 pub mod rules;
 pub mod settings;
+pub mod site;
 pub mod traffic;
 pub mod users;

--- a/crates/panel/src/service/site.rs
+++ b/crates/panel/src/service/site.rs
@@ -1,0 +1,136 @@
+//! v1.3.0: operator-configurable site identity.
+//!
+//! The brand string was hardcoded in three places (login page, sidebar, browser
+//! title), so every operator running this panel showed "RelayPanel" to their own
+//! users. This makes name, subtitle, announcement and support contact editable
+//! from the panel.
+//!
+//! Stored as one JSON blob in the kvs table, exactly like the notify config —
+//! a handful of free-text fields don't earn their own columns, and a new field
+//! then costs no migration.
+
+use serde::{Deserialize, Serialize};
+
+pub const SITE_CONFIG_KEY: &str = "site:config";
+
+/// Length caps. These are not security boundaries — they stop an accidental
+/// paste of a whole document from becoming a row every page load has to read.
+pub const MAX_NAME: usize = 64;
+pub const MAX_SUBTITLE: usize = 128;
+pub const MAX_ANNOUNCEMENT: usize = 4000;
+pub const MAX_CONTACT: usize = 256;
+
+/// Falls back to the current hardcoded brand, so an operator who never opens
+/// the page sees exactly what they saw before.
+pub const DEFAULT_NAME: &str = "RelayPanel";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct SiteConfig {
+    /// Shown on the login page, in the sidebar, and as the browser tab title.
+    pub site_name: String,
+    /// Small text under the name on the login page. Empty = the frontend keeps
+    /// its own translated default, which is why this is not defaulted here.
+    pub subtitle: String,
+    /// Free text shown to signed-in users on the dashboard and account page.
+    /// Empty = the banner is not rendered at all, rather than an empty box.
+    pub announcement: String,
+    /// How users reach the operator (Telegram handle, email, whatever).
+    pub contact: String,
+}
+
+impl SiteConfig {
+    /// Tolerates a missing, empty, or corrupt row — the panel must render its
+    /// login page even if this value is garbage, since a blank brand would make
+    /// the site look broken to everyone.
+    pub fn from_json(raw: Option<&str>) -> Self {
+        let mut cfg: Self = raw
+            .and_then(|r| serde_json::from_str(r).ok())
+            .unwrap_or_default();
+        if cfg.site_name.trim().is_empty() {
+            cfg.site_name = DEFAULT_NAME.to_string();
+        }
+        cfg
+    }
+
+    /// Trim and clamp every field. Applied on write so the stored row is always
+    /// already within bounds and readers never have to defend themselves.
+    ///
+    /// Truncation is by `char`, not by byte: slicing a multi-byte character in
+    /// half would panic, and every one of these fields is expected to hold CJK.
+    pub fn sanitized(&self) -> Self {
+        fn clamp(s: &str, max: usize) -> String {
+            s.trim().chars().take(max).collect()
+        }
+        let mut out = Self {
+            site_name: clamp(&self.site_name, MAX_NAME),
+            subtitle: clamp(&self.subtitle, MAX_SUBTITLE),
+            announcement: clamp(&self.announcement, MAX_ANNOUNCEMENT),
+            contact: clamp(&self.contact, MAX_CONTACT),
+        };
+        if out.site_name.is_empty() {
+            out.site_name = DEFAULT_NAME.to_string();
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A missing or damaged row must still yield a usable brand. Rendering an
+    /// empty site name would make every page look broken, including the login
+    /// page an operator would use to go fix it.
+    #[test]
+    fn from_json_always_yields_a_name() {
+        for raw in [
+            None,
+            Some(""),
+            Some("not json"),
+            Some("{}"),
+            Some("[]"),
+            Some(r#"{"site_name":"   "}"#),
+        ] {
+            let cfg = SiteConfig::from_json(raw);
+            assert_eq!(cfg.site_name, DEFAULT_NAME, "for {raw:?}");
+        }
+    }
+
+    /// A stored name is kept as-is; only blank falls back.
+    #[test]
+    fn from_json_keeps_a_configured_name() {
+        let cfg = SiteConfig::from_json(Some(r#"{"site_name":"我的中转","contact":"tg"}"#));
+        assert_eq!(cfg.site_name, "我的中转");
+        assert_eq!(cfg.contact, "tg");
+    }
+
+    /// Truncation counts characters, not bytes. A byte slice at MAX_NAME would
+    /// land mid-character on CJK input and panic — the exact input this panel
+    /// expects most.
+    #[test]
+    fn sanitize_truncates_multibyte_text_without_panicking() {
+        let cfg = SiteConfig {
+            site_name: "中".repeat(MAX_NAME + 10),
+            announcement: "公".repeat(MAX_ANNOUNCEMENT + 10),
+            ..Default::default()
+        };
+        let out = cfg.sanitized();
+        assert_eq!(out.site_name.chars().count(), MAX_NAME);
+        assert_eq!(out.announcement.chars().count(), MAX_ANNOUNCEMENT);
+    }
+
+    /// Whitespace-only input is the same as clearing the field, and clearing
+    /// the name falls back rather than storing "".
+    #[test]
+    fn sanitize_trims_and_falls_back_on_blank_name() {
+        let cfg = SiteConfig {
+            site_name: "   ".into(),
+            subtitle: "  hi  ".into(),
+            ..Default::default()
+        };
+        let out = cfg.sanitized();
+        assert_eq!(out.site_name, DEFAULT_NAME);
+        assert_eq!(out.subtitle, "hi");
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { ConfigProvider } from 'antd';
 import zhCN_antd from 'antd/locale/zh_CN';
@@ -7,9 +8,17 @@ import { rpTheme } from './styles/antdTheme';
 import { LanguageProvider } from './i18n';
 import { useI18n } from './i18n/context';
 import { AuthProvider } from './auth/AuthContext';
+import { useSite } from './hooks/useSite';
 
 function AppInner() {
   const { lang } = useI18n();
+  // v1.3.0: the browser tab title follows the operator's site name. Done here,
+  // once, rather than in each page — the title is a property of the app, and a
+  // per-page effect would fight itself on navigation.
+  const site = useSite();
+  useEffect(() => {
+    if (site.site_name) document.title = site.site_name;
+  }, [site.site_name]);
   return (
     <ConfigProvider theme={rpTheme} locale={lang === 'zh-CN' ? zhCN_antd : enUS_antd}>
       {/* v0.4.10: AuthProvider wraps the router so every route + the axios

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -200,6 +200,31 @@ export interface ListCodesResponse {
   total: number;
 }
 
+/** v1.3.0: one of the caller's own redeem-code top-ups. `code` arrives already
+ *  masked to the last group — the server never sends the full value here. */
+export interface MyRedeemRecord {
+  id: number;
+  code: string;
+  amount: string;
+  used_at: string | null;
+}
+
+/** v1.3.0: public site branding. No announcement/contact — those are behind
+ *  the authenticated /user/site-notice endpoint. */
+export interface PublicSite {
+  site_name: string;
+  subtitle: string;
+}
+
+/** v1.3.0: the signed-in half of the site config. */
+export interface SiteNotice {
+  announcement: string;
+  contact: string;
+}
+
+/** v1.3.0: the full site config, as the admin form reads and writes it. */
+export interface SiteConfig extends PublicSite, SiteNotice {}
+
 /** v1.3.0: one recorded admin action. */
 export interface AuditEntry {
   id: number;

--- a/frontend/src/components/AccountRecords.test.tsx
+++ b/frontend/src/components/AccountRecords.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('../api/client', () => ({ default: { get: mockGet } }));
+
+import AccountRecords from './AccountRecords';
+
+const ok = <T,>(data: T) => ({ code: 0, message: 'ok', data });
+
+const redeems = [
+  { id: 1, code: '****-****-****-CDEF', amount: '100.00', used_at: '2026-07-28 10:00:00' },
+];
+const orders = [
+  { id: 7, user_id: 2, plan_id: 3, plan_name: '基础套餐', price: '50.00', created_at: '2026-07-27 09:00:00' },
+];
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockGet.mockImplementation((url: string) =>
+    Promise.resolve(url.includes('redeem-records') ? ok(redeems) : ok(orders)),
+  );
+});
+
+const renderCard = async () => { await act(async () => { render(<AccountRecords />); }); };
+
+describe('AccountRecords', () => {
+  it('reads both histories from the user-scoped endpoints', async () => {
+    await renderCard();
+    const urls = mockGet.mock.calls.map((c) => c[0] as string);
+    // Neither URL carries a user id — the server pins both to the token, and a
+    // page that passed an id would be the wrong shape for this data.
+    expect(urls).toContain('/user/redeem-records');
+    expect(urls).toContain('/user/orders');
+    expect(urls.every((u) => !/\d/.test(u))).toBe(true);
+  });
+
+  it('shows the top-up amount and the masked code', async () => {
+    await renderCard();
+    expect(screen.getByText('****-****-****-CDEF')).toBeInTheDocument();
+    expect(screen.getByText('100.00')).toBeInTheDocument();
+  });
+
+  it('renders without crashing when both histories are empty', async () => {
+    // The default state for a brand-new account, and the one most likely to be
+    // hit by a first-time user.
+    mockGet.mockResolvedValue(ok([]));
+    await renderCard();
+    expect(screen.getByText('noRecharges')).toBeInTheDocument();
+  });
+
+  it('stays quiet when the requests fail', async () => {
+    mockGet.mockRejectedValue(new Error('network'));
+    await renderCard();
+    // Still renders its shell rather than blanking the account page.
+    expect(screen.getByText('rechargeHistory')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AccountRecords.tsx
+++ b/frontend/src/components/AccountRecords.tsx
@@ -1,0 +1,121 @@
+import { Card, Table, Tabs } from 'antd';
+import { useEffect, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope, MyRedeemRecord, Order } from '../api/types';
+import { useI18n } from '../i18n/context';
+
+/**
+ * v1.3.0: the user's own money history on the account page — redeem-code
+ * top-ups and plan purchases.
+ *
+ * Two tabs in one card rather than two stacked cards: they answer the same
+ * question ("where did my balance go"), and stacking them pushed the traffic
+ * chart far below the fold on the page most regular users land on.
+ *
+ * The purchase table is deliberately NOT removed from the shop page — buying
+ * and then seeing the receipt in place is worth the duplicated read.
+ */
+export default function AccountRecords() {
+  const { t } = useI18n();
+  const [redeems, setRedeems] = useState<MyRedeemRecord[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    Promise.all([
+      api.get<unknown, ApiEnvelope<MyRedeemRecord[]>>('/user/redeem-records'),
+      api.get<unknown, ApiEnvelope<Order[]>>('/user/orders'),
+    ])
+      .then(([r, o]) => {
+        if (!alive) return;
+        setRedeems(r.data ?? []);
+        setOrders(o.data ?? []);
+      })
+      // An empty history and an unreachable one look the same here on purpose:
+      // neither is worth an error toast on the landing page.
+      .catch(() => {})
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  const redeemColumns = [
+    {
+      title: t('redeemCode'),
+      dataIndex: 'code',
+      key: 'code',
+      // Masked server-side to the last group — see MyRedeemRecord.
+      render: (v: string) => <span className="rp-mono">{v}</span>,
+    },
+    {
+      title: t('rechargeAmount'),
+      dataIndex: 'amount',
+      key: 'amount',
+      render: (v: string) => <span className="rp-mono">{v}</span>,
+    },
+    {
+      title: t('rechargeTime'),
+      dataIndex: 'used_at',
+      key: 'used_at',
+      render: (v: string | null) => <span className="rp-mono">{v || '-'}</span>,
+    },
+  ];
+
+  const orderColumns = [
+    { title: t('orderId'), dataIndex: 'id', key: 'id', width: 70 },
+    { title: t('planName'), dataIndex: 'plan_name', key: 'plan_name' },
+    {
+      title: t('planPrice'),
+      dataIndex: 'price',
+      key: 'price',
+      render: (v: string) => <span className="rp-mono">{v}</span>,
+    },
+    {
+      title: t('purchaseTime'),
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (v: string) => <span className="rp-mono">{v}</span>,
+    },
+  ];
+
+  return (
+    <Card style={{ marginTop: 24 }}>
+      <Tabs
+        items={[
+          {
+            key: 'redeem',
+            label: t('rechargeHistory'),
+            children: (
+              <Table
+                dataSource={redeems}
+                columns={redeemColumns}
+                rowKey="id"
+                loading={loading}
+                size="small"
+                scroll={{ x: 'max-content' }}
+                pagination={{ pageSize: 10, showSizeChanger: false }}
+                locale={{ emptyText: t('noRecharges') }}
+              />
+            ),
+          },
+          {
+            key: 'orders',
+            label: t('orderHistory'),
+            children: (
+              <Table
+                dataSource={orders}
+                columns={orderColumns}
+                rowKey="id"
+                loading={loading}
+                size="small"
+                scroll={{ x: 'max-content' }}
+                pagination={{ pageSize: 10, showSizeChanger: false }}
+                locale={{ emptyText: t('noOrders') }}
+              />
+            ),
+          },
+        ]}
+      />
+    </Card>
+  );
+}

--- a/frontend/src/components/SiteAnnouncement.test.tsx
+++ b/frontend/src/components/SiteAnnouncement.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('../api/client', () => ({ default: { get: mockGet } }));
+
+import SiteAnnouncement from './SiteAnnouncement';
+import { invalidateSiteNotice } from '../hooks/useSiteNotice';
+
+const ok = <T,>(data: T) => ({ code: 0, message: 'ok', data });
+
+beforeEach(() => {
+  mockGet.mockReset();
+  // The hook caches module-wide; without this each test would see the first
+  // test's response.
+  invalidateSiteNotice();
+});
+
+const renderBanner = async () => { await act(async () => { render(<SiteAnnouncement />); }); };
+
+describe('SiteAnnouncement', () => {
+  it('renders the announcement text when the operator set one', async () => {
+    mockGet.mockResolvedValue(ok({ announcement: '今晚 02:00 维护', contact: '' }));
+    await renderBanner();
+    expect(screen.getByText('今晚 02:00 维护')).toBeInTheDocument();
+  });
+
+  it('renders nothing at all when the announcement is empty', async () => {
+    // An operator who never writes one must not get a permanent empty box —
+    // this is the default state for every fresh install.
+    mockGet.mockResolvedValue(ok({ announcement: '', contact: 'tg:@ops' }));
+    const { container } = await act(async () => render(<SiteAnnouncement />)) as unknown as { container: HTMLElement };
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('stays silent when the request fails', async () => {
+    // A dashboard should not sprout an error box because an optional banner
+    // could not be fetched.
+    mockGet.mockRejectedValue(new Error('network'));
+    const { container } = await act(async () => render(<SiteAnnouncement />)) as unknown as { container: HTMLElement };
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('never renders the announcement as HTML', async () => {
+    // Admin-authored, but injecting markup into every user's page is not a
+    // capability this field should hand out.
+    mockGet.mockResolvedValue(ok({ announcement: '<img src=x onerror=alert(1)>', contact: '' }));
+    await renderBanner();
+    expect(screen.getByText('<img src=x onerror=alert(1)>')).toBeInTheDocument();
+    expect(document.querySelector('img')).toBeNull();
+  });
+});

--- a/frontend/src/components/SiteAnnouncement.tsx
+++ b/frontend/src/components/SiteAnnouncement.tsx
@@ -1,0 +1,30 @@
+import { Alert } from 'antd';
+import { NotificationOutlined } from '@ant-design/icons';
+import { useSiteNotice } from '../hooks/useSiteNotice';
+
+/**
+ * v1.3.0: the operator's announcement, shown at the top of the dashboard and
+ * the account page.
+ *
+ * Renders nothing at all when the announcement is empty. An operator who never
+ * writes one should not see a permanent empty box on their dashboard.
+ */
+export default function SiteAnnouncement() {
+  const { announcement } = useSiteNotice();
+
+  if (!announcement) return null;
+
+  return (
+    <Alert
+      type="info"
+      showIcon
+      icon={<NotificationOutlined />}
+      style={{ marginBottom: 16 }}
+      // whiteSpace preserves the line breaks the operator typed. The text is
+      // rendered by React as a string, never as HTML — an announcement is
+      // admin-authored, but injecting markup into every user's page is not a
+      // capability worth handing out.
+      description={<span style={{ whiteSpace: 'pre-wrap' }}>{announcement}</span>}
+    />
+  );
+}

--- a/frontend/src/hooks/useSite.ts
+++ b/frontend/src/hooks/useSite.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope, PublicSite } from '../api/types';
+
+/**
+ * v1.3.0: the operator's site branding (name + subtitle).
+ *
+ * Served by the PUBLIC `/site` endpoint, because the login page renders the
+ * brand before anyone has a token. The announcement and support contact are
+ * deliberately not here — they come from the authenticated `/user/site-notice`.
+ *
+ * Cached in a module-level promise rather than fetched per component: the brand
+ * is rendered by both the login page and the sidebar, and re-requesting it on
+ * every mount would put a needless round-trip in front of every navigation.
+ *
+ * Invalidation notifies live subscribers rather than only clearing the cache.
+ * The sidebar is mounted while the admin saves the settings form, so a plain
+ * cache clear would leave the old name on screen until a full reload — the one
+ * moment the feature is being looked at.
+ */
+const EMPTY: PublicSite = { site_name: '', subtitle: '' };
+
+let cached: Promise<PublicSite> | null = null;
+const subscribers = new Set<(s: PublicSite) => void>();
+
+function fetchSite(): Promise<PublicSite> {
+  if (!cached) {
+    cached = api
+      .get<unknown, ApiEnvelope<PublicSite>>('/site')
+      .then((res) => (res.code === 0 && res.data ? res.data : EMPTY))
+      // A failed brand lookup must never block the login page — fall back to
+      // empty and let the caller use its translated default.
+      .catch(() => EMPTY);
+  }
+  return cached;
+}
+
+/** Drop the cache; re-fetch only if something is currently displaying it.
+ *  With nothing mounted there is no one to notify and the next mount will
+ *  fetch anyway, so an eager request would be pure waste. */
+export function invalidateSite() {
+  cached = null;
+  if (subscribers.size === 0) return;
+  fetchSite().then((s) => subscribers.forEach((fn) => fn(s)));
+}
+
+export function useSite(): PublicSite {
+  const [site, setSite] = useState<PublicSite>(EMPTY);
+  useEffect(() => {
+    let alive = true;
+    const update = (s: PublicSite) => { if (alive) setSite(s); };
+    subscribers.add(update);
+    fetchSite().then(update);
+    return () => {
+      alive = false;
+      subscribers.delete(update);
+    };
+  }, []);
+  return site;
+}

--- a/frontend/src/hooks/useSiteNotice.ts
+++ b/frontend/src/hooks/useSiteNotice.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope, SiteNotice } from '../api/types';
+
+/**
+ * v1.3.0: the signed-in half of the site config — announcement + support
+ * contact, from the AUTHENTICATED `/user/site-notice`.
+ *
+ * Separate from `useSite` (public branding) because the two have different auth
+ * requirements, not just different fields: the login page reads branding with
+ * no token, and these must not be served to unauthenticated callers.
+ *
+ * Same cache + subscriber shape as useSite, for the same reason — an admin who
+ * edits the announcement should see the banner change, not a stale copy.
+ */
+const EMPTY: SiteNotice = { announcement: '', contact: '' };
+
+let cached: Promise<SiteNotice> | null = null;
+const subscribers = new Set<(n: SiteNotice) => void>();
+
+function fetchNotice(): Promise<SiteNotice> {
+  if (!cached) {
+    cached = api
+      .get<unknown, ApiEnvelope<SiteNotice>>('/user/site-notice')
+      .then((res) => (res.code === 0 && res.data ? res.data : EMPTY))
+      // An unreachable announcement is not worth an error toast on every page.
+      .catch(() => EMPTY);
+  }
+  return cached;
+}
+
+/** Drop the cache; re-fetch only if something is currently displaying it.
+ *  With nothing mounted there is no one to notify and the next mount will
+ *  fetch anyway, so an eager request would be pure waste. */
+export function invalidateSiteNotice() {
+  cached = null;
+  if (subscribers.size === 0) return;
+  fetchNotice().then((n) => subscribers.forEach((fn) => fn(n)));
+}
+
+export function useSiteNotice(): SiteNotice {
+  const [notice, setNotice] = useState<SiteNotice>(EMPTY);
+  useEffect(() => {
+    let alive = true;
+    const update = (n: SiteNotice) => { if (alive) setNotice(n); };
+    subscribers.add(update);
+    fetchNotice().then(update);
+    return () => {
+      alive = false;
+      subscribers.delete(update);
+    };
+  }, []);
+  return notice;
+}

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -579,6 +579,23 @@ export const enUS: Dict = {
   notifyCredentialNote: 'Note: the bot token and SMTP password are stored in plaintext (same as node tokens). The API never returns them to the browser.',
 
   // ── v1.2.0: redeem codes ──
+  // ── v1.3.0: account money history ──
+  rechargeHistory: 'Top-up History',
+  rechargeAmount: 'Amount',
+  rechargeTime: 'Redeemed at',
+  noRecharges: 'No top-ups yet',
+  // ── v1.3.0: site settings ──
+  siteSettings: 'Site Settings',
+  siteName: 'Site name',
+  siteNameHint: 'Shown on the login page, in the sidebar, and as the browser tab title. Empty falls back to RelayPanel.',
+  siteSubtitle: 'Subtitle',
+  siteSubtitleHint: 'Small text under the name on the login page. Empty keeps the default.',
+  siteAnnouncement: 'Announcement',
+  siteAnnouncementHint: 'Shown at the top of the dashboard and account page; line breaks are kept. Empty hides the banner entirely. Visible to signed-in users only.',
+  siteContact: 'Support contact',
+  siteContactHint: 'Shown on the account page — a Telegram handle, an email, whatever. Empty hides the row.',
+  siteFieldTooLong: 'Too long',
+  siteSettingsHint: 'Takes effect immediately. The announcement and contact require sign-in to read and never appear on the login page.',
   // ── v1.3.0: audit log ──
   auditLog: 'Audit Log',
   auditTime: 'Time (UTC)',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -577,6 +577,23 @@ export const zhCN = {
   notifyTestFailed: '测试发送失败',
   notifyCredentialNote: '说明:Bot Token 和 SMTP 密码以明文存储在数据库中(与节点令牌一致),接口不会把它们返回给浏览器。',
 
+  // ── v1.3.0: 个人中心账目记录 ──
+  rechargeHistory: '卡密充值记录',
+  rechargeAmount: '充值金额',
+  rechargeTime: '充值时间',
+  noRecharges: '暂无充值记录',
+  // ── v1.3.0: 站点设置 ──
+  siteSettings: '站点设置',
+  siteName: '站点名称',
+  siteNameHint: '显示在登录页、左侧边栏和浏览器标签标题。留空则使用 RelayPanel。',
+  siteSubtitle: '副标题',
+  siteSubtitleHint: '登录页站点名称下方的小字。留空则使用默认文案。',
+  siteAnnouncement: '公告',
+  siteAnnouncementHint: '显示在仪表盘和个人中心顶部,支持换行。留空则不显示公告栏。仅登录用户可见。',
+  siteContact: '客服联系方式',
+  siteContactHint: '显示在个人中心,例如 Telegram 或邮箱。留空则不显示该行。',
+  siteFieldTooLong: '内容过长',
+  siteSettingsHint: '保存后立即生效。公告和客服方式需要登录才能读取,不会出现在登录页。',
   // ── v1.3.0: 操作审计 ──
   auditLog: '操作审计',
   auditTime: '时间 (UTC)',

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -12,11 +12,13 @@ import {
   ShoppingOutlined,
   GiftOutlined,
   FileSearchOutlined,
+  GlobalOutlined,
 } from '@ant-design/icons';
 import { useI18n } from '../i18n/context';
 import api from '../api/client';
 import type { ApiEnvelope } from '../api/types';
 import { useAuth } from '../auth/useAuth';
+import { useSite } from '../hooks/useSite';
 import { makePasswordValidator } from '../utils/password';
 
 const { Sider, Content, Header } = Layout;
@@ -27,6 +29,7 @@ export default function MainLayout() {
   const location = useLocation();
   const { t, lang, setLang } = useI18n();
   const { isAdmin, logout: authLogout } = useAuth();
+  const site = useSite();
   const [changePwOpen, setChangePwOpen] = useState(false);
   const [pwForm] = Form.useForm();
   const [pwSubmitting, setPwSubmitting] = useState(false);
@@ -49,6 +52,7 @@ export default function MainLayout() {
     { key: '/redeem-codes', icon: <GiftOutlined />, label: t('redeemCodes') },
     { key: '/users', icon: <UserOutlined />, label: t('users') },
     { key: '/audit-log', icon: <FileSearchOutlined />, label: t('auditLog') },
+    { key: '/site-settings', icon: <GlobalOutlined />, label: t('siteSettings') },
     { key: '/settings', icon: <SettingOutlined />, label: t('systemSettings') },
   ];
   const menuItems = isAdmin
@@ -91,7 +95,7 @@ export default function MainLayout() {
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           color: '#fff', fontSize: 17, fontWeight: 600, letterSpacing: 0.5,
         }}>
-          RelayPanel
+          {site.site_name || t('brand')}
         </div>
         <Menu
           theme="dark"

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -9,6 +9,9 @@ import { formatBytes } from '../utils/format';
 import { makePasswordValidator } from '../utils/password';
 import { useAuth } from '../auth/useAuth';
 import TrafficChart from '../components/TrafficChart';
+import SiteAnnouncement from '../components/SiteAnnouncement';
+import { useSiteNotice } from '../hooks/useSiteNotice';
+import AccountRecords from '../components/AccountRecords';
 
 const { Text } = Typography;
 
@@ -31,6 +34,7 @@ export default function Account() {
   const { t } = useI18n();
   const navigate = useNavigate();
   const { logout: authLogout } = useAuth();
+  const notice = useSiteNotice();
   const [me, setMe] = useState<UserSelf | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -129,6 +133,9 @@ export default function Account() {
 
   return (
     <>
+      {/* v1.3.0: operator announcement. Regular users land here rather than on
+          the dashboard, so without this they would never see one. */}
+      <SiteAnnouncement />
       {/* v1.0.8: suspended banner — the user can still log in and buy a plan
           (buying does NOT auto-unsuspend), but forwarding is gated off. */}
       {me.suspended && (
@@ -216,6 +223,13 @@ export default function Account() {
           <Descriptions.Item label={t('accountMemberSince')}>
             <span className="rp-mono">{me.registered_at || '-'}</span>
           </Descriptions.Item>
+          {/* v1.3.0: only rendered when the operator filled it in — an empty
+              "Support" row would just look like something is broken. */}
+          {notice.contact && (
+            <Descriptions.Item label={t('siteContact')}>
+              <span style={{ whiteSpace: 'pre-wrap' }}>{notice.contact}</span>
+            </Descriptions.Item>
+          )}
         </Descriptions>
       </Card>
 
@@ -226,6 +240,11 @@ export default function Account() {
           per-rule drill-down) on the dashboard, and an admin's "personal"
           traffic is a near-meaningless number. The same card on two pages is
           just noise. */}
+      {/* v1.3.0: the user's own top-up and purchase history. Above the traffic
+          chart — "where did my money go" is the question that brings people to
+          this page, and it should not sit below a chart. */}
+      <AccountRecords />
+
       {!me.admin && <TrafficChart />}
 
       <Modal

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { aggregateNodesByGroup } from '../components/nodes/aggregate';
 import TrafficChart from '../components/TrafficChart';
 import NodeMetricsChart from '../components/NodeMetricsChart';
 import { formatBps, formatBytes } from '../utils/format';
+import SiteAnnouncement from '../components/SiteAnnouncement';
 
 const { Text } = Typography;
 
@@ -203,6 +204,10 @@ export default function Dashboard() {
 
   return (
     <>
+      {/* v1.3.0: operator announcement. Renders nothing when unset. Sits above
+          the version alerts — it is the operator's own message, and a stale
+          update warning should not push it below the fold. */}
+      <SiteAnnouncement />
       {versionInfo?.check_failed && (
         <Alert
           type="warning"

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import api from '../api/client';
 import type { ApiEnvelope, LoginResponse, RegistrationStatus } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { useAuth } from '../auth/useAuth';
+import { useSite } from '../hooks/useSite';
 
 const { Title, Text } = Typography;
 
@@ -13,6 +14,7 @@ export default function Login() {
   const navigate = useNavigate();
   const { t, lang, setLang } = useI18n();
   const { login } = useAuth();
+  const site = useSite();
   // v0.4.10 PR3: whether to show the "create account" link. null = still
   // loading (don't flash the link then remove it); a network failure leaves
   // it hidden rather than guessing.
@@ -68,8 +70,10 @@ export default function Login() {
       </div>
       <Card style={{ width: 380, boxShadow: 'var(--rp-shadow)' }}>
         <div style={{ textAlign: 'center', marginBottom: 28 }}>
-          <Title level={3} style={{ margin: 0, fontWeight: 600 }}>{t('brand')}</Title>
-          <Text type="secondary" style={{ fontSize: 13 }}>{t('subtitle')}</Text>
+          {/* v1.3.0: operator-configurable branding, falling back to the
+              translated default so an unconfigured panel looks unchanged. */}
+          <Title level={3} style={{ margin: 0, fontWeight: 600 }}>{site.site_name || t('brand')}</Title>
+          <Text type="secondary" style={{ fontSize: 13 }}>{site.subtitle || t('subtitle')}</Text>
         </div>
 
         {/* v0.3.6 / v0.4.22: first-login security reminder. Only shown when

--- a/frontend/src/pages/SiteSettings.tsx
+++ b/frontend/src/pages/SiteSettings.tsx
@@ -1,0 +1,135 @@
+import { Card, Form, Input, Button, message, Spin, Result, Typography } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope, SiteConfig } from '../api/types';
+import { useI18n } from '../i18n/context';
+import { invalidateSite } from '../hooks/useSite';
+import { invalidateSiteNotice } from '../hooks/useSiteNotice';
+
+const { Text } = Typography;
+
+// Mirrors the caps enforced in service::site. Duplicated deliberately: the
+// server is the authority (it truncates), and these only exist so the user is
+// told before submitting rather than silently losing the tail.
+const MAX_NAME = 64;
+const MAX_SUBTITLE = 128;
+const MAX_ANNOUNCEMENT = 4000;
+const MAX_CONTACT = 256;
+
+/**
+ * v1.3.0: site identity — name, subtitle, announcement, support contact.
+ *
+ * Separate from "System Settings", which is registration policy (open
+ * registration / allowed plans / default plan). Different concerns, and folding
+ * them into one page would make both harder to scan.
+ */
+export default function SiteSettings() {
+  const { t } = useI18n();
+  const [form] = Form.useForm<SiteConfig>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [initial, setInitial] = useState<SiteConfig | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setFailed(false);
+    try {
+      const res = await api.get<unknown, ApiEnvelope<SiteConfig>>('/admin/settings/site');
+      if (res.code !== 0 || !res.data) {
+        setFailed(true);
+        return;
+      }
+      // Held in state and handed to the Form as initialValues rather than
+      // pushed with setFieldsValue: the Form is not mounted yet during the
+      // loading render, and calling into a disconnected form instance is what
+      // antd's "useForm is not connected to any Form element" warning is about.
+      setInitial(res.data);
+    } catch {
+      setFailed(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const onSave = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      const res = await api.put<unknown, ApiEnvelope<SiteConfig>>('/admin/settings/site', values);
+      if (res.code !== 0) {
+        message.error(res.message || t('settingsSaveFailed'));
+        return;
+      }
+      // The server trims and clamps; show what actually landed rather than
+      // leaving the form displaying input that was silently adjusted.
+      if (res.data) form.setFieldsValue(res.data);
+      // The brand is cached module-wide and rendered by the sidebar and login
+      // page — drop it so the new name appears without a hard refresh.
+      invalidateSite();
+      invalidateSiteNotice();
+      message.success(t('settingsSaved'));
+    } catch {
+      message.error(t('settingsSaveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div style={{ textAlign: 'center', padding: 48 }}><Spin /></div>;
+
+  if (failed) {
+    return (
+      <Result
+        status="warning"
+        title={t('settingsLoadFailed')}
+        extra={<Button type="primary" onClick={load}>{t('refresh')}</Button>}
+      />
+    );
+  }
+
+  return (
+    <Card
+      title={t('siteSettings')}
+      extra={<Button type="primary" loading={saving} onClick={onSave}>{t('save')}</Button>}
+    >
+      <Form form={form} layout="vertical" style={{ maxWidth: 640 }} initialValues={initial ?? undefined}>
+        <Form.Item
+          name="site_name"
+          label={t('siteName')}
+          extra={t('siteNameHint')}
+          rules={[{ max: MAX_NAME, message: t('siteFieldTooLong') }]}
+        >
+          <Input placeholder="RelayPanel" showCount maxLength={MAX_NAME} />
+        </Form.Item>
+        <Form.Item
+          name="subtitle"
+          label={t('siteSubtitle')}
+          extra={t('siteSubtitleHint')}
+          rules={[{ max: MAX_SUBTITLE, message: t('siteFieldTooLong') }]}
+        >
+          <Input showCount maxLength={MAX_SUBTITLE} />
+        </Form.Item>
+        <Form.Item
+          name="announcement"
+          label={t('siteAnnouncement')}
+          extra={t('siteAnnouncementHint')}
+          rules={[{ max: MAX_ANNOUNCEMENT, message: t('siteFieldTooLong') }]}
+        >
+          <Input.TextArea rows={6} showCount maxLength={MAX_ANNOUNCEMENT} />
+        </Form.Item>
+        <Form.Item
+          name="contact"
+          label={t('siteContact')}
+          extra={t('siteContactHint')}
+          rules={[{ max: MAX_CONTACT, message: t('siteFieldTooLong') }]}
+        >
+          <Input showCount maxLength={MAX_CONTACT} />
+        </Form.Item>
+        <Text type="secondary" style={{ fontSize: 12 }}>{t('siteSettingsHint')}</Text>
+      </Form>
+    </Card>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -29,6 +29,7 @@ const SystemSettings = lazy(() => import('./pages/SystemSettings'));
 const Plans = lazy(() => import('./pages/Plans'));
 const RedeemCodes = lazy(() => import('./pages/RedeemCodes'));
 const AuditLog = lazy(() => import('./pages/AuditLog'));
+const SiteSettings = lazy(() => import('./pages/SiteSettings'));
 const Shop = lazy(() => import('./pages/Shop'));
 const Forbidden = lazy(() => import('./pages/Forbidden'));
 const RoleHome = lazy(() => import('./RoleHome'));
@@ -79,6 +80,9 @@ export const router = createBrowserRouter([
       { path: 'audit-log', element: <RequireAdmin><AuditLog /></RequireAdmin> },
       // v0.4.20: tunnel-profiles route hidden; component kept for future recovery.
       { path: 'users', element: <RequireAdmin><Users /></RequireAdmin> },
+      // v1.3.0: operator-configurable site identity, separate from the
+      // registration policy that lives on /settings.
+      { path: 'site-settings', element: <RequireAdmin><SiteSettings /></RequireAdmin> },
       { path: 'settings', element: <RequireAdmin><SystemSettings /></RequireAdmin> },
       // Account is open to every authenticated user (admin or not).
       { path: 'account', element: <Account /> },


### PR DESCRIPTION
两件事:面板挂不上运营者自己的名字,用户也看不到自己的余额从哪来、花到哪去。

## 一、站点设置(新增独立页面)

和现有「系统设置」分开 —— 那一页装的是注册策略(开放注册 / 可选套餐 / 默认套餐),两类配置塞一页会越堆越乱。

| 字段 | 显示位置 |
|---|---|
| 站点名称 | 登录页、左侧边栏、浏览器标签标题 |
| 副标题 | 登录页名称下方 |
| 公告 | 仪表盘顶部 + 个人中心顶部 |
| 客服联系方式 | 个人中心 |

存成 kvs 里的一个 JSON,和通知配置一样 —— 几个自由文本字段不值得单开列,以后加字段也不用迁移。写入时统一 trim + 截断,**按字符不按字节**:这几个字段最可能填中文,按字节切会切在多字节字符中间直接 panic。行缺失或损坏时仍然回落到可用的品牌名 —— 站点名渲染成空会让每个页面都像坏了,包括运营者要用来修它的那个登录页。

### 刻意分成三个鉴权层级

- `GET /site` **免鉴权** —— 登录页要在任何人拿到 token 之前渲染品牌 —— 只带**名称 + 副标题**
- `GET /user/site-notice` **需登录**,带公告和客服方式
- `PUT /admin/settings/site` 仅管理员,并且**写审计**(只记录哪些字段现在有值,不记内容)

你选的是公告不放登录页。那我就没把它做成公开接口 —— **不显示 ≠ 不暴露**,如果 API 对任何能连上端口的人都吐公告,那个选择就是空的。有一条测试钉住:公开接口能拿到品牌,拿不到公告和客服方式;同时反向断言登录后的接口确实能拿到,否则这条测试会在另一个方向上空过。

## 二、个人中心账目记录

新增「卡密充值记录」+「购买记录」两个 tab,放在流量图上方 —— "我的钱去哪了"才是把人带到这页的问题,不该压在图表下面。

购买记录在**套餐商店页仍然保留**,买完就地看到回执值得这一份重复读取。

卡密查询是**独立的 repo 方法**,不是给管理员那个再加一个 filter:这个接口非管理员可达,uid 过滤必须是结构性的,不能是又一个"后来的调用方可能忘了设"的可选字段。有测试钉住 A 用户读不到 B 用户的充值记录。

卡密**回传时打码**到最后一组(`****-****-****-P0BD`)。码是用户自己输的,显示全码不算泄露给他本人,但会把一个看起来还有效的凭证放进一个经常被截图丢进客服群的页面,而对账只需要那四位。

## 三、一个实机才暴露的问题

保存后侧边栏名字不变 —— `invalidateSite()` 只清了模块缓存,而侧边栏组件已经挂载着,不会重新拉。改成**通知在线订阅者**,并且没有订阅者时只清缓存不发请求(下次挂载自然会拉,提前发是纯浪费)。修完侧边栏和标签标题都随保存实时更新。

## 验证

- 490 个后端测试通过;sqlite / pg 契约 parity(129 / 128);clippy + fmt 干净
- 192 个前端测试通过;tsc + eslint 干净
- **本地起真面板 + 浏览器跑通全流程**:
  - 未配置时公开接口回落 `RelayPanel`
  - 保存中文配置后,登录页 / 侧边栏 / 标签标题全部生效
  - 公开接口不含公告和客服方式;不带 token 读 `/user/site-notice` 返回 **401**
  - 审计记到 `站点名称 示例站点 / 公告 已设置 / 客服 已设置`,不含公告全文
  - 生成卡密 → 充值 → 个人中心显示 `****-****-****-P0BD`,响应里确认无完整卡密
  - 两个 tab 都有数据;控制台无报错

