### PR TITLE
refactor(announcements): 公告入口改为顶栏铃铛 + 未读红点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ boot; nothing to reconfigure.
   Migration 44 / PG revision 27 carry the existing announcement out of the site
   config into the new table, so upgrading does not blank a notice that is live.
 
+  The entry point is a bell in the header rather than a sidebar row. The banner
+  already carries the current notice, so a menu row would only be a route to
+  the archive — a low-frequency destination sitting beside pages people use
+  daily. A bell also does what a menu row cannot: show a dot when something is
+  new. Unread is "latest id > the id this account last opened", kept in
+  localStorage per account; the server stores no per-user read state, which
+  would be a table and a write on every page view for a dot.
+
 ### Changed
 
 - **The admin menu is grouped into two submenus.** It had reached twelve

--- a/crates/panel/src/api/announcements.rs
+++ b/crates/panel/src/api/announcements.rs
@@ -90,6 +90,28 @@ pub async fn active_for_user(
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct LatestId {
+    pub latest_id: i64,
+}
+
+/// GET /api/v1/user/announcements/latest-id
+///
+/// Feeds the header bell. Returns 0 when there are no announcements at all, so
+/// a fresh install shows no dot rather than a permanent one.
+pub async fn latest_id(
+    _user: AuthUser,
+    State(state): State<AppState>,
+) -> Json<ApiResponse<LatestId>> {
+    match state.db.latest_announcement_id().await {
+        Ok(latest_id) => Json(ApiResponse::success(LatestId { latest_id })),
+        Err(e) => {
+            tracing::error!("latest_announcement_id: {}", e);
+            Json(err(500, "数据库错误"))
+        }
+    }
+}
+
 /// GET /api/v1/admin/announcements — same archive, for the management page.
 pub async fn list_for_admin(
     _admin: AdminOnly,

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -61,6 +61,10 @@ pub fn routes() -> Router<AppState> {
             axum::routing::get(announcements::active_for_user),
         )
         .route(
+            "/user/announcements/latest-id",
+            axum::routing::get(announcements::latest_id),
+        )
+        .route(
             "/admin/announcements",
             axum::routing::get(announcements::list_for_admin).post(announcements::create),
         )

--- a/crates/panel/src/db/pg_repo/announcements.rs
+++ b/crates/panel/src/db/pg_repo/announcements.rs
@@ -114,4 +114,11 @@ impl AnnouncementRepository for PgRepository {
             .await?
             .rows_affected())
     }
+    async fn latest_announcement_id(&self) -> Result<i64, DbError> {
+        Ok(
+            sqlx::query_scalar("SELECT COALESCE(MAX(id), 0) FROM announcements")
+                .fetch_one(&self.pool)
+                .await?,
+        )
+    }
 }

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -811,6 +811,14 @@ pub trait AnnouncementRepository: Send + Sync {
     async fn update_announcement(&self, id: i64, a: &NewAnnouncement) -> Result<u64, DbError>;
 
     async fn delete_announcement(&self, id: i64) -> Result<u64, DbError>;
+
+    /// Highest announcement id, or 0 when there are none.
+    ///
+    /// Drives the header bell's unread dot: the client stores the id it last
+    /// looked at and compares. Deliberately the id and not a timestamp —
+    /// editing an old notice must not re-notify everyone, and only a new row
+    /// raises the maximum.
+    async fn latest_announcement_id(&self) -> Result<i64, DbError>;
 }
 
 /// An audit entry being written.

--- a/crates/panel/src/db/sqlite_repo/announcements.rs
+++ b/crates/panel/src/db/sqlite_repo/announcements.rs
@@ -111,4 +111,11 @@ impl AnnouncementRepository for SqliteRepository {
             .await?
             .rows_affected())
     }
+    async fn latest_announcement_id(&self) -> Result<i64, DbError> {
+        Ok(
+            sqlx::query_scalar("SELECT COALESCE(MAX(id), 0) FROM announcements")
+                .fetch_one(&self.pool)
+                .await?,
+        )
+    }
 }

