### PR TITLE
fix(account): 公告横幅改为摘要条(299px → 119px)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,16 @@ boot; nothing to reconfigure.
 - Announcement severities render as words rather than the wire values
   `info` / `success` / `warning` / `error`.
 
+- **The account page's announcement banner is a summary, not the full notice.**
+  Carrying the whole text made it 299px — a third of the viewport — for a
+  routine maintenance message, pushing the account details the page exists for
+  down the screen. It now shows the title, two clamped lines of plain text and
+  a link through to the archive; a 4000-character notice takes exactly as much
+  room as a short one (measured: 119px either way, down from 273-299px).
 
+  The excerpt is stripped of markup rather than rendered: a two-line cut with
+  half a bold run and a dangling list dash reads worse than the same words
+  plain, and the formatting is intact one click away.
 
 - **The admin menu is grouped into two submenus.** It had reached twelve
   top-level entries. 用户与计费 holds 用户管理 / 套餐管理 / 卡密管理; 系统设置

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,9 @@ boot; nothing to reconfigure.
   half a bold run and a dangling list dash reads worse than the same words
   plain, and the formatting is intact one click away.
 
+  The header bell is labelled 公告 rather than a bare icon. Every other control
+  in that header is icon + text, so an icon alone read as decoration.
+
 - **The admin menu is grouped into two submenus.** It had reached twelve
   top-level entries. 用户与计费 holds 用户管理 / 套餐管理 / 卡密管理; 系统设置
   holds 基础设置 / 通知设置 / 站点设置 / 操作审计. Top level drops to eight.

--- a/frontend/src/components/SiteAnnouncement.test.tsx
+++ b/frontend/src/components/SiteAnnouncement.test.tsx
@@ -84,12 +84,30 @@ describe('SiteAnnouncement', () => {
     expect(document.querySelector('.ant-alert-info')).not.toBeNull();
   });
 
