### PR TITLE
chore(release): 1.2.4(仅面板)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
-## [Unreleased]
+## [1.2.4] - 2026-07-29
 
-Panel only so far — no node release and no node change is required. Two new
-tables (node metric history, audit log) are created by migrations on first
-boot; nothing to reconfigure.
+Panel only — no node release, and no node change is required (the config
+protocol is unchanged at version 4, so existing nodes keep working as-is).
+
+Three tables are created by migrations on first boot: node metric history, the
+audit log, and announcements. Nothing to reconfigure. One thing to know: the
+announcement you have configured today is carried out of the site config into
+the new announcements table by the migration, so it survives the upgrade — it
+appears as the first entry on the new 公告 page.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -865,7 +865,7 @@ mod tests {
         );
     }
 
-    /// v1.3.0: the audit trail must never become a place to read a live node
+    /// v1.2.4: the audit trail must never become a place to read a live node
     /// credential out of. Rotation is exactly the operation that produces one,
     /// and `detail` is free-form text a future edit could carelessly widen —
     /// so pin it: the new token must appear in NO column of the audit row.
@@ -908,12 +908,12 @@ mod tests {
         }
     }
 
-    /// v1.3.0: the public site endpoint is reachable with NO token, so it must
+    /// v1.2.4: the public site endpoint is reachable with NO token, so it must
     /// carry branding only. The support contact is for this operator's users,
     /// not for anyone who can reach the port.
     ///
     /// (The announcement used to be checked here too. It moved to its own table
