### PR TITLE
chore(release): 1.3.0(仅面板)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
-## [Unreleased]
+## [1.3.0] - 2026-07-29
 
-Panel only so far — no node release and no node change is required. Two new
-tables (node metric history, audit log) are created by migrations on first
-boot; nothing to reconfigure.
+Panel only — no node release, and no node change is required (the config
+protocol is unchanged at version 4, so existing nodes keep working as-is).
+
+Three tables are created by migrations on first boot: node metric history, the
+audit log, and announcements. Nothing to reconfigure. One thing to know: the
+announcement you have configured today is carried out of the site config into
+the new announcements table by the migration, so it survives the upgrade — it
+will appear as the first entry in the new 公告 page.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.3";
+const COMPILED_APP_VERSION: &str = "1.3.0";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.3}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.3.0}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)


### PR DESCRIPTION
1.2.3 之后累计 **14 个 PR**,发 v1.3.0。

**面板单独发布** —— 配置协议仍是版本 4,现有节点照常工作,**不需要发节点版本、不需要升级节点**。

## 升级须知

首次启动会由迁移建三张表:节点指标历史、审计日志、公告。**不需要改配置。**

有一件事要知道:**你现在配置的那条公告会被 Migration 44 搬进新的公告表**,所以升级后不会消失,它会作为第一条出现在新的「公告」页里。(不搬的话,存它的那个字段升级后就不再被读取,公告等于凭空不见了。)

## 版本号同步

`release-check.sh panel 1.3.0` 从 6 FAIL 到 **0 FAIL**:`Cargo.toml`、`Cargo.lock`、`config.rs` 的 `COMPILED_APP_VERSION`、`docker-compose.release.yaml` 的镜像 tag、CHANGELOG 的 `[1.3.0]` 段。

顺手重写了 CHANGELOG 的发布导语 —— 它是攒批过程中逐步写的,已经过时(还写着"两张新表",实际是三张,而且没提公告数据搬运)。发布正文是运维升级前唯一会读的东西,不能留着错的。

## 验证

511 后端 / 242 前端测试;parity(137/136);clippy、fmt、typecheck、lint 全部干净。

## 合并后

合了之后我打 `v1.3.0` tag 触发镜像构建,然后改官网。
