### PR TITLE
refactor(ui): 管理员菜单收成两个二级分组

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,22 @@ boot; nothing to reconfigure.
   have used, with the code masked to its last group. Purchase history stays on
   the shop page, where buying and reading the receipt happen together.
 
+### Changed
+
+- **The admin menu is grouped into two submenus.** It had reached twelve
+  top-level entries. 用户与计费 holds 用户管理 / 套餐管理 / 卡密管理; 系统设置
+  holds 基础设置 / 通知设置 / 站点设置 / 操作审计. Top level drops to eight.
+
+  Plans and redeem codes are deliberately NOT under 系统设置: they are records
+  you create and delete as routine work, not configuration you set once, and a
+  daily CRUD page buried in "system settings" costs a click every time.
+
+  Regular users are unaffected — their menu was already four entries.
+
+  Notification settings, previously a second card on the system-settings page,
+  are now their own entry at `/notify-settings`; the remaining registration
+  card is retitled 基础设置 so the submenu does not read "系统设置 > 系统设置".
+
 ### Fixed
 
 - **Node metric percentages were multiplied by 100.** CPU and memory arrive

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -484,6 +484,8 @@ export const enUS: Dict = {
   registrationStatusFailed: 'Could not check registration status. Check your connection and retry.',
   retry: 'Retry',
   systemSettings: 'System settings',
+  basicSettings: 'Basic settings',
+  userAndBilling: 'Users & billing',
   registrationEnabled: 'Open registration',
   defaultPlan: 'Default selected plan',
   defaultPlanRequired: 'Please select a default plan.',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -483,6 +483,8 @@ export const zhCN = {
   registrationStatusFailed: '无法获取注册状态，请检查网络后重试。',
   retry: '重试',
   systemSettings: '系统设置',
+  basicSettings: '基础设置',
+  userAndBilling: '用户与计费',
   registrationEnabled: '开放注册',
   defaultPlan: '默认选中套餐',
   defaultPlanRequired: '请选择默认套餐。',

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -10,9 +10,7 @@ import {
   LockOutlined,
   SettingOutlined,
   ShoppingOutlined,
-  GiftOutlined,
-  FileSearchOutlined,
-  GlobalOutlined,
+  TeamOutlined,
 } from '@ant-design/icons';
 import { useI18n } from '../i18n/context';
 import api from '../api/client';
@@ -46,18 +44,51 @@ export default function MainLayout() {
     { key: '/rules', icon: <ApiOutlined />, label: t('myRules') },
     { key: '/nodes', icon: <CloudServerOutlined />, label: t('availableNodes') },
   ];
+  // v1.3.0: the admin list had grown to seven top-level entries. Grouped into
+  // two submenus by what they ARE, not just to shorten the list:
+  //
+  //   billing  — records you create, edit and delete day to day
+  //   system   — configuration you set once, plus the audit trail
+  //
+  // Plans and redeem codes deliberately did NOT go under 系统设置: generating
+  // codes is a routine task, and burying a daily CRUD page inside "system
+  // settings" costs a click every time and misfiles it besides.
+  const billingChildren = [
+    { key: '/users', label: t('users') },
+    { key: '/plans', label: t('planManagement') },
+    { key: '/redeem-codes', label: t('redeemCodes') },
+  ];
+  const systemChildren = [
+    { key: '/settings', label: t('basicSettings') },
+    { key: '/notify-settings', label: t('notifySettings') },
+    { key: '/site-settings', label: t('siteSettings') },
+    { key: '/audit-log', label: t('auditLog') },
+  ];
   const adminOnlyItems = [
     { key: '/groups', icon: <CloudServerOutlined />, label: t('deviceGroups') },
-    { key: '/plans', icon: <ShoppingOutlined />, label: t('planManagement') },
-    { key: '/redeem-codes', icon: <GiftOutlined />, label: t('redeemCodes') },
-    { key: '/users', icon: <UserOutlined />, label: t('users') },
-    { key: '/audit-log', icon: <FileSearchOutlined />, label: t('auditLog') },
-    { key: '/site-settings', icon: <GlobalOutlined />, label: t('siteSettings') },
-    { key: '/settings', icon: <SettingOutlined />, label: t('systemSettings') },
+    {
+      key: 'grp-billing',
+      icon: <TeamOutlined />,
+      label: t('userAndBilling'),
+      children: billingChildren,
+    },
+    {
+      key: 'grp-system',
+      icon: <SettingOutlined />,
+      label: t('systemSettings'),
+      children: systemChildren,
+    },
   ];
   const menuItems = isAdmin
     ? [dashboardItem, ...sharedItems, ...adminOnlyItems]
     : sharedItems;
+
+  // Expand whichever group holds the current page. Computed from the path, not
+  // stored, so landing on /site-settings from a bookmark opens 系统设置 too.
+  const openKeys = [
+    billingChildren.some((c) => c.key === location.pathname) ? 'grp-billing' : '',
+    systemChildren.some((c) => c.key === location.pathname) ? 'grp-system' : '',
+  ].filter(Boolean);
 
   const logout = () => {
     authLogout();
@@ -101,8 +132,11 @@ export default function MainLayout() {
           theme="dark"
           mode="inline"
           selectedKeys={[location.pathname]}
+          defaultOpenKeys={openKeys}
           items={menuItems}
-          onClick={({ key }) => navigate(key)}
+          // Parent entries carry a `grp-` key and no route — clicking one only
+          // expands it, so navigating on them would 404.
+          onClick={({ key }) => { if (!key.startsWith('grp-')) navigate(key); }}
           style={{ borderRight: 0 }}
         />
       </Sider>

--- a/frontend/src/pages/SystemSettings.tsx
+++ b/frontend/src/pages/SystemSettings.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import api from '../api/client';
 import type { ApiEnvelope, Plan, RegistrationSettings } from '../api/types';
 import { useI18n } from '../i18n/context';
-import NotifySettings from './NotifySettings';
 
 const { Text } = Typography;
 
@@ -109,9 +108,8 @@ export default function SystemSettings() {
   const planOptions = plans.map((p) => ({ value: p.id, label: `${p.name} (${p.max_rules} ${t('rules')})` }));
 
   return (
-    <>
     <Card
-      title={t('systemSettings')}
+      title={t('basicSettings')}
       extra={<Button type="primary" loading={saving} onClick={onSave}>{t('save')}</Button>}
     >
       <Form form={form} layout="vertical">
@@ -163,9 +161,5 @@ export default function SystemSettings() {
         </Text>
       </Form>
     </Card>
-    {/* v1.2.0: node-offline alerting. Its own card + form so saving one
-        section can never submit the other. */}
-    <NotifySettings />
-    </>
   );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -30,6 +30,7 @@ const Plans = lazy(() => import('./pages/Plans'));
 const RedeemCodes = lazy(() => import('./pages/RedeemCodes'));
 const AuditLog = lazy(() => import('./pages/AuditLog'));
 const SiteSettings = lazy(() => import('./pages/SiteSettings'));
+const NotifySettings = lazy(() => import('./pages/NotifySettings'));
 const Shop = lazy(() => import('./pages/Shop'));
 const Forbidden = lazy(() => import('./pages/Forbidden'));
 const RoleHome = lazy(() => import('./RoleHome'));
@@ -84,6 +85,9 @@ export const router = createBrowserRouter([
       // registration policy that lives on /settings.
       { path: 'site-settings', element: <RequireAdmin><SiteSettings /></RequireAdmin> },
       { path: 'settings', element: <RequireAdmin><SystemSettings /></RequireAdmin> },
+      // v1.3.0: notification settings were a second card on /settings; they
+      // are their own entry now that 系统设置 is a submenu.
+      { path: 'notify-settings', element: <RequireAdmin><NotifySettings /></RequireAdmin> },
       // Account is open to every authenticated user (admin or not).
       { path: 'account', element: <Account /> },
       // v0.4.10: explicit 403 page for admin-only routes a regular user


### PR DESCRIPTION
管理员侧边栏已经 12 项了,确实该收。分组按**页面的性质**来,而不只是为了让列表变短:

| 用户与计费 | 系统设置 |
|---|---|
| 用户管理 | 基础设置 |
| 套餐管理 | 通知设置 |
| 卡密管理 | 站点设置 |
| | 操作审计 |

顶层从 **12 项降到 8 项**。普通用户不受影响 —— 他们的菜单本来就只有 4 项,拥挤纯粹是管理员侧的问题。

## 一处和原方案不同

**套餐管理和卡密管理没有放进系统设置**(最初提的是放进去)。它们不是设置:卡密要不断生成、筛选、作废、删除,套餐要上下架调价,都是日常操作。把每天要点的 CRUD 页面埋进"系统设置"二级,既多一次点击,归类上也说不通 —— 没人会去"系统设置"里找今天要发的卡密。设置是配一次就放着不动的东西。

## 两个连带改动

**通知设置拆出独立路由。** 它原来是系统设置页里的第二张卡片,没有自己的路由 —— 要变成菜单项就必须有。现在在 `/notify-settings`,原页面只剩注册那张卡。

**那张卡改名叫「基础设置」。** 它原来标题就叫「系统设置」,变成同名父菜单的子项后会读成"系统设置 > 系统设置"。

## 实现细节

父项用 `grp-` 前缀的 key 且不对应任何路由,点击处理器跳过它们 —— 否则展开分组会导航到一个不存在的路径。展开哪一组由当前路径推导,所以从书签或刷新进来时对应分组已经是展开的。

## 验证

- 492 后端 / 221 前端测试;typecheck、lint、fmt、clippy 干净
- **浏览器实测**(1400px 宽):
  - 顶层 8 项,两个分组正确渲染
  - 全新加载 `/site-settings` → 系统设置自动展开,选中「站点设置」;全新加载 `/plans` → 用户与计费自动展开
  - 点父项只展开、**不跳转**(路径保持不变)
  - `/settings` 只剩「基础设置」一张卡,通知字段确认已不在该页
  - `/notify-settings` 正常加载,Telegram / 邮件卡片都在
  - 普通用户菜单仍是 4 项、无分组,直接访问 `/notify-settings` 被挡到 403

一个过程记录:第一次测的时候分组没展开,查下来是浏览器面板只有 783px 宽、侧边栏按 `lg` 断点自动收起了 —— 收起态 antd 用悬浮弹出,`openKeys` 本来就不生效。放宽视口后正常,不是 bug。