-    /// in v1.3.0 and is served by an authenticated endpoint of its own.)
+    /// in v1.2.4 and is served by an authenticated endpoint of its own.)
     #[tokio::test]
     async fn public_site_endpoint_exposes_branding_but_not_the_contact() {
         let (state, _pool) = test_state().await;

--- a/crates/panel/src/api/admin/shop.rs
+++ b/crates/panel/src/api/admin/shop.rs
@@ -187,7 +187,7 @@ pub async fn buy_plan(
 }
 
 /// GET /user/orders — the calling user's purchase history, newest first.
-/// v1.3.0: one order with the buyer's name resolved for display.
+/// v1.2.4: one order with the buyer's name resolved for display.
 #[derive(Debug, serde::Serialize)]
 pub struct AdminOrderRow {
     pub id: i64,

--- a/crates/panel/src/api/announcements.rs
+++ b/crates/panel/src/api/announcements.rs
@@ -1,4 +1,4 @@
-//! v1.3.0: site announcement endpoints.
+//! v1.2.4: site announcement endpoints.
 //!
 //! Auth split mirrors the site config: signed-in users read (the archive is for
 //! them), admins write. Nothing here is public — the announcement was

--- a/crates/panel/src/api/audit.rs
+++ b/crates/panel/src/api/audit.rs
@@ -1,4 +1,4 @@
-//! v1.3.0: read side of the admin audit trail.
+//! v1.2.4: read side of the admin audit trail.
 //!
 //! Write side is `service::audit::record`, called from each destructive handler.
 

--- a/crates/panel/src/api/mod.rs
+++ b/crates/panel/src/api/mod.rs
@@ -49,7 +49,7 @@ pub fn routes() -> Router<AppState> {
             "/auth/registration-status",
             axum::routing::get(auth::registration_status),
         )
-        // v1.3.0: site announcements. Reading requires sign-in (the archive is
+        // v1.2.4: site announcements. Reading requires sign-in (the archive is
         // for this operator's users, and the banner was deliberately kept off
         // the login page); writing is admin-only.
         .route(
@@ -72,12 +72,12 @@ pub fn routes() -> Router<AppState> {
             "/admin/announcements/{id}",
             axum::routing::put(announcements::update).delete(announcements::delete),
         )
-        // v1.3.0: public site branding. Unauthenticated because the login page
+        // v1.2.4: public site branding. Unauthenticated because the login page
         // renders the operator's name before anyone has a token. Carries ONLY
         // name + subtitle — the announcement and support contact are behind
         // /user/site-notice.
         .route("/site", axum::routing::get(site::get_public_site))
-        // v1.3.0: the signed-in half of the site config.
+        // v1.2.4: the signed-in half of the site config.
         .route(
             "/user/site-notice",
             axum::routing::get(site::get_site_notice),
@@ -89,14 +89,14 @@ pub fn routes() -> Router<AppState> {
         // v1.0.8: self-service plan purchase + order history.
         .route("/user/buy-plan", axum::routing::post(admin::buy_plan))
         .route("/user/orders", axum::routing::get(admin::list_my_orders))
-        // v1.3.0: every user's orders, for the plan-management page. Admin-only
+        // v1.2.4: every user's orders, for the plan-management page. Admin-only
         // and paginated — this table only grows.
         .route("/admin/orders", axum::routing::get(admin::list_all_orders))
         // v1.2.0: self-service balance top-up. Scoped to the caller's own id
         // from the token — there is no user_id in the body, so it can never
         // credit another account.
         .route("/user/redeem", axum::routing::post(redeem::redeem_code))
-        // v1.3.0: the caller's own top-up history, for the account page. Scoped
+        // v1.2.4: the caller's own top-up history, for the account page. Scoped
         // to the token's uid — there is no id in the path.
         .route(
             "/user/redeem-records",
@@ -244,7 +244,7 @@ pub fn routes() -> Router<AppState> {
             axum::routing::get(admin::get_registration_settings)
                 .put(admin::update_registration_settings),
         )
-        // v1.3.0: site identity (name / subtitle / announcement / contact).
+        // v1.2.4: site identity (name / subtitle / announcement / contact).
         .route(
             "/admin/settings/site",
             axum::routing::get(site::get_site_settings).put(site::update_site_settings),
@@ -272,14 +272,14 @@ pub fn routes() -> Router<AppState> {
             "/stats/traffic",
             axum::routing::get(stats::get_traffic_history),
         )
-        // v1.3.0: node CPU / memory / connection history. Admin-gated inside
+        // v1.2.4: node CPU / memory / connection history. Admin-gated inside
         // the handler (AdminOnly) — unlike traffic, these are properties of the
         // operator's machines, not of any tenant's rules.
         .route(
             "/stats/node-metrics",
             axum::routing::get(stats::get_node_metrics),
         )
-        // v1.3.0: admin audit trail (read side). AdminOnly inside the handler,
+        // v1.2.4: admin audit trail (read side). AdminOnly inside the handler,
         // and never owner-scoped — the rows record who acted on whom.
         .route("/admin/audit-log", axum::routing::get(audit::get_audit_log))
         // v0.4.10: node status is owner-scoped (a user sees only nodes for

--- a/crates/panel/src/api/node.rs
+++ b/crates/panel/src/api/node.rs
@@ -286,7 +286,7 @@ pub async fn report_status(
             .await
             .map_err(|e| tracing::warn!("report_status: kvs set failed: {}", e));
 
-        // v1.3.0: fold this report into the node's hourly metrics bucket. The
+        // v1.2.4: fold this report into the node's hourly metrics bucket. The
         // status written above is a snapshot each report overwrites; this is the
         // only thing that survives to answer "what was it doing last night".
         //

--- a/crates/panel/src/api/site.rs
+++ b/crates/panel/src/api/site.rs
@@ -1,4 +1,4 @@
-//! v1.3.0: site identity endpoints.
+//! v1.2.4: site identity endpoints.
 //!
 //! Split across THREE auth levels on purpose:
 //!
@@ -43,7 +43,7 @@ pub async fn get_public_site(State(state): State<AppState>) -> Json<ApiResponse<
 
 /// The signed-in half.
 ///
-/// v1.3.0: no longer carries the announcement. That moved to its own table
+/// v1.2.4: no longer carries the announcement. That moved to its own table
 /// with history; the copy still sitting in site:config is frozen at whatever
 /// Migration 44 carried over, and serving it would show stale text beside the
 /// live banner.

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.3";
+const COMPILED_APP_VERSION: &str = "1.2.4";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/crates/panel/src/db/pg_repo/announcements.rs
+++ b/crates/panel/src/db/pg_repo/announcements.rs
@@ -3,7 +3,7 @@ use crate::db::error::DbError;
 use crate::db::repo::*;
 use async_trait::async_trait;
 
-// ── AnnouncementRepository (v1.3.0) ──
+// ── AnnouncementRepository (v1.2.4) ──
 //
 // Mirrors the SQLite impl; see there for the ordering and update-semantics
 // notes. Placeholders are numbered ($1) rather than positional (?).

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -4977,7 +4977,7 @@ async fn pg_migration_41_backfills_group_id_from_the_rule() {
     cleanup(&db).await;
 }
 
-// ── v1.3.0: node metrics history ──
+// ── v1.2.4: node metrics history ──
 
 fn pg_metric(
     node: &str,
@@ -5111,7 +5111,7 @@ async fn pg_node_metrics_prune_respects_the_cutoff() {
     assert_eq!(rows[0].bucket, "2026-07-28 10:00:00");
 }
 
-// ── Audit log (v1.3.0) ──
+// ── Audit log (v1.2.4) ──
 
 fn pg_audit(actor: Option<i64>, name: &str, action: &str, ts: &str) -> NewAuditEntry {
     NewAuditEntry {
@@ -5226,7 +5226,7 @@ async fn pg_audit_prune_keeps_the_cutoff_row() {
     assert!(rows.iter().all(|e| e.ts.as_str() >= "2026-07-10 10:00:00"));
 }
 
-// ── v1.3.0: per-user redeem history ──
+// ── v1.2.4: per-user redeem history ──
 
 /// The account page is reachable by every user, so this query must be scoped by
 /// construction. If it ever returned another account's top-ups, one user could
@@ -5278,7 +5278,7 @@ async fn pg_redeem_history_lists_only_used_codes() {
     assert_eq!(mine[0].status, "used");
 }
 
-// ── v1.3.0: announcements ──
+// ── v1.2.4: announcements ──
 
 fn ann(content: &str, published: &str, pinned: bool, expires: Option<&str>) -> NewAnnouncement {
     NewAnnouncement {
@@ -5430,7 +5430,7 @@ async fn pg_update_and_delete_report_a_missing_row() {
     assert_eq!(db.delete_announcement(999).await.unwrap(), 0);
 }
 
-// ── v1.3.0: admin-wide order list ──
+// ── v1.2.4: admin-wide order list ──
 
 /// The admin list spans every account, unlike list_orders_by_user. Getting this
 /// wrong in the other direction — scoping it to the caller — would make the

--- a/crates/panel/src/db/pg_schema.rs
+++ b/crates/panel/src/db/pg_schema.rs
@@ -216,7 +216,7 @@ CREATE TABLE IF NOT EXISTS traffic_history (
 CREATE INDEX IF NOT EXISTS idx_traffic_history_uid ON traffic_history(uid, hour_ts);
 CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts);
 
--- v1.3.0: hourly node metrics (mirrors the SQLite baseline — see there for why
+-- v1.2.4: hourly node metrics (mirrors the SQLite baseline — see there for why
 -- sum+samples+max instead of a running average, and why there is no FK).
 CREATE TABLE IF NOT EXISTS node_metrics_history (
     node_id TEXT NOT NULL,
@@ -234,7 +234,7 @@ CREATE TABLE IF NOT EXISTS node_metrics_history (
 CREATE INDEX IF NOT EXISTS idx_node_metrics_hour ON node_metrics_history(hour_ts);
 CREATE INDEX IF NOT EXISTS idx_node_metrics_group ON node_metrics_history(group_id, hour_ts);
 
--- v1.3.0: admin audit trail (mirrors the SQLite baseline — see there for why
+-- v1.2.4: admin audit trail (mirrors the SQLite baseline — see there for why
 -- actor_name is a snapshot and why detail must never carry a secret).
 CREATE TABLE IF NOT EXISTS audit_log (
     id BIGSERIAL PRIMARY KEY,
@@ -249,7 +249,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 CREATE INDEX IF NOT EXISTS idx_audit_log_ts ON audit_log(ts);
 CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action, ts);
 
--- v1.3.0: site announcements (mirrors the SQLite baseline — see there for why
+-- v1.2.4: site announcements (mirrors the SQLite baseline — see there for why
 -- this replaced the single announcement string in the site:config kvs blob and
 -- why author_name is a snapshot).
 CREATE TABLE IF NOT EXISTS announcements (
@@ -1310,7 +1310,7 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
     }
 
     if current < 25 {
-        // v1.3.0: hourly node metrics. See the baseline for why sum+samples+max
+        // v1.2.4: hourly node metrics. See the baseline for why sum+samples+max
         // rather than a running average. Nothing to backfill — node status was
         // only ever a snapshot, so there is no prior history to recover.
         sqlx::query(
@@ -1349,7 +1349,7 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
     }
 
     if current < 26 {
-        // v1.3.0: admin audit trail. See the baseline for the snapshot/secret
+        // v1.2.4: admin audit trail. See the baseline for the snapshot/secret
         // rules. Nothing to backfill — prior actions only ever hit the process
         // log, which this cannot recover.
         sqlx::query(
@@ -1381,7 +1381,7 @@ pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
     }
 
     if current < 27 {
-        // v1.3.0: site announcements. Carries the single announcement out of
+        // v1.2.4: site announcements. Carries the single announcement out of
         // the site:config kvs blob so an upgrade does not silently blank a
         // notice the operator has live. The "table is empty" guard makes the
         // carry-over run exactly once — a flag would not survive a restore from

--- a/crates/panel/src/db/repo.rs
+++ b/crates/panel/src/db/repo.rs
@@ -707,7 +707,7 @@ pub trait TrafficRepository: Send + Sync {
     /// die.
     async fn prune_traffic_history(&self, cutoff: &str) -> Result<u64, DbError>;
 
-    /// v1.3.0: fold one status report into the node's hourly metrics bucket.
+    /// v1.2.4: fold one status report into the node's hourly metrics bucket.
     ///
     /// Called on every report (~10s), so it must be a single UPSERT: sums and
     /// the sample count accumulate, the maxima take whichever is larger. The
@@ -728,7 +728,7 @@ pub trait TrafficRepository: Send + Sync {
     /// rows die.
     async fn prune_node_metrics(&self, cutoff: &str) -> Result<u64, DbError>;
 
-    /// v1.3.0: append one audit entry. Best-effort at the call site — see
+    /// v1.2.4: append one audit entry. Best-effort at the call site — see
     /// service::audit for why a failure here must not undo the operation that
     /// was just performed.
     async fn record_audit(&self, e: &NewAuditEntry) -> Result<(), DbError>;
@@ -750,7 +750,7 @@ pub trait TrafficRepository: Send + Sync {
     async fn prune_audit_log(&self, cutoff: &str) -> Result<u64, DbError>;
 }
 
-/// v1.3.0: one site announcement.
+/// v1.2.4: one site announcement.
 #[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct Announcement {
     pub id: i64,
@@ -780,7 +780,7 @@ pub struct NewAnnouncement {
     pub author_name: String,
 }
 
-// ── Announcements (v1.3.0) ──
+// ── Announcements (v1.2.4) ──
 
 #[async_trait]
 pub trait AnnouncementRepository: Send + Sync {
@@ -1075,7 +1075,7 @@ pub trait RedeemRepository: Send + Sync {
         now: &str,
     ) -> Result<(String, String), RedeemCodeError>;
 
-    /// v1.3.0: the codes a given user redeemed, newest first.
+    /// v1.2.4: the codes a given user redeemed, newest first.
     ///
     /// Separate from `list_redeem_codes` rather than another filter on it: this
     /// one is reachable by a NON-admin (their own account page), so the uid
@@ -1227,7 +1227,7 @@ pub trait SettingsRepository: Send + Sync {
 pub trait OrderRepository: Send + Sync {
     /// List a user's orders, newest first.
     async fn list_orders_by_user(&self, user_id: i64) -> Result<Vec<Order>, DbError>;
-    /// v1.3.0: every user's orders, newest first, for the admin view.
+    /// v1.2.4: every user's orders, newest first, for the admin view.
     ///
     /// Paginated rather than returning the lot: this table only grows, and the
     /// per-user list it sits beside is naturally small enough not to need it.

--- a/crates/panel/src/db/schema.rs
+++ b/crates/panel/src/db/schema.rs
@@ -296,7 +296,7 @@ CREATE INDEX IF NOT EXISTS idx_traffic_history_hour ON traffic_history(hour_ts);
 -- group_id". Migrations run on fresh installs too, so the index is still
 -- created exactly once either way.
 
--- v1.3.0: hourly node metrics (CPU / memory / connections).
+-- v1.2.4: hourly node metrics (CPU / memory / connections).
 --
 -- Node status is a SNAPSHOT — each report overwrites the last — so "why was it
 -- slow last night" had no data to answer with. This keeps an hourly rollup.
@@ -328,7 +328,7 @@ CREATE TABLE IF NOT EXISTS node_metrics_history (
 CREATE INDEX IF NOT EXISTS idx_node_metrics_hour ON node_metrics_history(hour_ts);
 CREATE INDEX IF NOT EXISTS idx_node_metrics_group ON node_metrics_history(group_id, hour_ts);
 
--- v1.3.0: admin audit trail.
+-- v1.2.4: admin audit trail.
 --
 -- Destructive operations were only ever written to the process log: it rotates,
 -- it dies with the container, and it is not visible from the panel. "Who
@@ -359,7 +359,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 CREATE INDEX IF NOT EXISTS idx_audit_log_ts ON audit_log(ts);
 CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action, ts);
 
--- v1.3.0: site announcements.
+-- v1.2.4: site announcements.
 --
 -- Replaces the single `announcement` string that lived in the site:config kvs
 -- blob. That field could only hold one notice and overwrote it on every edit,
@@ -1668,7 +1668,7 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
         backfilled
     );
 
-    // ── Migration 42: v1.3.0 hourly node metrics ──
+    // ── Migration 42: v1.2.4 hourly node metrics ──
     // See SCHEMA_SQL for why sum+samples+max rather than a running average, and
     // why there is no FK on node_id. Nothing to backfill: node status was only
     // ever a snapshot, so there is no history to recover.
@@ -1703,7 +1703,7 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
     .await?;
     tracing::info!("Migration 42: node_metrics_history table present");
 
-    // ── Migration 43: v1.3.0 admin audit trail ──
+    // ── Migration 43: v1.2.4 admin audit trail ──
     // See SCHEMA_SQL for why actor_name is a snapshot and why detail must never
     // carry a secret. Nothing to backfill: destructive actions were previously
     // only in the process log, which this cannot recover.
@@ -1729,7 +1729,7 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> Result<(), sqlx::Error> 
         .await?;
     tracing::info!("Migration 43: audit_log table present");
 
-    // ── Migration 44: v1.3.0 site announcements ──
+    // ── Migration 44: v1.2.4 site announcements ──
     //
     // Carries the single announcement out of the site:config kvs blob so an
     // upgrade does not silently blank a notice the operator has live. Runs

--- a/crates/panel/src/db/sqlite_repo/announcements.rs
+++ b/crates/panel/src/db/sqlite_repo/announcements.rs
@@ -3,7 +3,7 @@ use crate::db::error::DbError;
 use crate::db::repo::*;
 use async_trait::async_trait;
 
-// ── AnnouncementRepository (v1.3.0) ──
+// ── AnnouncementRepository (v1.2.4) ──
 
 /// Ordering shared by the banner pick and the history list: pinned first, then
 /// newest. `id DESC` breaks ties because several notices can share a second and

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -4915,7 +4915,7 @@ async fn migration_41_backfills_group_id_from_the_rule() {
     assert_eq!(orphan, 0, "an orphan keeps 0 — never invent an attribution");
 }
 
-// ── v1.3.0: node metrics history ──
+// ── v1.2.4: node metrics history ──
 
 fn metric(node: &str, group: i64, hour: &str, cpu: f64, mem: f64, conns: i64) -> NodeMetricSample {
     NodeMetricSample {
@@ -5034,7 +5034,7 @@ async fn node_metrics_prune_respects_the_cutoff() {
     assert_eq!(rows[0].bucket, "2026-07-28 10:00:00");
 }
 
-// ── Audit log (v1.3.0) ──
+// ── Audit log (v1.2.4) ──
 
 fn audit(actor: Option<i64>, name: &str, action: &str, ts: &str) -> NewAuditEntry {
     NewAuditEntry {
@@ -5142,7 +5142,7 @@ async fn audit_prune_keeps_the_cutoff_row() {
     assert!(rows.iter().all(|e| e.ts.as_str() >= "2026-07-10 10:00:00"));
 }
 
-// ── v1.3.0: per-user redeem history ──
+// ── v1.2.4: per-user redeem history ──
 
 /// The account page is reachable by every user, so this query must be scoped by
 /// construction. If it ever returned another account's top-ups, one user could
@@ -5190,7 +5190,7 @@ async fn redeem_history_lists_only_used_codes() {
     assert_eq!(mine[0].status, "used");
 }
 
-// ── v1.3.0: announcements ──
+// ── v1.2.4: announcements ──
 
 fn ann(content: &str, published: &str, pinned: bool, expires: Option<&str>) -> NewAnnouncement {
     NewAnnouncement {
@@ -5330,7 +5330,7 @@ async fn update_and_delete_report_a_missing_row() {
     assert_eq!(db.delete_announcement(999).await.unwrap(), 0);
 }
 
-// ── v1.3.0: admin-wide order list ──
+// ── v1.2.4: admin-wide order list ──
 
 /// The admin list spans every account, unlike list_orders_by_user. Getting this
 /// wrong in the other direction — scoping it to the caller — would make the

--- a/crates/panel/src/service/announcements.rs
+++ b/crates/panel/src/service/announcements.rs
@@ -1,4 +1,4 @@
-//! v1.3.0: site announcements.
+//! v1.2.4: site announcements.
 //!
 //! Replaces the single `announcement` string in the site:config blob. That
 //! field held one notice, overwrote it on every edit, and kept no history — so

--- a/crates/panel/src/service/audit.rs
+++ b/crates/panel/src/service/audit.rs
@@ -1,4 +1,4 @@
-//! v1.3.0: admin audit trail.
+//! v1.2.4: admin audit trail.
 //!
 //! Destructive operations already emitted a `tracing` line with
 //! `action = "..."`, but the process log rotates, dies with the container, and

--- a/crates/panel/src/service/history_prune.rs
+++ b/crates/panel/src/service/history_prune.rs
@@ -1,4 +1,4 @@
-//! v1.2.0: history retention sweeper (traffic, and since v1.3.0 node metrics
+//! v1.2.0: history retention sweeper (traffic, and since v1.2.4 node metrics
 //! and the audit log).
 //!
 //! Neither table has an FK — rows are never deleted by a parent cascade
@@ -14,7 +14,7 @@ use crate::api::AppState;
 /// straddles the boundary mid-query never disappears from under a chart.
 const RETENTION_DAYS: i64 = 35;
 
-/// v1.3.0: node metrics keep a week. A report every ~10s is far denser than
+/// v1.2.4: node metrics keep a week. A report every ~10s is far denser than
 /// per-rule traffic, and week-old CPU is rarely what you are looking for —
 /// paying 35 days of rows for it would be the wrong trade.
 const METRICS_RETENTION_DAYS: i64 = 7;
@@ -62,7 +62,7 @@ pub fn spawn(state: AppState) {
                 Err(e) => tracing::error!("node-metrics: prune failed: {}", e),
             }
 
-            // v1.3.0: the audit trail, on its own much longer cutoff. Swept in
+            // v1.2.4: the audit trail, on its own much longer cutoff. Swept in
             // the same pass but independently — one table failing must not skip
             // the others.
             let audit_cutoff = (chrono::Utc::now()

--- a/crates/panel/src/service/site.rs
+++ b/crates/panel/src/service/site.rs
@@ -1,4 +1,4 @@
-//! v1.3.0: operator-configurable site identity.
+//! v1.2.4: operator-configurable site identity.
 //!
 //! The brand string was hardcoded in three places (login page, sidebar, browser
 //! title), so every operator running this panel showed "RelayPanel" to their own
@@ -35,7 +35,7 @@ pub struct SiteConfig {
     /// Free text shown to signed-in users on the dashboard and account page.
     /// Empty = the banner is not rendered at all, rather than an empty box.
     ///
-    /// v1.3.0: a small Markdown subset (bold / italic / code / links / lists)
+    /// v1.2.4: a small Markdown subset (bold / italic / code / links / lists)
     /// is rendered by the frontend. Stored verbatim — the rendering side turns
     /// it into React elements, never into HTML, so there is nothing to escape
     /// here.
@@ -66,7 +66,7 @@ impl SiteConfig {
         if cfg.site_name.trim().is_empty() {
             cfg.site_name = DEFAULT_NAME.to_string();
         }
-        // Rows written before v1.3.0 have no type at all, and a bad value must
+        // Rows written before v1.2.4 have no type at all, and a bad value must
         // not reach the frontend as an unknown antd Alert type.
         if !ANNOUNCEMENT_TYPES.contains(&cfg.announcement_type.as_str()) {
             cfg.announcement_type = DEFAULT_ANNOUNCEMENT_TYPE.to_string();
@@ -127,7 +127,7 @@ mod tests {
     }
 
     /// An unknown or absent banner type must become a known one. It is handed
-    /// straight to antd's Alert `type`, and rows written before v1.3.0 have no
+    /// straight to antd's Alert `type`, and rows written before v1.2.4 have no
     /// value at all.
     #[test]
     fn announcement_type_falls_back_to_a_known_severity() {

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.3}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.4}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import { useSite } from './hooks/useSite';
 
 function AppInner() {
   const { lang } = useI18n();
-  // v1.3.0: the browser tab title follows the operator's site name. Done here,
+  // v1.2.4: the browser tab title follows the operator's site name. Done here,
   // once, rather than in each page — the title is a property of the app, and a
   // per-page effect would fight itself on navigation.
   const site = useSite();

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -108,7 +108,7 @@ export interface TrafficHistoryBucket {
   billed_total: number;
 }
 
-/** v1.3.0: one node's metrics for one bucket. CPU/memory are 0..1 fractions;
+/** v1.2.4: one node's metrics for one bucket. CPU/memory are 0..1 fractions;
  *  connections is a raw count. `*_avg` is the sample-weighted mean of the
  *  bucket, `*_max` its peak — both are kept because an average alone flattens
  *  the spike that caused a stall. */
@@ -200,7 +200,7 @@ export interface ListCodesResponse {
   total: number;
 }
 
-/** v1.3.0: one of the caller's own redeem-code top-ups. `code` arrives already
+/** v1.2.4: one of the caller's own redeem-code top-ups. `code` arrives already
  *  masked to the last group — the server never sends the full value here. */
 export interface MyRedeemRecord {
   id: number;
@@ -209,7 +209,7 @@ export interface MyRedeemRecord {
   used_at: string | null;
 }
 
-/** v1.3.0: one site announcement. Replaces the single announcement string that
+/** v1.2.4: one site announcement. Replaces the single announcement string that
  *  used to live in the site config. */
 export interface Announcement {
   id: number;
@@ -231,7 +231,7 @@ export interface AnnouncementList {
   total: number;
 }
 
-/** v1.3.0: one site announcement. Replaces the single announcement string that
+/** v1.2.4: one site announcement. Replaces the single announcement string that
  *  used to live in the site config. */
 export interface Announcement {
   id: number;
@@ -253,22 +253,22 @@ export interface AnnouncementList {
   total: number;
 }
 
-/** v1.3.0: public site branding. No announcement/contact — those are behind
+/** v1.2.4: public site branding. No announcement/contact — those are behind
  *  the authenticated /user/site-notice endpoint. */
 export interface PublicSite {
   site_name: string;
   subtitle: string;
 }
 
-/** v1.3.0: the signed-in half of the site config. */
+/** v1.2.4: the signed-in half of the site config. */
 export interface SiteNotice {
   contact: string;
 }
 
-/** v1.3.0: the full site config, as the admin form reads and writes it. */
+/** v1.2.4: the full site config, as the admin form reads and writes it. */
 export interface SiteConfig extends PublicSite, SiteNotice {}
 
-/** v1.3.0: one recorded admin action. */
+/** v1.2.4: one recorded admin action. */
 export interface AuditEntry {
   id: number;
   ts: string;

--- a/frontend/src/components/AllOrders.tsx
+++ b/frontend/src/components/AllOrders.tsx
@@ -21,7 +21,7 @@ interface AdminOrderRow {
 }
 
 /**
- * v1.3.0: every user's purchases, under the plan-management table.
+ * v1.2.4: every user's purchases, under the plan-management table.
  *
  * The shop page shows a user their own orders; this is the operator's view of
  * all of them, which is what answers "who bought what this week". Paginated

--- a/frontend/src/components/NodeMetricsChart.tsx
+++ b/frontend/src/components/NodeMetricsChart.tsx
@@ -18,7 +18,7 @@ interface Point {
 }
 
 /**
- * v1.3.0: node CPU / memory / connection history.
+ * v1.2.4: node CPU / memory / connection history.
  *
  * Node status is a snapshot each report overwrites, so "why was it slow last
  * night" previously had no data behind it. This charts the hourly rollup.

--- a/frontend/src/components/RedeemHistory.tsx
+++ b/frontend/src/components/RedeemHistory.tsx
@@ -5,7 +5,7 @@ import type { ApiEnvelope, MyRedeemRecord } from '../api/types';
 import { useI18n } from '../i18n/context';
 
 /**
- * v1.3.0: the user's own redeem-code top-ups, on the account page.
+ * v1.2.4: the user's own redeem-code top-ups, on the account page.
  *
  * Purchase history is deliberately NOT here — it lives on the shop page, where
  * buying and seeing the receipt happen in the same place. Showing the same

--- a/frontend/src/components/SiteAnnouncement.tsx
+++ b/frontend/src/components/SiteAnnouncement.tsx
@@ -13,7 +13,7 @@ const TYPES = ['info', 'success', 'warning', 'error'] as const;
 type AlertType = (typeof TYPES)[number];
 
 /**
- * v1.3.0: a one-glance summary of the current announcement.
+ * v1.2.4: a one-glance summary of the current announcement.
  *
  * Deliberately NOT the full text. Carrying the whole notice made this 299px —
  * a third of the viewport — for a routine maintenance message, pushing the

--- a/frontend/src/hooks/useActiveAnnouncement.ts
+++ b/frontend/src/hooks/useActiveAnnouncement.ts
@@ -3,7 +3,7 @@ import api from '../api/client';
 import type { ApiEnvelope, Announcement } from '../api/types';
 
 /**
- * v1.3.0: the one announcement the banner shows, from the authenticated
+ * v1.2.4: the one announcement the banner shows, from the authenticated
  * `/user/announcements/active`.
  *
  * `null` means there is nothing live — no pinned notice, and everything else

--- a/frontend/src/hooks/useAnnouncementBadge.ts
+++ b/frontend/src/hooks/useAnnouncementBadge.ts
@@ -3,7 +3,7 @@ import api from '../api/client';
 import type { ApiEnvelope } from '../api/types';
 
 /**
- * v1.3.0: unread state for the header announcement bell.
+ * v1.2.4: unread state for the header announcement bell.
  *
  * "Unread" is `latest id > the id this account last looked at`. The id, not a
  * timestamp: editing an old notice must not re-notify everyone, and only a new

--- a/frontend/src/hooks/useSite.ts
+++ b/frontend/src/hooks/useSite.ts
@@ -3,7 +3,7 @@ import api from '../api/client';
 import type { ApiEnvelope, PublicSite } from '../api/types';
 
 /**
- * v1.3.0: the operator's site branding (name + subtitle).
+ * v1.2.4: the operator's site branding (name + subtitle).
  *
  * Served by the PUBLIC `/site` endpoint, because the login page renders the
  * brand before anyone has a token. The announcement and support contact are

--- a/frontend/src/hooks/useSiteNotice.ts
+++ b/frontend/src/hooks/useSiteNotice.ts
@@ -3,7 +3,7 @@ import api from '../api/client';
 import type { ApiEnvelope, SiteNotice } from '../api/types';
 
 /**
- * v1.3.0: the signed-in half of the site config — the support contact, from the AUTHENTICATED `/user/site-notice`.
+ * v1.2.4: the signed-in half of the site config — the support contact, from the AUTHENTICATED `/user/site-notice`.
  *
  * Separate from `useSite` (public branding) because the two have different auth
  * requirements, not just different fields: the login page reads branding with

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -581,12 +581,12 @@ export const enUS: Dict = {
   notifyCredentialNote: 'Note: the bot token and SMTP password are stored in plaintext (same as node tokens). The API never returns them to the browser.',
 
   // ── v1.2.0: redeem codes ──
-  // ── v1.3.0: account money history ──
+  // ── v1.2.4: account money history ──
   rechargeHistory: 'Top-up History',
   rechargeAmount: 'Amount',
   rechargeTime: 'Redeemed at',
   noRecharges: 'No top-ups yet',
-  // ── v1.3.0: announcements ──
+  // ── v1.2.4: announcements ──
   announcements: 'Announcements',
   announcementAdmin: 'Announcements',
   announcementTitle: 'Title',
@@ -628,7 +628,7 @@ export const enUS: Dict = {
   auditTargetSettings: 'Settings',
   auditTargetSettingsNotify: 'Notification settings',
   auditTargetSettingsSite: 'Site settings',
-  // ── v1.3.0: site settings ──
+  // ── v1.2.4: site settings ──
   siteSettings: 'Site Settings',
   siteName: 'Site name',
   siteNameHint: 'Shown on the login page, in the sidebar, and as the browser tab title. Empty falls back to RelayPanel.',
@@ -648,7 +648,7 @@ export const enUS: Dict = {
   siteContactHint: 'Shown on the account page — a Telegram handle, an email, whatever. Empty hides the row.',
   siteFieldTooLong: 'Too long',
   siteSettingsHint: 'Takes effect immediately. The announcement and contact require sign-in to read and never appear on the login page.',
-  // ── v1.3.0: audit log ──
+  // ── v1.2.4: audit log ──
   auditLog: 'Audit Log',
   auditTime: 'Time (UTC)',
   auditActor: 'Actor',

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -579,12 +579,12 @@ export const zhCN = {
   notifyTestFailed: '测试发送失败',
   notifyCredentialNote: '说明:Bot Token 和 SMTP 密码以明文存储在数据库中(与节点令牌一致),接口不会把它们返回给浏览器。',
 
-  // ── v1.3.0: 个人中心账目记录 ──
+  // ── v1.2.4: 个人中心账目记录 ──
   rechargeHistory: '卡密充值记录',
   rechargeAmount: '充值金额',
   rechargeTime: '充值时间',
   noRecharges: '暂无充值记录',
-  // ── v1.3.0: 公告 ──
+  // ── v1.2.4: 公告 ──
   announcements: '公告',
   announcementAdmin: '公告管理',
   announcementTitle: '标题',
@@ -625,7 +625,7 @@ export const zhCN = {
   auditTargetSettings: '设置',
   auditTargetSettingsNotify: '通知设置',
   auditTargetSettingsSite: '站点设置',
-  // ── v1.3.0: 站点设置 ──
+  // ── v1.2.4: 站点设置 ──
   siteSettings: '站点设置',
   siteName: '站点名称',
   siteNameHint: '显示在登录页、左侧边栏和浏览器标签标题。留空则使用 RelayPanel。',
@@ -645,7 +645,7 @@ export const zhCN = {
   siteContactHint: '显示在个人中心,例如 Telegram 或邮箱。留空则不显示该行。',
   siteFieldTooLong: '内容过长',
   siteSettingsHint: '保存后立即生效。公告和客服方式需要登录才能读取,不会出现在登录页。',
-  // ── v1.3.0: 操作审计 ──
+  // ── v1.2.4: 操作审计 ──
   auditLog: '操作审计',
   auditTime: '时间 (UTC)',
   auditActor: '操作人',

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -49,7 +49,7 @@ export default function MainLayout() {
     { key: '/rules', icon: <ApiOutlined />, label: t('myRules') },
     { key: '/nodes', icon: <CloudServerOutlined />, label: t('availableNodes') },
   ];
-  // v1.3.0: the admin list had grown to seven top-level entries. Grouped into
+  // v1.2.4: the admin list had grown to seven top-level entries. Grouped into
   // two submenus by what they ARE, not just to shorten the list:
   //
   //   billing  — records you create, edit and delete day to day
@@ -154,7 +154,7 @@ export default function MainLayout() {
           borderBottom: '1px solid var(--rp-border)',
         }}>
           <Space size="middle">
-            {/* v1.3.0: announcements live here rather than in the sidebar.
+            {/* v1.2.4: announcements live here rather than in the sidebar.
                 The banner already carries the current notice, so a menu row
                 would only be a route to the archive — a low-frequency
                 destination sitting beside pages people use daily. A bell also

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -133,7 +133,7 @@ export default function Account() {
 
   return (
     <>
-      {/* v1.3.0: operator announcement. Regular users land here rather than on
+      {/* v1.2.4: operator announcement. Regular users land here rather than on
           the dashboard, so without this they would never see one. */}
       <SiteAnnouncement />
       {/* v1.0.8: suspended banner — the user can still log in and buy a plan
@@ -223,7 +223,7 @@ export default function Account() {
           <Descriptions.Item label={t('accountMemberSince')}>
             <span className="rp-mono">{me.registered_at || '-'}</span>
           </Descriptions.Item>
-          {/* v1.3.0: only rendered when the operator filled it in — an empty
+          {/* v1.2.4: only rendered when the operator filled it in — an empty
               "Support" row would just look like something is broken. */}
           {notice.contact && (
             <Descriptions.Item label={t('siteContact')}>
@@ -240,7 +240,7 @@ export default function Account() {
           per-rule drill-down) on the dashboard, and an admin's "personal"
           traffic is a near-meaningless number. The same card on two pages is
           just noise. */}
-      {/* v1.3.0: the user's own top-up history. Above the traffic chart —
+      {/* v1.2.4: the user's own top-up history. Above the traffic chart —
           "where did my balance come from" is the question that brings people to
           this page, and it should not sit below a chart. Purchase history is
           not duplicated here; it stays on the shop page. */}

--- a/frontend/src/pages/AnnouncementAdmin.tsx
+++ b/frontend/src/pages/AnnouncementAdmin.tsx
@@ -35,7 +35,7 @@ interface FormValues {
 }
 
 /**
- * v1.3.0: announcement management.
+ * v1.2.4: announcement management.
  *
  * Replaces the single announcement field on the site-settings page. That field
  * held one notice and overwrote it on every edit; this keeps every notice, so

--- a/frontend/src/pages/Announcements.tsx
+++ b/frontend/src/pages/Announcements.tsx
@@ -20,7 +20,7 @@ const TAG_COLOR: Record<string, string> = {
 };
 
 /**
- * v1.3.0: the announcement archive, for any signed-in user.
+ * v1.2.4: the announcement archive, for any signed-in user.
  *
  * The banner only ever shows one notice, so without this page everything the
  * operator ever announced was unreadable the moment the next one went up.

--- a/frontend/src/pages/AuditLog.tsx
+++ b/frontend/src/pages/AuditLog.tsx
@@ -55,7 +55,7 @@ const DESTRUCTIVE = new Set<string>([
 const PAGE_SIZE = 20;
 
 /**
- * v1.3.0: admin audit trail.
+ * v1.2.4: admin audit trail.
  *
  * Answers "who deleted my rule" from the panel instead of from a container log
  * that rotates and dies with the process.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -277,7 +277,7 @@ export default function Dashboard() {
       {/* v1.2.0: fleet-wide traffic trend, with per-rule drill-down. */}
       <TrafficChart rules={ruleList.map(r => ({ id: r.id, name: r.name }))} />
 
-      {/* v1.3.0: node CPU / memory / connections, directly below the traffic
+      {/* v1.2.4: node CPU / memory / connections, directly below the traffic
           chart — the two answer "how much" and "was the box coping", which is
           the order you ask them in. Admin-only endpoint, and this page is
           already admin-only. */}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -70,7 +70,7 @@ export default function Login() {
       </div>
       <Card style={{ width: 380, boxShadow: 'var(--rp-shadow)' }}>
         <div style={{ textAlign: 'center', marginBottom: 28 }}>
-          {/* v1.3.0: operator-configurable branding, falling back to the
+          {/* v1.2.4: operator-configurable branding, falling back to the
               translated default so an unconfigured panel looks unchanged. */}
           <Title level={3} style={{ margin: 0, fontWeight: 600 }}>{site.site_name || t('brand')}</Title>
           <Text type="secondary" style={{ fontSize: 13 }}>{site.subtitle || t('subtitle')}</Text>

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -199,7 +199,7 @@ export default function Plans() {
       </div>
       <Table dataSource={plans} columns={columns} rowKey="id" loading={loading} pagination={{ pageSize: 20 }} />
 
-      {/* v1.3.0: the operator's view of every purchase. Below the plan
+      {/* v1.2.4: the operator's view of every purchase. Below the plan
           table because it is a consequence of it — you set the prices here,
           you see what sold here. */}
       <AllOrders />

--- a/frontend/src/pages/SiteSettings.tsx
+++ b/frontend/src/pages/SiteSettings.tsx
@@ -17,13 +17,13 @@ const MAX_CONTACT = 256;
 
 
 /**
- * v1.3.0: site identity — name, subtitle, support contact.
+ * v1.2.4: site identity — name, subtitle, support contact.
  *
  * Separate from "System Settings", which is registration policy (open
  * registration / allowed plans / default plan). Different concerns, and folding
  * them into one page would make both harder to scan.
  *
- * The announcement moved out in v1.3.0: it became a table with history, so it
+ * The announcement moved out in v1.2.4: it became a table with history, so it
  * has its own management page rather than one overwritable field here.
  */
 export default function SiteSettings() {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -79,18 +79,18 @@ export const router = createBrowserRouter([
       { path: 'plans', element: <RequireAdmin><Plans /></RequireAdmin> },
       // v1.2.0: redeem-code management (admin-only).
       { path: 'redeem-codes', element: <RequireAdmin><RedeemCodes /></RequireAdmin> },
-      // v1.3.0: admin audit trail (read-only).
+      // v1.2.4: admin audit trail (read-only).
       { path: 'audit-log', element: <RequireAdmin><AuditLog /></RequireAdmin> },
       // v0.4.20: tunnel-profiles route hidden; component kept for future recovery.
       { path: 'users', element: <RequireAdmin><Users /></RequireAdmin> },
-      // v1.3.0: operator-configurable site identity, separate from the
+      // v1.2.4: operator-configurable site identity, separate from the
       // registration policy that lives on /settings.
       { path: 'site-settings', element: <RequireAdmin><SiteSettings /></RequireAdmin> },
       { path: 'settings', element: <RequireAdmin><SystemSettings /></RequireAdmin> },
-      // v1.3.0: notification settings were a second card on /settings; they
+      // v1.2.4: notification settings were a second card on /settings; they
       // are their own entry now that 系统设置 is a submenu.
       { path: 'notify-settings', element: <RequireAdmin><NotifySettings /></RequireAdmin> },
-      // v1.3.0: the announcement archive is for every signed-in user; the
+      // v1.2.4: the announcement archive is for every signed-in user; the
       // management page is admin-only.
       { path: 'announcements', element: <Announcements /> },
       { path: 'announcement-admin', element: <RequireAdmin><AnnouncementAdmin /></RequireAdmin> },

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -52,7 +52,7 @@ window.getComputedStyle = ((elt: Element) =>
 // library; the page tests keep testing the page around it.
 vi.mock('@ant-design/charts', () => ({
   Column: () => null,
-  // v1.3.0: NodeMetricsChart uses Line. A chart component missing from this
+  // v1.2.4: NodeMetricsChart uses Line. A chart component missing from this
   // stub throws at import time and fails every test on the page that embeds
   // it — add the export here when a page starts using a new chart type.
   Line: () => null,

--- a/frontend/src/utils/announcementKind.ts
+++ b/frontend/src/utils/announcementKind.ts
@@ -1,7 +1,7 @@
 import type { Dict } from '../i18n/zh-CN';
 
 /**
- * v1.3.0: the display label for an announcement severity.
+ * v1.2.4: the display label for an announcement severity.
  *
  * The raw value (`info` / `success` / `warning` / `error`) is a wire value, not
  * something to show an operator. The tag labels are deliberately SHORT — the

--- a/frontend/src/utils/markdown.tsx
+++ b/frontend/src/utils/markdown.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 /**
- * v1.3.0: a deliberately tiny Markdown subset for the site announcement.
+ * v1.2.4: a deliberately tiny Markdown subset for the site announcement.
  *
  * Renders to **React elements, never to an HTML string**. That is the whole
  * design: React escapes text nodes, so there is no sanitizer to get wrong and


### PR DESCRIPTION
1.2.3 之后累计 **14 个 PR**,发 v1.2.4。

**面板单独发布** —— 配置协议仍是版本 4,现有节点照常工作,**不需要发节点版本、不需要升级节点**。

## 升级须知

首次启动由迁移建三张表:节点指标历史、审计日志、公告。**不需要改配置。**

一件必须知道的事:**你现在配置的那条公告会被 Migration 44 搬进新的公告表**,升级后不会消失,它会作为第一条出现在新的「公告」页里。(不搬的话,存它的那个字段升级后就不再被读取,公告等于凭空不见。)

## 关于版本号

这批改动本来按 v1.3.0 写的,改为 v1.2.4 发布。因此**同步重写了 43 个文件里的 101 处 `v1.3.0:` 注释标记**。那些标记的作用就是回答"这行是哪个版本加的",指向一个永远不会存在的版本比没有更糟。纯注释改动,无行为影响。

`release-check.sh panel 1.2.4`:**0 FAIL**(`Cargo.toml` / `Cargo.lock` / `config.rs` 的 `COMPILED_APP_VERSION` / `docker-compose.release.yaml` 镜像 tag / CHANGELOG 的 `[1.2.4]` 段全部对齐)。

顺手重写了 CHANGELOG 的发布导语 —— 它是攒批过程中逐步写的,已经过时(写着"两张新表",实际三张;也没提公告数据会被搬运)。发布正文是运维升级前唯一会读的东西。

## 验证

511 后端 / 242 前端测试;parity(137/136);clippy、fmt、typecheck、lint 全部干净。

## 合并后

我打 `v1.2.4` tag 触发镜像构建,然后改官网。