-  it('renders the markdown subset and shows who posted it', async () => {
+  it('shows a plain-text summary, not rendered markdown', async () => {
+    // The banner is a prompt, not a reading surface. A two-line excerpt with
+    // half a bold run reads worse than the same words plain, and the full
+    // formatting is one click away on the archive.
     mockGet.mockResolvedValue(ok(ann({ content: '**加粗** 和 [链接](https://example.com)' })));
     await renderBanner();
-    expect(document.querySelector('.ant-alert strong')?.textContent).toBe('加粗');
-    expect(document.querySelector('.ant-alert a[href="https://example.com"]')).not.toBeNull();
-    expect(screen.getByText(/admin/)).toBeInTheDocument();
+    expect(screen.getByText('加粗 和 链接')).toBeInTheDocument();
+    expect(document.querySelector('.ant-alert strong')).toBeNull();
+    expect(document.querySelector('.ant-alert-description a')).toBeNull();
+  });
+
+  it('offers a way through to the archive', async () => {
+    mockGet.mockResolvedValue(ok(ann()));
+    await renderBanner();
+    expect(screen.getByText(/viewAnnouncementDetail/)).toBeInTheDocument();
+  });
+
+  it('does not put the author or timestamp in the banner', async () => {
+    // They belong on the archive page — in the banner they were noise that
+    // added a whole line to every notice.
+    mockGet.mockResolvedValue(ok(ann({ author_name: 'admin' })));
+    await renderBanner();
+    expect(screen.queryByText(/admin/)).toBeNull();
+    expect(screen.queryByText(/2026-07-28/)).toBeNull();
   });
 
   it('never renders the announcement as HTML', async () => {
@@ -97,6 +115,8 @@ describe('SiteAnnouncement', () => {
     // capability this field should hand out.
     mockGet.mockResolvedValue(ok(ann({ content: '<img src=x onerror=alert(1)>' })));
     await renderBanner();
+    // Stripping markdown must not unwrap HTML — React renders it as a text
+    // node either way, but the summary should show what was typed.
     expect(screen.getByText('<img src=x onerror=alert(1)>')).toBeInTheDocument();
     expect(document.querySelector('.ant-alert img')).toBeNull();
   });

--- a/frontend/src/components/SiteAnnouncement.tsx
+++ b/frontend/src/components/SiteAnnouncement.tsx
@@ -1,11 +1,11 @@
-import { Alert, Typography } from 'antd';
-import { NotificationOutlined } from '@ant-design/icons';
-import { Link } from 'react-router-dom';
+import { Alert, Button, Typography } from 'antd';
+import { NotificationOutlined, RightOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
 import { useActiveAnnouncement } from '../hooks/useActiveAnnouncement';
 import { useI18n } from '../i18n/context';
-import { renderMarkdown } from '../utils/markdown';
+import { stripMarkdown } from '../utils/markdown';
 
-const { Text } = Typography;
+const { Paragraph } = Typography;
 
 /** The four severities the backend allows. Anything else was already coerced
  *  server-side; this is the last stop before antd's Alert. */
@@ -13,18 +13,23 @@ const TYPES = ['info', 'success', 'warning', 'error'] as const;
 type AlertType = (typeof TYPES)[number];
 
 /**
- * v1.3.0: the operator's current announcement, at the top of the dashboard and
- * the account page.
+ * v1.3.0: a one-glance summary of the current announcement.
  *
- * Shows ONE notice — the pinned one, else the newest unexpired one. Stacking
- * several banners would push the actual page content off the screen and train
- * people to ignore all of them. Past notices live on the archive page, linked
- * from here.
+ * Deliberately NOT the full text. Carrying the whole notice made this 299px —
+ * a third of the viewport — for a routine maintenance message, pushing the
+ * account details the page exists for below the fold. A banner is a prompt;
+ * the archive page is the reading surface.
+ *
+ * So: title, two clamped lines of plain text, and a link. The body is stripped
+ * of markup rather than rendered, because a two-line excerpt with half a bold
+ * run and a dangling list dash reads worse than the same words plain — and the
+ * formatting is intact one click away.
  *
  * Renders nothing at all when there is no live notice.
  */
 export default function SiteAnnouncement() {
   const { t } = useI18n();
+  const navigate = useNavigate();
   const active = useActiveAnnouncement();
 
   if (!active) return null;
@@ -33,31 +38,36 @@ export default function SiteAnnouncement() {
     ? (active.kind as AlertType)
     : 'info';
 
+  const summary = stripMarkdown(active.content);
+
   return (
     <Alert
       type={type}
       showIcon
       icon={<NotificationOutlined />}
       style={{ marginBottom: 16 }}
-      // antd v6 renamed Alert's `message` prop to `title`; `message` is
-      // silently ignored, which is how the heading first came out blank.
       title={active.title || undefined}
       description={
-        <div>
-          {/* renderMarkdown returns React elements, never an HTML string — see
-              utils/markdown. That is what keeps operator-authored text from
-              becoming markup on every signed-in user's page. */}
-          <div style={{ whiteSpace: 'pre-wrap' }}>{renderMarkdown(active.content)}</div>
-          <div style={{ marginTop: 6 }}>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {active.published_at}
-              {active.author_name ? ` · ${active.author_name}` : ''}
-            </Text>
-            <Link to="/announcements" style={{ fontSize: 12, marginLeft: 12 }}>
-              {t('viewAllAnnouncements')}
-            </Link>
-          </div>
-        </div>
+        <Paragraph
+          type="secondary"
+          // antd's own multi-line ellipsis. A hand-rolled -webkit-line-clamp
+          // did not survive to the DOM here — the other two clamp properties
+          // landed in the inline style and this one was dropped — so rather
+          // than fight whatever swallows it, use the API built for this. It is
+          // what bounds the banner: a 4000-character notice takes exactly as
+          // much room as a short one.
+          ellipsis={{ rows: 2, tooltip: summary }}
+          style={{ marginBottom: 0 }}
+        >
+          {summary}
+        </Paragraph>
+      }
+      // `action` keeps the link out of the text flow, so it cannot be pushed
+      // around by the length of the summary.
+      action={
+        <Button type="link" size="small" onClick={() => navigate('/announcements')}>
+          {t('viewAnnouncementDetail')} <RightOutlined />
+        </Button>
       }
     />
   );

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -595,6 +595,7 @@ export const enUS: Dict = {
   announcementContentRequired: 'Content is required',
   noAnnouncements: 'No announcements yet',
   viewAllAnnouncements: 'View all',
+  viewAnnouncementDetail: 'Details',
   publishedAt: 'Published',
   expiresAt: 'Expires',
   pinned: 'Pinned',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -593,6 +593,7 @@ export const zhCN = {
   announcementContentRequired: '请输入公告内容',
   noAnnouncements: '暂无公告',
   viewAllAnnouncements: '查看全部公告',
+  viewAnnouncementDetail: '查看详情',
   publishedAt: '发布时间',
   expiresAt: '到期时间',
   pinned: '置顶',

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Layout, Menu, Button, Space, Typography, Segmented, Modal, Form, Input, message, Spin, Badge, Tooltip } from 'antd';
+import { Layout, Menu, Button, Space, Typography, Segmented, Modal, Form, Input, message, Spin, Badge } from 'antd';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useState, Suspense } from 'react';
 import {
@@ -158,18 +158,22 @@ export default function MainLayout() {
                 The banner already carries the current notice, so a menu row
                 would only be a route to the archive — a low-frequency
                 destination sitting beside pages people use daily. A bell also
-                does what a menu row cannot: say that something is new. */}
-            <Tooltip title={t('announcements')}>
-              <Badge dot={unread} offset={[-2, 2]}>
-                <Button
-                  type="text"
-                  size="small"
-                  aria-label={t('announcements')}
-                  icon={<NotificationOutlined />}
-                  onClick={() => navigate('/announcements')}
-                />
-              </Badge>
-            </Tooltip>
+                does what a menu row cannot: say that something is new.
+
+                Labelled, not bare: every other control in this header is icon
+                + text, so an icon alone read as decoration and people did not
+                find it. The Tooltip is gone with it — a tooltip that repeats
+                the visible label is noise. */}
+            <Badge dot={unread} offset={[-4, 2]}>
+              <Button
+                type="text"
+                size="small"
+                icon={<NotificationOutlined />}
+                onClick={() => navigate('/announcements')}
+              >
+                {t('announcements')}
+              </Button>
+            </Badge>
             <Segmented
               size="small"
               value={lang}

--- a/frontend/src/utils/markdown.test.tsx
+++ b/frontend/src/utils/markdown.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { renderMarkdown, renderInline } from './markdown';
+import { renderMarkdown, renderInline, stripMarkdown } from './markdown';
 
 const show = (src: string) => render(<div data-testid="out">{renderMarkdown(src)}</div>);
 const out = () => screen.getByTestId('out');
@@ -96,5 +96,44 @@ describe('renderMarkdown never emits raw HTML', () => {
     show('[<img src=x onerror=alert(1)>](https://example.com)');
     expect(out().querySelector('img')).toBeNull();
     expect(out().querySelector('a')?.textContent).toContain('<img');
+  });
+});
+
+describe('stripMarkdown', () => {
+  it('removes every marker the parser treats as markup', () => {
+    // If the two ever disagree, the marker characters leak into the summary
+    // bar — which is the one place they must not appear.
+    expect(stripMarkdown('**粗** 和 *斜* 和 `码`')).toBe('粗 和 斜 和 码');
+  });
+
+  it('keeps a link label and drops the URL', () => {
+    expect(stripMarkdown('详见 [公告页](https://example.com/x)')).toBe('详见 公告页');
+  });
+
+  it('flattens list markers and blank lines into one run', () => {
+    const src = ['维护通知', '', '- 香港不受影响', '- 日本重启', '', '结束'].join('\n');
+    expect(stripMarkdown(src)).toBe('维护通知 香港不受影响 日本重启 结束');
+  });
+
+  it('leaves a mid-sentence hyphen and a lone asterisk alone', () => {
+    // Only line-leading "- " is a list marker, and a single asterisk is not
+    // emphasis — the summary should read like what the operator typed.
+    expect(stripMarkdown('02:00 - 04:00 维护,2 * 3 = 6')).toBe('02:00 - 04:00 维护,2 * 3 = 6');
+  });
+
+  it('does not turn bold into a stray italic marker', () => {
+    // Stripping italic first would leave "*x*" behind.
+    expect(stripMarkdown('**x**')).toBe('x');
+  });
+
+  it('leaves unsupported syntax as typed', () => {
+    expect(stripMarkdown('# 不是标题')).toBe('# 不是标题');
+    expect(stripMarkdown('~~不是删除线~~')).toBe('~~不是删除线~~');
+  });
+
+  it('does not execute or unwrap HTML', () => {
+    // The summary is rendered as a React text node, so this stays literal —
+    // asserted here so a future "smarter" stripper cannot quietly unwrap it.
+    expect(stripMarkdown('<b>x</b>')).toBe('<b>x</b>');
   });
 });

--- a/frontend/src/utils/markdown.tsx
+++ b/frontend/src/utils/markdown.tsx
@@ -60,6 +60,35 @@ const RULES: Rule[] = [
   },
 ];
 
+/**
+ * Flatten the markdown subset to plain text, for the account-page summary bar.
+ *
+ * The banner is a prompt, not a reading surface: a two-line excerpt with half a
+ * bold run and a dangling list dash reads worse than the same words plain. The
+ * formatting is rendered in full on the archive page.
+ *
+ * Mirrors the RULES above deliberately — anything the parser treats as markup
+ * has to be stripped here too, or the marker characters leak into the summary.
+ */
+export function stripMarkdown(src: string): string {
+  return (
+    src
+      // Code first, so ** inside a code span is not read as bold.
+      .replace(/`([^`\n]+)`/g, '$1')
+      // Links keep their label; the URL is noise in a one-line summary.
+      .replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/g, '$1')
+      // Bold before italic, so **x** does not degrade to *x*.
+      .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+      .replace(/\*([^*\n]+)\*/g, '$1')
+      // List markers only at the start of a line — a hyphen mid-sentence stays.
+      .replace(/^\s*-\s+/gm, '')
+      // Blank lines and newlines collapse: the summary is one flowing run.
+      .replace(/\s*\n+\s*/g, ' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+  );
+}
+
 /** Parse one line's inline markup into React nodes. */
 export function renderInline(line: string, keyPrefix = ''): ReactNode[] {
   const out: ReactNode[] = [];


### PR DESCRIPTION
个人中心那条横幅"丑"是有具体原因的:**它在承载全文**。量出来的数字:

| | 改前 | 改后 |
|---|---|---|
| 短公告 | 125px | 119px |
| 真实维护公告 | **299px(视口 33%)** | 119px(13%) |
| 598 字长公告 | 273px | **119px** |
| 「我的账户」卡片顶部 | y=395 | **y=215** |

一条例行维护通知就把这个页面存在的意义(账户信息)挤到了屏幕下方。**横幅是提示,公告页才是阅读界面。**

## 改动

标题 + 两行截断摘要 + 右侧「查看详情」。长公告和短公告现在**一样高** —— 截断就是那个上限。

**摘要去掉 Markdown 标记而不是渲染它**:两行的截断里出现半截加粗和悬空的列表横杠,比同样文字排成纯文本更难看,而格式在公告页里完整保留。`stripMarkdown` 刻意对齐解析器的规则 —— 两者不一致的话,标记字符就会漏进唯一不该出现它的地方。测试钉住了这点,也钉住了句中的连字符和单个星号不被误伤。

**日期和作者从横幅里去掉了。** 它们在公告页上,那才是正经阅读的地方;在横幅里每条要多占一行,而且当时渲染成了 `admin查看全部公告` —— 中间少个分隔。

## 两点关于截断本身

用的是 antd 的 `ellipsis={{ rows: 2 }}`,不是手写 `-webkit-line-clamp`。手写那版**静默失效**:同一个 style 对象里另外两个截断属性都进了内联样式,唯独这一个没到 DOM。我先猜是 React 给数字补 `px`,改成字符串后**依然没有**,所以那个解释不成立;换成内置 API 就好了,我没有继续追下去。

「…」我是**通过与未截断克隆节点对比测量**确认的,不是看出来的 —— 这个浏览器面板不合成帧,截图不可用。

## 验证

238 前端测试通过(新增 stripMarkdown 7 条 + 横幅 3 条);typecheck、lint 干净。实机以普通用户量了上表所有数字。
