### PR TITLE
feat(admin): 全部购买记录 + 公告样式中文 + 仪表盘去掉公告横幅

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,19 @@ boot; nothing to reconfigure.
 
 ### Changed
 
+- **All users' purchases are listed under plan management.** The shop page shows
+  a user their own orders; this is the operator's view of every one, which is
+  what answers "who bought what this week". Paginated — that table only grows.
+
+- **The announcement banner is gone from the dashboard.** It stays on the
+  account page, which is where regular users land; the dashboard is admin-only,
+  and admins have the header bell.
+
+- Announcement severities render as words rather than the wire values
+  `info` / `success` / `warning` / `error`.
+
+
+
 - **The admin menu is grouped into two submenus.** It had reached twelve
   top-level entries. 用户与计费 holds 用户管理 / 套餐管理 / 卡密管理; 系统设置
   holds 基础设置 / 通知设置 / 站点设置 / 操作审计. Top level drops to eight.

--- a/crates/panel/src/api/admin/shop.rs
+++ b/crates/panel/src/api/admin/shop.rs
@@ -187,6 +187,85 @@ pub async fn buy_plan(
 }
 
 /// GET /user/orders — the calling user's purchase history, newest first.
+/// v1.3.0: one order with the buyer's name resolved for display.
+#[derive(Debug, serde::Serialize)]
+pub struct AdminOrderRow {
+    pub id: i64,
+    pub user_id: i64,
+    /// None when the account was deleted — the order row survives as the
+    /// money-in record, so the id is kept and only the name goes missing.
+    pub username: Option<String>,
+    pub plan_name: String,
+    pub price: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct AdminOrdersQuery {
+    #[serde(default)]
+    pub limit: Option<i64>,
+    #[serde(default)]
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct AdminOrdersResponse {
+    pub items: Vec<AdminOrderRow>,
+    pub total: i64,
+}
+
+/// GET /api/v1/admin/orders — every user's purchases.
+///
+/// The shop page shows the caller their own; this is the operator's view of
+/// all of them, which is what answers "who bought what this week".
+pub async fn list_all_orders(
+    _admin: crate::api::middleware::AdminOnly,
+    State(state): State<AppState>,
+    axum::extract::Query(q): axum::extract::Query<AdminOrdersQuery>,
+) -> Json<ApiResponse<AdminOrdersResponse>> {
+    let limit = q.limit.unwrap_or(20).clamp(1, 200);
+    let offset = q.offset.unwrap_or(0).max(0);
+
+    let total = match state.db.count_all_orders().await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!("list_all_orders: count failed: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
+    let orders = match state.db.list_all_orders(limit, offset).await {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::error!("list_all_orders: query failed: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
+
+    // One user fetch for the page, not one per row — the same shape the redeem
+    // list uses. An id that no longer resolves stays None rather than blocking
+    // the page: the order outlives the account on purpose.
+    let names: std::collections::HashMap<i64, String> = match state.db.list_users_public().await {
+        Ok(users) => users.into_iter().map(|u| (u.id, u.username)).collect(),
+        Err(e) => {
+            tracing::error!("list_all_orders: user lookup failed: {}", e);
+            return Json(err(500, "数据库错误"));
+        }
+    };
+
+    let items = orders
+        .into_iter()
+        .map(|o| AdminOrderRow {
+            id: o.id,
+            user_id: o.user_id,
+            username: names.get(&o.user_id).cloned(),
+            plan_name: o.plan_name,
+            price: o.price,
+            created_at: o.created_at,
+        })
+        .collect();
+    Json(ApiResponse::success(AdminOrdersResponse { items, total }))
+}
+
 pub async fn list_my_orders(
     user: AuthUser,
     State(state): State<AppState>,

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -89,6 +89,9 @@ pub fn routes() -> Router<AppState> {
         // v1.0.8: self-service plan purchase + order history.
         .route("/user/buy-plan", axum::routing::post(admin::buy_plan))
         .route("/user/orders", axum::routing::get(admin::list_my_orders))
+        // v1.3.0: every user's orders, for the plan-management page. Admin-only
+        // and paginated — this table only grows.
+        .route("/admin/orders", axum::routing::get(admin::list_all_orders))
         // v1.2.0: self-service balance top-up. Scoped to the caller's own id
         // from the token — there is no user_id in the body, so it can never
         // credit another account.

--- a/crates/panel/src/db/pg_repo/orders.rs
+++ b/crates/panel/src/db/pg_repo/orders.rs
@@ -37,4 +37,21 @@ impl OrderRepository for PgRepository {
         .await?;
         Ok(())
     }
+    async fn list_all_orders(&self, limit: i64, offset: i64) -> Result<Vec<Order>, DbError> {
+        // id DESC breaks ties: several purchases can land in the same second,
+        // and only the id gives a stable total order for pagination.
+        Ok(sqlx::query_as(
+            "SELECT * FROM orders ORDER BY created_at DESC, id DESC LIMIT $1 OFFSET $2",
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
+    async fn count_all_orders(&self) -> Result<i64, DbError> {
+        Ok(sqlx::query_scalar("SELECT COUNT(*) FROM orders")
+            .fetch_one(&self.pool)
+            .await?)
+    }
 }

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -5429,3 +5429,62 @@ async fn pg_update_and_delete_report_a_missing_row() {
     );
     assert_eq!(db.delete_announcement(999).await.unwrap(), 0);
 }
+
+// ── v1.3.0: admin-wide order list ──
+
+/// The admin list spans every account, unlike list_orders_by_user. Getting this
+/// wrong in the other direction — scoping it to the caller — would make the
+/// operator's view silently show only their own purchases.
+#[tokio::test]
+async fn pg_admin_order_list_spans_all_users() {
+    let Some(db) = repo("ord_all").await else {
+        return;
+    };
+    db.insert_user("alice", "h", 1).await.unwrap();
+    db.insert_user("bob", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+    let bob = db.find_by_username("bob").await.unwrap().unwrap().id;
+
+    db.insert_order(alice, Some(1), "basic", "10.00")
+        .await
+        .unwrap();
+    db.insert_order(bob, Some(1), "pro", "50.00").await.unwrap();
+
+    assert_eq!(db.count_all_orders().await.unwrap(), 2);
+    let all = db.list_all_orders(50, 0).await.unwrap();
+    assert_eq!(all.len(), 2);
+    let mut buyers: Vec<i64> = all.iter().map(|o| o.user_id).collect();
+    buyers.sort_unstable();
+    assert_eq!(buyers, vec![alice, bob]);
+
+    // The per-user list still sees only its own — the two must not converge.
+    assert_eq!(db.list_orders_by_user(alice).await.unwrap().len(), 1);
+}
+
+/// Pagination must partition the rows, not repeat or drop any. Orders routinely
+/// share a created_at second, which is why the ordering falls back to the id.
+#[tokio::test]
+async fn pg_admin_order_list_pages_without_overlap() {
+    let Some(db) = repo("ord_page").await else {
+        return;
+    };
+    db.insert_user("alice", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+    for name in ["a", "b", "c"] {
+        db.insert_order(alice, Some(1), name, "1.00").await.unwrap();
+    }
+
+    let page1 = db.list_all_orders(2, 0).await.unwrap();
+    let page2 = db.list_all_orders(2, 2).await.unwrap();
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page2.len(), 1);
+
+    let mut ids: Vec<i64> = page1.iter().chain(page2.iter()).map(|o| o.id).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        3,
+        "the two pages must cover all three rows exactly once"
+    );
+}

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -1227,6 +1227,12 @@ pub trait SettingsRepository: Send + Sync {
 pub trait OrderRepository: Send + Sync {
     /// List a user's orders, newest first.
     async fn list_orders_by_user(&self, user_id: i64) -> Result<Vec<Order>, DbError>;
+    /// v1.3.0: every user's orders, newest first, for the admin view.
+    ///
+    /// Paginated rather than returning the lot: this table only grows, and the
+    /// per-user list it sits beside is naturally small enough not to need it.
+    async fn list_all_orders(&self, limit: i64, offset: i64) -> Result<Vec<Order>, DbError>;
+    async fn count_all_orders(&self) -> Result<i64, DbError>;
     /// Insert an order row (snapshots plan_name + price). Used inside the
     /// purchase transaction.
     async fn insert_order(

--- a/crates/panel/src/db/sqlite_repo/orders.rs
+++ b/crates/panel/src/db/sqlite_repo/orders.rs
@@ -35,4 +35,21 @@ impl OrderRepository for SqliteRepository {
             .await?;
         Ok(())
     }
+    async fn list_all_orders(&self, limit: i64, offset: i64) -> Result<Vec<Order>, DbError> {
+        // id DESC breaks ties: several purchases can land in the same second,
+        // and only the id gives a stable total order for pagination.
+        Ok(sqlx::query_as(
+            "SELECT * FROM orders ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
+    async fn count_all_orders(&self) -> Result<i64, DbError> {
+        Ok(sqlx::query_scalar("SELECT COUNT(*) FROM orders")
+            .fetch_one(&self.pool)
+            .await?)
+    }
 }

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -5329,3 +5329,58 @@ async fn update_and_delete_report_a_missing_row() {
     );
     assert_eq!(db.delete_announcement(999).await.unwrap(), 0);
 }
+
+// ── v1.3.0: admin-wide order list ──
+
+/// The admin list spans every account, unlike list_orders_by_user. Getting this
+/// wrong in the other direction — scoping it to the caller — would make the
+/// operator's view silently show only their own purchases.
+#[tokio::test]
+async fn admin_order_list_spans_all_users() {
+    let db = repo().await;
+    db.insert_user("alice", "h", 1).await.unwrap();
+    db.insert_user("bob", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+    let bob = db.find_by_username("bob").await.unwrap().unwrap().id;
+
+    db.insert_order(alice, Some(1), "basic", "10.00")
+        .await
+        .unwrap();
+    db.insert_order(bob, Some(1), "pro", "50.00").await.unwrap();
+
+    assert_eq!(db.count_all_orders().await.unwrap(), 2);
+    let all = db.list_all_orders(50, 0).await.unwrap();
+    assert_eq!(all.len(), 2);
+    let mut buyers: Vec<i64> = all.iter().map(|o| o.user_id).collect();
+    buyers.sort_unstable();
+    assert_eq!(buyers, vec![alice, bob]);
+
+    // The per-user list still sees only its own — the two must not converge.
+    assert_eq!(db.list_orders_by_user(alice).await.unwrap().len(), 1);
+}
+
+/// Pagination must partition the rows, not repeat or drop any. Orders routinely
+/// share a created_at second, which is why the ordering falls back to the id.
+#[tokio::test]
+async fn admin_order_list_pages_without_overlap() {
+    let db = repo().await;
+    db.insert_user("alice", "h", 1).await.unwrap();
+    let alice = db.find_by_username("alice").await.unwrap().unwrap().id;
+    for name in ["a", "b", "c"] {
+        db.insert_order(alice, Some(1), name, "1.00").await.unwrap();
+    }
+
+    let page1 = db.list_all_orders(2, 0).await.unwrap();
+    let page2 = db.list_all_orders(2, 2).await.unwrap();
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page2.len(), 1);
+
+    let mut ids: Vec<i64> = page1.iter().chain(page2.iter()).map(|o| o.id).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        3,
+        "the two pages must cover all three rows exactly once"
+    );
+}

--- a/frontend/src/components/AllOrders.test.tsx
+++ b/frontend/src/components/AllOrders.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('../api/client', () => ({ default: { get: mockGet } }));
+
+import AllOrders from './AllOrders';
+
+const ok = <T,>(data: T) => ({ code: 0, message: 'ok', data });
+
+const rows = [
+  { id: 2, user_id: 5, username: 'zhangsan', plan_name: '广港', price: '50.00', created_at: '2026-07-28 10:00:00' },
+  { id: 1, user_id: 9, username: null, plan_name: 'Free', price: '9.90', created_at: '2026-07-27 09:00:00' },
+];
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockGet.mockResolvedValue(ok({ items: rows, total: 2 }));
+});
+
+const renderCard = async () => { await act(async () => { render(<AllOrders />); }); };
+
+describe('AllOrders', () => {
+  it('reads the admin endpoint, not the per-user one', async () => {
+    // /user/orders is scoped to the caller; using it here would silently show
+    // the operator only their own purchases.
+    await renderCard();
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/admin/orders');
+    expect(url).not.toContain('/user/orders');
+  });
+
+  it('shows the buyer name', async () => {
+    await renderCard();
+    expect(screen.getByText('zhangsan')).toBeInTheDocument();
+    expect(screen.getByText('广港')).toBeInTheDocument();
+  });
+
+  it('falls back to the id when the buyer account was deleted', async () => {
+    // The order row outlives the account on purpose — it is the money-in
+    // record — so a missing name must not blank the row.
+    await renderCard();
+    expect(screen.getByText('#9')).toBeInTheDocument();
+  });
+
+  it('renders an empty state rather than failing when the request errors', async () => {
+    mockGet.mockRejectedValue(new Error('network'));
+    await renderCard();
+    expect(screen.getByText('noOrdersAll')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AllOrders.tsx
+++ b/frontend/src/components/AllOrders.tsx
@@ -1,0 +1,110 @@
+import { Card, Table, Typography } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+import api from '../api/client';
+import type { ApiEnvelope } from '../api/types';
+import { useI18n } from '../i18n/context';
+
+const { Text } = Typography;
+
+const PAGE_SIZE = 20;
+
+/** One row of the operator-wide purchase list. */
+interface AdminOrderRow {
+  id: number;
+  user_id: number;
+  /** null when the buyer's account was deleted — the order survives as the
+   *  money-in record, so the id is kept and only the name goes missing. */
+  username: string | null;
+  plan_name: string;
+  price: string;
+  created_at: string;
+}
+
+/**
+ * v1.3.0: every user's purchases, under the plan-management table.
+ *
+ * The shop page shows a user their own orders; this is the operator's view of
+ * all of them, which is what answers "who bought what this week". Paginated
+ * because this table only grows — the per-user list it mirrors is naturally
+ * small enough not to need it.
+ */
+export default function AllOrders() {
+  const { t } = useI18n();
+  const [items, setItems] = useState<AdminOrderRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        offset: String((page - 1) * PAGE_SIZE),
+      });
+      const res = await api.get<unknown, ApiEnvelope<{ items: AdminOrderRow[]; total: number }>>(
+        `/admin/orders?${qs}`,
+      );
+      if (res.code === 0 && res.data) {
+        setItems(res.data.items);
+        setTotal(res.data.total);
+      }
+    } catch {
+      // An unreachable list shows its empty state rather than an error box on
+      // a page whose main job is managing plans.
+    } finally {
+      setLoading(false);
+    }
+  }, [page]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const columns = [
+    { title: t('orderId'), dataIndex: 'id', key: 'id', width: 80 },
+    {
+      title: t('orderUser'),
+      key: 'user',
+      width: 160,
+      // Falls back to the id so a deleted account still identifies the buyer
+      // as far as the data allows.
+      render: (_: unknown, r: AdminOrderRow) =>
+        r.username ?? <Text type="secondary">#{r.user_id}</Text>,
+    },
+    { title: t('planName'), dataIndex: 'plan_name', key: 'plan_name' },
+    {
+      title: t('planPrice'),
+      dataIndex: 'price',
+      key: 'price',
+      width: 110,
+      render: (v: string) => <span className="rp-mono">{v}</span>,
+    },
+    {
+      title: t('purchaseTime'),
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 180,
+      render: (v: string) => <span className="rp-mono">{v}</span>,
+    },
+  ];
+
+  return (
+    <Card title={t('allOrders')} style={{ marginTop: 24 }}>
+      <Table
+        rowKey="id"
+        loading={loading}
+        columns={columns}
+        dataSource={items}
+        size="small"
+        scroll={{ x: 'max-content' }}
+        locale={{ emptyText: t('noOrdersAll') }}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          onChange: setPage,
+        }}
+      />
+    </Card>
+  );
+}

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -602,6 +602,15 @@ export const enUS: Dict = {
   expired: 'Expired',
   actions: 'Actions',
   confirmDelete: 'Delete this?',
+  // Short labels for tags — the Tag's colour already carries the severity, so
+  // repeating "(blue)" there is noise. The form's picker keeps the long names.
+  announcementKindInfo: 'Info',
+  announcementKindSuccess: 'Success',
+  announcementKindWarning: 'Warning',
+  announcementKindError: 'Error',
+  allOrders: 'All Purchases',
+  orderUser: 'User',
+  noOrdersAll: 'No purchases yet',
   // ── v1.3.0: site settings ──
   siteSettings: 'Site Settings',
   siteName: 'Site name',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -600,6 +600,15 @@ export const zhCN = {
   expired: '已过期',
   actions: '操作',
   confirmDelete: '确定删除?',
+  // 标签用短名(表格里颜色已由 Tag 本身表达,再写"(蓝)"是噪音);
+  // 表单选择器仍用带颜色的长名,因为那里选的就是颜色。
+  announcementKindInfo: '信息',
+  announcementKindSuccess: '成功',
+  announcementKindWarning: '提醒',
+  announcementKindError: '警告',
+  allOrders: '全部购买记录',
+  orderUser: '用户',
+  noOrdersAll: '暂无购买记录',
   // ── v1.3.0: 站点设置 ──
   siteSettings: '站点设置',
   siteName: '站点名称',

--- a/frontend/src/pages/AnnouncementAdmin.tsx
+++ b/frontend/src/pages/AnnouncementAdmin.tsx
@@ -8,6 +8,7 @@ import type { ApiEnvelope, Announcement, AnnouncementList } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { renderMarkdown } from '../utils/markdown';
 import { invalidateActiveAnnouncement } from '../hooks/useActiveAnnouncement';
+import { kindLabel } from '../utils/announcementKind';
 
 const { Text } = Typography;
 
@@ -143,7 +144,7 @@ export default function AnnouncementAdmin() {
       render: (_: unknown, a: Announcement) => (
         <Space direction="vertical" size={0}>
           <Space size={4} wrap>
-            <Tag color={TAG_COLOR[a.kind] ?? 'blue'}>{a.kind}</Tag>
+            <Tag color={TAG_COLOR[a.kind] ?? 'blue'}>{kindLabel(t, a.kind)}</Tag>
             {a.pinned && <Tag color="gold">{t('pinned')}</Tag>}
             <Text strong>{a.title || '-'}</Text>
           </Space>

--- a/frontend/src/pages/Announcements.tsx
+++ b/frontend/src/pages/Announcements.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '../i18n/context';
 import { renderMarkdown } from '../utils/markdown';
 import { useAnnouncementBadge } from '../hooks/useAnnouncementBadge';
 import { useAuth } from '../auth/useAuth';
+import { kindLabel } from '../utils/announcementKind';
 
 const { Text, Title } = Typography;
 
@@ -80,7 +81,7 @@ export default function Announcements() {
               renderItem={(a) => (
                 <List.Item key={a.id}>
                   <div style={{ marginBottom: 6 }}>
-                    <Tag color={TAG_COLOR[a.kind] ?? 'blue'}>{t(`announcementType${a.kind.charAt(0).toUpperCase()}${a.kind.slice(1)}` as Parameters<typeof t>[0])}</Tag>
+                    <Tag color={TAG_COLOR[a.kind] ?? 'blue'}>{kindLabel(t, a.kind)}</Tag>
                     {a.pinned && <Tag color="gold">{t('pinned')}</Tag>}
                     {isExpired(a) && <Tag>{t('expired')}</Tag>}
                     {a.title && (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,7 +12,6 @@ import { aggregateNodesByGroup } from '../components/nodes/aggregate';
 import TrafficChart from '../components/TrafficChart';
 import NodeMetricsChart from '../components/NodeMetricsChart';
 import { formatBps, formatBytes } from '../utils/format';
-import SiteAnnouncement from '../components/SiteAnnouncement';
 
 const { Text } = Typography;
 
@@ -204,10 +203,6 @@ export default function Dashboard() {
 
   return (
     <>
-      {/* v1.3.0: operator announcement. Renders nothing when unset. Sits above
-          the version alerts — it is the operator's own message, and a stale
-          update warning should not push it below the fold. */}
-      <SiteAnnouncement />
       {versionInfo?.check_failed && (
         <Alert
           type="warning"

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -5,6 +5,7 @@ import api from '../api/client';
 import type { ApiEnvelope, Plan, DeviceGroup } from '../api/types';
 import { useI18n } from '../i18n/context';
 import { formatBytes } from '../utils/format';
+import AllOrders from '../components/AllOrders';
 
 const { Text } = Typography;
 
@@ -197,6 +198,11 @@ export default function Plans() {
         </Space>
       </div>
       <Table dataSource={plans} columns={columns} rowKey="id" loading={loading} pagination={{ pageSize: 20 }} />
+
+      {/* v1.3.0: the operator's view of every purchase. Below the plan
+          table because it is a consequence of it — you set the prices here,
+          you see what sold here. */}
+      <AllOrders />
 
       <Modal title={t('addPlan')} open={createOpen} onCancel={() => setCreateOpen(false)} onOk={() => createForm.submit()} okText={t('create')} cancelText={t('cancel')} width={520}>
         <Form form={createForm} onFinish={handleCreate} layout="vertical" initialValues={{ plan_type: 'data', duration_days: 0, hidden: false, reset_traffic: false, description: '', grant_all_groups: false, device_group_ids: [] }}>

--- a/frontend/src/utils/announcementKind.ts
+++ b/frontend/src/utils/announcementKind.ts
@@ -1,0 +1,24 @@
+import type { Dict } from '../i18n/zh-CN';
+
+/**
+ * v1.3.0: the display label for an announcement severity.
+ *
+ * The raw value (`info` / `success` / `warning` / `error`) is a wire value, not
+ * something to show an operator. The tag labels are deliberately SHORT — the
+ * colour-naming variants ("信息(蓝)") exist only in the form's picker, where
+ * choosing a colour is the point; repeating it in a coloured tag is noise.
+ *
+ * Anything unrecognised falls back to the raw string rather than an empty tag,
+ * so a value added on the backend before its label lands still reads.
+ */
+const LABEL_KEY: Record<string, keyof Dict> = {
+  info: 'announcementKindInfo',
+  success: 'announcementKindSuccess',
+  warning: 'announcementKindWarning',
+  error: 'announcementKindError',
+};
+
+export function kindLabel(t: (k: keyof Dict) => string, kind: string): string {
+  const key = LABEL_KEY[kind];
+  return key ? t(key) : kind;
+}


### PR DESCRIPTION
你提的前三件事。第四件(网站和 README 写 Markdown 格式说明)按你说的**后续单独做**,我记着了。

## 一、仪表盘去掉公告横幅

普通用户落地页是个人中心、那里有横幅;仪表盘是管理员专属,而管理员现在有顶栏铃铛。少一样东西把真正的仪表盘内容往下挤。

个人中心那份保持不变,已实测仍正常显示。

## 二、套餐管理页新增「全部购买记录」

套餐商店给用户看自己的订单,之前没有看**所有人**的地方 ——「这周谁买了什么」没法回答。

`GET /admin/orders` 分页,因为这张表只增不减(它对应的单用户列表天然不用分页)。买家名用**每页一次用户查询**解析,不是每行一次(沿用卡密列表的写法);解析不到的 id 显示成 `#9` 而不是把整行留白 —— 订单本来就设计成比账号活得久,它是入账记录。

仓储方法是**独立的**,没有在 `list_orders_by_user` 上加个开关:一个是全站、一个是调用者维度,中间夹个 bool 正是后来的调用方最容易搞反、而且是往泄露方向搞反的东西。

## 三、公告样式显示中文

管理表格原来直接打印 `info` / `success` 这种线上值。现在标签用短名(信息 / 成功 / 提醒 / 警告)。带颜色的长名(「信息(蓝)」)**只保留在表单选择器里** —— 那里选的就是颜色;标签本身已经有颜色了,再写一遍是噪音。

## 验证

- 511 后端 / 233 前端测试;parity(137 / 136);clippy、fmt、typecheck、lint 干净
- 新增测试:全站订单跨用户(并断言单用户列表**没有**跟着变成全站)、分页不重不漏、前端读的是 `/admin/orders` 而非 `/user/orders`、账号删除后回落 `#id`
- **实机验证**:让 xiaoming 也下一单 → 管理员看到 2 条(admin + xiaoming),普通用户访问 `/admin/orders` 返回 **403**;套餐管理页表头「订单号/用户/套餐/价格/购买时间」两行数据正确;公告管理标签显示「成功 置顶 信息 提醒 警告」;仪表盘只剩版本提示、公告横幅已消失;个人中心横幅仍在