--- a/frontend/src/hooks/useAnnouncementBadge.test.tsx
+++ b/frontend/src/hooks/useAnnouncementBadge.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('../api/client', () => ({ default: { get: mockGet } }));
+
+import { useAnnouncementBadge, resetAnnouncementBadgeCache } from './useAnnouncementBadge';
+
+const ok = (latest_id: number) => ({ code: 0, message: 'ok', data: { latest_id } });
+
+beforeEach(() => {
+  mockGet.mockReset();
+  localStorage.clear();
+  resetAnnouncementBadgeCache();
+});
+
+describe('useAnnouncementBadge', () => {
+  it('shows the dot when there is an announcement nobody on this account has opened', async () => {
+    mockGet.mockResolvedValue(ok(7));
+    const { result } = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(result.current.latestId).toBe(7));
+    expect(result.current.unread).toBe(true);
+  });
+
+  it('clears the dot once marked seen, and keeps it clear', async () => {
+    mockGet.mockResolvedValue(ok(7));
+    const { result } = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(result.current.latestId).toBe(7));
+
+    act(() => result.current.markSeen());
+    expect(result.current.unread).toBe(false);
+
+    // A fresh mount for the same account stays clear — the marker persisted.
+    const second = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(second.result.current.latestId).toBe(7));
+    expect(second.result.current.unread).toBe(false);
+  });
+
+  it('clears the dot on OTHER mounted instances, not just the one that marked', async () => {
+    // The header bell and the archive page each hold an instance, and the PAGE
+    // is what marks seen. With per-instance state the bell kept its stale copy
+    // and the dot stayed lit until a full reload — which is exactly when
+    // someone is looking at it. This is the regression that caught me.
+    mockGet.mockResolvedValue(ok(7));
+    const bell = renderHook(() => useAnnouncementBadge(1));
+    const page = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(bell.result.current.latestId).toBe(7));
+    await waitFor(() => expect(page.result.current.latestId).toBe(7));
+    expect(bell.result.current.unread).toBe(true);
+
+    act(() => page.result.current.markSeen());
+
+    expect(page.result.current.unread).toBe(false);
+    expect(bell.result.current.unread).toBe(false);
+  });
+
+  it('lights up again when a newer announcement appears', async () => {
+    mockGet.mockResolvedValue(ok(7));
+    const { result } = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(result.current.latestId).toBe(7));
+    act(() => result.current.markSeen());
+
+    mockGet.mockResolvedValue(ok(8));
+    const next = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(next.result.current.latestId).toBe(8));
+    expect(next.result.current.unread).toBe(true);
+  });
+
+  it('keeps the marker per account', async () => {
+    // A shared browser must not let one account's "seen" suppress another's
+    // dot — the marker is keyed by user id for exactly this.
+    mockGet.mockResolvedValue(ok(7));
+    const first = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(first.result.current.latestId).toBe(7));
+    act(() => first.result.current.markSeen());
+
+    const other = renderHook(() => useAnnouncementBadge(2));
+    await waitFor(() => expect(other.result.current.latestId).toBe(7));
+    expect(other.result.current.unread).toBe(true);
+  });
+
+  it('shows no dot on an install with no announcements', async () => {
+    // latest_id 0 must not read as "something newer than 0 exists".
+    mockGet.mockResolvedValue(ok(0));
+    const { result } = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(result.current.latestId).toBe(0));
+    expect(result.current.unread).toBe(false);
+  });
+
+  it('shows no dot when the request fails', async () => {
+    // A bell that lights up because a request failed trains people to ignore it.
+    mockGet.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useAnnouncementBadge(1));
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(result.current.unread).toBe(false);
+  });
+
+  it('does not call the endpoint before the account is known', async () => {
+    renderHook(() => useAnnouncementBadge(null));
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useAnnouncementBadge.ts
+++ b/frontend/src/hooks/useAnnouncementBadge.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope } from '../api/types';
+
+/**
+ * v1.3.0: unread state for the header announcement bell.
+ *
+ * "Unread" is `latest id > the id this account last looked at`. The id, not a
+ * timestamp: editing an old notice must not re-notify everyone, and only a new
+ * row raises the maximum.
+ *
+ * The seen marker is per account and lives in localStorage — the server keeps
+ * no per-user read state, which would be a table and a write on every page view
+ * for a dot. The cost is that the dot returns on a new browser, which is the
+ * right way for this to be wrong.
+ *
+ * The marker is exposed through useSyncExternalStore rather than per-instance
+ * component state. The header bell and the archive page each hold their own
+ * instance of this hook and the PAGE is what marks things seen; with local
+ * state the bell kept its stale copy and the dot stayed lit until a full
+ * reload — exactly when someone is looking at it.
+ */
+const KEY_PREFIX = 'relaypanel_ann_seen_';
+
+const listeners = new Set<() => void>();
+
+/** In-memory mirror so getSnapshot is cheap and returns a stable number. */
+const cache = new Map<string, number>();
+
+function seenKey(userId: number | null): string | null {
+  return userId == null ? null : `${KEY_PREFIX}${userId}`;
+}
+
+function getSeen(userId: number | null): number {
+  const k = seenKey(userId);
+  if (!k) return 0;
+  const hit = cache.get(k);
+  if (hit !== undefined) return hit;
+  const raw = localStorage.getItem(k);
+  const n = raw ? Number(raw) : 0;
+  const val = Number.isFinite(n) ? n : 0;
+  cache.set(k, val);
+  return val;
+}
+
+function setSeen(userId: number | null, id: number) {
+  const k = seenKey(userId);
+  if (!k) return;
+  localStorage.setItem(k, String(id));
+  cache.set(k, id);
+  listeners.forEach((fn) => fn());
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+export interface AnnouncementBadge {
+  latestId: number;
+  unread: boolean;
+  /** Call when the archive has actually been shown. */
+  markSeen: () => void;
+}
+
+export function useAnnouncementBadge(userId: number | null): AnnouncementBadge {
+  const [latestId, setLatestId] = useState(0);
+  const seen = useSyncExternalStore(subscribe, () => getSeen(userId));
+
+  useEffect(() => {
+    if (userId == null) return;
+    let alive = true;
+    api
+      .get<unknown, ApiEnvelope<{ latest_id: number }>>('/user/announcements/latest-id')
+      .then((res) => {
+        if (alive && res.code === 0 && res.data) setLatestId(res.data.latest_id);
+      })
+      // No dot is the right failure mode: a bell that lights up because a
+      // request failed would train people to ignore it.
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [userId]);
+
+  const markSeen = useCallback(() => {
+    if (userId == null || latestId <= 0) return;
+    setSeen(userId, latestId);
+  }, [userId, latestId]);
+
+  return { latestId, unread: latestId > seen, markSeen };
+}
+
+/** Test helper: drop the in-memory mirror so a cleared localStorage is re-read. */
+export function resetAnnouncementBadgeCache() {
+  cache.clear();
+  listeners.forEach((fn) => fn());
+}

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Layout, Menu, Button, Space, Typography, Segmented, Modal, Form, Input, message, Spin } from 'antd';
+import { Layout, Menu, Button, Space, Typography, Segmented, Modal, Form, Input, message, Spin, Badge, Tooltip } from 'antd';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useState, Suspense } from 'react';
 import {
@@ -18,6 +18,7 @@ import api from '../api/client';
 import type { ApiEnvelope } from '../api/types';
 import { useAuth } from '../auth/useAuth';
 import { useSite } from '../hooks/useSite';
+import { useAnnouncementBadge } from '../hooks/useAnnouncementBadge';
 import { makePasswordValidator } from '../utils/password';
 
 const { Sider, Content, Header } = Layout;
@@ -27,8 +28,11 @@ export default function MainLayout() {
   const navigate = useNavigate();
   const location = useLocation();
   const { t, lang, setLang } = useI18n();
-  const { isAdmin, logout: authLogout } = useAuth();
+  const { isAdmin, user, logout: authLogout } = useAuth();
   const site = useSite();
+  // Marked seen by the archive page itself, so the dot clears only once the
+  // notices have actually been shown.
+  const { unread } = useAnnouncementBadge(user?.id ?? null);
   const [changePwOpen, setChangePwOpen] = useState(false);
   const [pwForm] = Form.useForm();
   const [pwSubmitting, setPwSubmitting] = useState(false);
@@ -44,9 +48,6 @@ export default function MainLayout() {
     { key: '/shop', icon: <ShoppingOutlined />, label: t('shop') },
     { key: '/rules', icon: <ApiOutlined />, label: t('myRules') },
     { key: '/nodes', icon: <CloudServerOutlined />, label: t('availableNodes') },
-    // v1.3.0: the archive is for everyone — a regular user's only way to
-    // read a notice the banner has already replaced.
-    { key: '/announcements', icon: <NotificationOutlined />, label: t('announcements') },
   ];
   // v1.3.0: the admin list had grown to seven top-level entries. Grouped into
   // two submenus by what they ARE, not just to shorten the list:
@@ -153,6 +154,22 @@ export default function MainLayout() {
           borderBottom: '1px solid var(--rp-border)',
         }}>
           <Space size="middle">
+            {/* v1.3.0: announcements live here rather than in the sidebar.
+                The banner already carries the current notice, so a menu row
+                would only be a route to the archive — a low-frequency
+                destination sitting beside pages people use daily. A bell also
+                does what a menu row cannot: say that something is new. */}
+            <Tooltip title={t('announcements')}>
+              <Badge dot={unread} offset={[-2, 2]}>
+                <Button
+                  type="text"
+                  size="small"
+                  aria-label={t('announcements')}
+                  icon={<NotificationOutlined />}
+                  onClick={() => navigate('/announcements')}
+                />
+              </Badge>
+            </Tooltip>
             <Segmented
               size="small"
               value={lang}

--- a/frontend/src/pages/Announcements.tsx
+++ b/frontend/src/pages/Announcements.tsx
@@ -4,6 +4,8 @@ import api from '../api/client';
 import type { ApiEnvelope, Announcement, AnnouncementList } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { renderMarkdown } from '../utils/markdown';
+import { useAnnouncementBadge } from '../hooks/useAnnouncementBadge';
+import { useAuth } from '../auth/useAuth';
 
 const { Text, Title } = Typography;
 
@@ -26,6 +28,8 @@ const TAG_COLOR: Record<string, string> = {
  */
 export default function Announcements() {
   const { t } = useI18n();
+  const { user } = useAuth();
+  const { latestId, markSeen } = useAnnouncementBadge(user?.id ?? null);
   const [items, setItems] = useState<Announcement[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -53,6 +57,12 @@ export default function Announcements() {
   }, [page]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Clear the header dot once the archive has actually rendered — marking on
+  // click would clear it even if the page then failed to load.
+  useEffect(() => {
+    if (latestId > 0) markSeen();
+  }, [latestId, markSeen]);
 
   const isExpired = (a: Announcement) =>
     !!a.expires_at && a.expires_at <= new Date().toISOString().slice(0, 19).replace('T', ' ');


### PR DESCRIPTION
你截图那个位置(共享区末尾、紧挨管理员区)确实尴尬。但我认为**更根本的问题是它该不该占一个侧边栏位置**:

- 当前公告已经由横幅在仪表盘和个人中心顶部显示,横幅上还有「查看全部公告」链接
- 所以这个菜单项唯一的用途是**翻历史** —— 低频操作,却和「我的规则」「节点状态」这些天天点的并排

直接删掉又不行:**没有生效公告时横幅不显示**,那条链接也没了,用户除了手敲 URL 进不了归档。所以入口必须常驻。

改成**顶栏铃铛**。它还能做菜单项做不到的事:**告诉用户有新公告**。

## 未读怎么算

`最大公告 id > 本账号上次打开时记录的 id`。

用 **id 而不是时间戳**:编辑旧公告不该重新提醒所有人,只有新增才会抬高最大值。`GET /user/announcements/latest-id` 返回这个最大值,没有公告时返回 0,所以全新安装不会挂一个永远消不掉的红点。

标记按账号存在 localStorage。服务端**不存每用户已读状态** —— 那要建一张表、每次浏览都写一次,只为一个小红点。代价是换浏览器红点会重现,这是这件事出错时比较能接受的方向。

## 一个我自己踩的坑

第一版红点点进去不消。原因是顶栏和归档页各持有一个 hook 实例,而**标记已读的是页面那个**,顶栏保留了自己那份过时状态,要整页刷新才消 —— 恰恰是用户正盯着它的时候。

改用 `useSyncExternalStore` 把标记做成共享 store 后解决。**我原来的测试没抓到这个**,因为它们是串行挂载两个实例而不是同时存在。现在补了一条同时挂载的测试,并**做了变异验证**:退回成 per-instance state 后,那条测试立刻红。

## 验证

- 507 后端 / 229 前端测试;parity、clippy、fmt、typecheck、lint 干净
- 浏览器实测:铃铛在顶栏、未读时有红点、点击跳转归档(4 条)、localStorage 写入 `relaypanel_ann_seen_3=4`、刷新后红点不再出现;侧边栏回到 4 项

**一处没能目视确认**:点击后红点的消失动画在这个浏览器面板里播不完(面板不合成帧,`animationend` 不触发,rc-motion 把元素留在 DOM 里并停在 `zoom-leave-start`)。状态层面已确认 `unread` 翻成 false —— React 已决定移除该元素,刷新路径也确实不显示 —— 但"看着它消失"这一步我没做到。合并后你在测试机上点一下确认。
