### PR TITLE
feat(cli): 新增 reset-admin-password 命令

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`relay-panel reset-admin-password [USER]`.** Recovering a lost admin
+  password meant editing the database by hand: pasting a bcrypt placeholder
+  full of `$` through a shell, which mangles under quoting, only worked for
+  user id 1, and failed SILENTLY when the pattern did not match. Somebody
+  locked out of their own panel is the last person who should be debugging
+  shell escaping.
+
+      docker exec relay-panel-panel-1 ./relay-panel reset-admin-password
+
+  The password is generated, not taken from the arguments — anything passed on
+  a command line lands in shell history and is visible to `ps` on a shared
+  host. Sixteen characters with at least one of each class, drawn from the OS
+  CSPRNG with rejection sampling so no character is likelier than another.
+  Ambiguous glyphs (`0/O`, `1/l/I`) and shell-hostile ones (quotes, backslash,
+  backtick, `$`) are excluded: this gets read off a terminal, retyped, and
+  pasted through shells.
+
+  Resetting signs out that account's existing sessions, which matters when the
+  reason for the lockout is that somebody else got in. It does NOT force a
+  password change on next login — the generated password is strong enough to
+  keep — and it writes an audit entry so the reset is visible afterwards.
+
+  USER defaults to `admin`; passing a name fixes the old id-1-only limitation.
+
+---
+
 ## [1.2.4] - 2026-07-29
 
 Panel only — no node release, and no node change is required (the config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ dependencies = [
  "bcrypt",
  "chrono",
  "futures-util",
+ "getrandom 0.2.17",
  "jsonwebtoken",
  "lettre",
  "once_cell",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -19,6 +19,9 @@ futures-util = "0.3"
 bcrypt = "0.16"
 jsonwebtoken = "9"
 uuid = { version = "1", features = ["v4"] }
+# Already in the tree transitively; taken as a direct dep so the password
+# generator draws from the OS CSPRNG explicitly rather than through uuid.
+getrandom = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 once_cell = "1"
 semver = "1"

--- a/crates/panel/src/cli.rs
+++ b/crates/panel/src/cli.rs
@@ -1,0 +1,104 @@
+//! v1.2.5: command-line recovery, run against the same database the server uses.
+//!
+//! Exists because the only way to recover a lost admin password was to edit the
+//! database by hand — pasting a bcrypt placeholder string full of `$` through a
+//! shell, which mangles under quoting, only worked for user id 1, and failed
+//! SILENTLY when the pattern did not match. An operator locked out of their own
+//! panel is exactly the person who should not be debugging shell escaping.
+//!
+//! These subcommands are reachable only from the CLI. Anyone who can run them
+//! already has the database file, so they add no attack surface — but they must
+//! never be wired to an HTTP route.
+
+use crate::db::repo::{NewAuditEntry, Repository};
+use crate::service::password::{generate_password, hash_password};
+use std::sync::Arc;
+
+pub const USAGE: &str = "\
+RelayPanel — self-hosted TCP/UDP forwarding panel
+
+USAGE:
+    relay-panel                                 start the server (default)
+    relay-panel reset-admin-password [USER]     reset a password, print a new one
+    relay-panel --help                          show this
+
+reset-admin-password:
+    USER defaults to `admin`. A strong password is generated and printed once —
+    it is not read from the arguments, because anything passed on the command
+    line lands in shell history and is visible to `ps` on a shared host.
+
+    All of that account's existing sessions are signed out.
+";
+
+/// Reset one account's password to a freshly generated one. Returns the process
+/// exit code.
+pub async fn reset_admin_password(db: Arc<dyn Repository>, username: &str) -> i32 {
+    let user = match db.find_by_username(username).await {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            eprintln!("错误：用户 `{username}` 不存在。");
+            eprintln!("提示：管理员账号默认叫 `admin`；也可以传入用户名，例如：");
+            eprintln!("      relay-panel reset-admin-password someone");
+            return 1;
+        }
+        Err(e) => {
+            eprintln!("错误：查询用户失败：{e}");
+            return 1;
+        }
+    };
+
+    let password = generate_password();
+    let hash = match hash_password(&password) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("错误：密码哈希失败：{e}");
+            return 1;
+        }
+    };
+
+    // must_change_password = false: the generated password is strong enough to
+    // keep, and someone who has just been locked out should not be made to pick
+    // a new one before they can look at anything.
+    //
+    // The same call bumps token_version, which signs out every existing session
+    // for this account. That matters most in the case where the reason for the
+    // lockout is that somebody else got in.
+    match db.admin_reset_password(user.id, &hash, false).await {
+        Ok(0) => {
+            eprintln!("错误：用户 `{username}` 在更新时已不存在。");
+            return 1;
+        }
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("错误：更新密码失败：{e}");
+            return 1;
+        }
+    }
+
+    // Recorded so the operator can later see that a CLI reset happened and when.
+    // actor_id is None — there is no authenticated user behind a shell command,
+    // and inventing one would put a false name in the trail.
+    let entry = NewAuditEntry {
+        ts: chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+        actor_id: None,
+        actor_name: "命令行".to_string(),
+        action: "reset_password".to_string(),
+        target_type: "user".to_string(),
+        target_id: user.id.to_string(),
+        detail: format!("{username} — 通过命令行重置"),
+    };
+    if let Err(e) = db.record_audit(&entry).await {
+        // Best-effort, exactly like the HTTP path: the password IS reset, and
+        // failing the command now would leave the operator thinking it was not.
+        eprintln!("警告：审计记录写入失败（密码已重置）：{e}");
+    }
+
+    println!();
+    println!("  用户名： {username}");
+    println!("  新密码： {password}");
+    println!();
+    println!("  该账号的所有登录会话已失效，请用上面的密码重新登录。");
+    println!("  这串密码现在留在你的终端记录里，建议登录后到「个人中心 → 修改密码」换掉。");
+    println!();
+    0
+}

--- a/crates/panel/src/main.rs
+++ b/crates/panel/src/main.rs
@@ -1,4 +1,5 @@
 mod api;
+mod cli;
 mod config;
 mod db;
 mod dto;
@@ -21,33 +22,31 @@ async fn main() {
 
     let config = Config::load();
 
-    // v0.4.3: backend is chosen at startup by the database_url prefix and is
-    // fixed for the process lifetime — NO runtime switching, NO fallback. If
-    // the URL is a PostgreSQL DSN, we init PG; anything else (including the
-    // default SQLite file path) inits SQLite.
-    //
-    // Fail-fast contract: a configured PG backend that can't connect MUST
-    // terminate startup. Falling back to SQLite would silently write data
-    // locally while the user believes it's in PG — strictly worse than a crash.
-    // The `?` in init_db/init_pg propagates errors to `.expect()`, which panics
-    // and exits with a non-zero status. No `unwrap_or_else(fallback)` branch.
-    let db: Arc<dyn Repository> = if is_postgres_url(&config.database_path) {
-        tracing::info!("database backend: PostgreSQL");
-        let pool = init_pg(&config.database_path)
-            .await
-            .expect("Failed to initialize PostgreSQL database");
-        Arc::new(PgRepository::new(pool))
-    } else {
-        if config.database_path == "sqlite::memory:" || config.database_path.is_empty() {
-            tracing::info!("database backend: SQLite (in-memory / default)");
-        } else {
-            tracing::info!("database backend: SQLite ({})", config.database_path);
+    // v1.2.5: CLI subcommands run against the same database and then exit —
+    // they never start the HTTP server. Checked before anything else binds a
+    // port, so a recovery command works on a host where the panel is already
+    // running.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Some(cmd) = args.first() {
+        match cmd.as_str() {
+            "reset-admin-password" => {
+                let db = open_database(&config).await;
+                let username = args.get(1).map(String::as_str).unwrap_or("admin");
+                std::process::exit(cli::reset_admin_password(db, username).await);
+            }
+            "--help" | "-h" | "help" => {
+                print!("{}", cli::USAGE);
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("未知命令：{other}\n");
+                print!("{}", cli::USAGE);
+                std::process::exit(2);
+            }
         }
-        let pool = init_db(&config.database_path)
-            .await
-            .expect("Failed to initialize SQLite database");
-        Arc::new(SqliteRepository::new(pool))
-    };
+    }
+
+    let db = open_database(&config).await;
 
     // v0.4.10 PR3: seed the app_settings row from REGISTRATION_ENABLED on the
     // very first boot. insert_settings_if_absent is a no-op once the row
@@ -136,4 +135,37 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
+}
+
+/// Open the configured backend, run migrations, and return the repository.
+/// Shared by the server path and the CLI subcommands so they can never
+/// diverge on which database they touch.
+async fn open_database(config: &Config) -> Arc<dyn Repository> {
+    // v0.4.3: backend is chosen at startup by the database_url prefix and is
+    // fixed for the process lifetime — NO runtime switching, NO fallback. If
+    // the URL is a PostgreSQL DSN, we init PG; anything else (including the
+    // default SQLite file path) inits SQLite.
+    //
+    // Fail-fast contract: a configured PG backend that can't connect MUST
+    // terminate startup. Falling back to SQLite would silently write data
+    // locally while the user believes it's in PG — strictly worse than a crash.
+    // The `?` in init_db/init_pg propagates errors to `.expect()`, which panics
+    // and exits with a non-zero status. No `unwrap_or_else(fallback)` branch.
+    if is_postgres_url(&config.database_path) {
+        tracing::info!("database backend: PostgreSQL");
+        let pool = init_pg(&config.database_path)
+            .await
+            .expect("Failed to initialize PostgreSQL database");
+        Arc::new(PgRepository::new(pool))
+    } else {
+        if config.database_path == "sqlite::memory:" || config.database_path.is_empty() {
+            tracing::info!("database backend: SQLite (in-memory / default)");
+        } else {
+            tracing::info!("database backend: SQLite ({})", config.database_path);
+        }
+        let pool = init_db(&config.database_path)
+            .await
+            .expect("Failed to initialize SQLite database");
+        Arc::new(SqliteRepository::new(pool))
+    }
 }

--- a/crates/panel/src/service/password.rs
+++ b/crates/panel/src/service/password.rs
@@ -14,6 +14,85 @@ pub fn validate_password(password: &str) -> Result<(), PasswordValidationError> 
     Ok(())
 }
 
+/// Character classes for a generated recovery password.
+///
+/// Ambiguous glyphs are left out on purpose — `0/O` and `1/l/I` are read off a
+/// terminal and retyped by hand often enough that the confusion costs more than
+/// the handful of bits. Quotes, backslash and backtick are out too: the value
+/// gets pasted through shells on its way to a browser, and those are exactly
+/// the characters that break when it does.
+const GEN_LOWER: &[u8] = b"abcdefghijkmnopqrstuvwxyz";
+const GEN_UPPER: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ";
+const GEN_DIGIT: &[u8] = b"23456789";
+const GEN_SYMBOL: &[u8] = b"!@#%^&*-_=+?";
+
+/// Length of a generated password. Long enough that this stays acceptable as a
+/// permanent password, since the reset flow does not force a change.
+pub const GENERATED_PASSWORD_LEN: usize = 16;
+
+/// Draw `n` bytes from the OS CSPRNG.
+///
+/// Panics rather than falling back to anything weaker: a "random" password from
+/// a degraded source is worse than no password reset at all, because the
+/// operator would never know.
+fn random_bytes(n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    getrandom::getrandom(&mut buf).expect("OS randomness unavailable");
+    buf
+}
+
+/// Uniformly pick one byte from `set`, without modulo bias.
+///
+/// Rejection sampling: bytes at or above the largest whole multiple of the set
+/// size are discarded. Taking `% len` directly would make the first
+/// `256 % len` characters measurably likelier.
+fn pick(set: &[u8]) -> u8 {
+    let len = set.len();
+    let limit = 256 - (256 % len);
+    loop {
+        let b = random_bytes(1)[0] as usize;
+        if b < limit {
+            return set[b % len];
+        }
+    }
+}
+
+/// A random password containing at least one lowercase, uppercase, digit and
+/// symbol.
+///
+/// The four classes are placed first and then shuffled in, rather than hoped
+/// for: drawing 16 characters from the combined set leaves a real chance of
+/// producing one with no digit at all, and an operator who is told the password
+/// has a digit should get one.
+pub fn generate_password() -> String {
+    let mut chars: Vec<u8> = vec![
+        pick(GEN_LOWER),
+        pick(GEN_UPPER),
+        pick(GEN_DIGIT),
+        pick(GEN_SYMBOL),
+    ];
+    let all: Vec<u8> = [GEN_LOWER, GEN_UPPER, GEN_DIGIT, GEN_SYMBOL].concat();
+    while chars.len() < GENERATED_PASSWORD_LEN {
+        chars.push(pick(&all));
+    }
+
+    // Fisher-Yates, so the guaranteed four are not always in positions 0..4.
+    for i in (1..chars.len()).rev() {
+        let j = {
+            let limit = 256 - (256 % (i + 1));
+            loop {
+                let b = random_bytes(1)[0] as usize;
+                if b < limit {
+                    break b % (i + 1);
+                }
+            }
+        };
+        chars.swap(i, j);
+    }
+
+    String::from_utf8(chars).expect("charset is ASCII")
+}
+
 pub fn hash_password(password: &str) -> Result<String, bcrypt::BcryptError> {
     bcrypt::hash(password, 12)
 }
@@ -25,6 +104,75 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every generated password contains all four classes. Drawing 16 characters
+    /// from the combined set would leave a real chance of producing one with no
+    /// digit, and an operator told the password has digits should get one.
+    /// Repeated because this is a probabilistic property — one sample proves
+    /// nothing.
+    #[test]
+    fn generated_password_always_has_all_four_classes() {
+        for _ in 0..200 {
+            let p = generate_password();
+            assert_eq!(p.chars().count(), GENERATED_PASSWORD_LEN);
+            assert!(
+                p.chars().any(|c| c.is_ascii_lowercase()),
+                "no lowercase in {p}"
+            );
+            assert!(
+                p.chars().any(|c| c.is_ascii_uppercase()),
+                "no uppercase in {p}"
+            );
+            assert!(p.chars().any(|c| c.is_ascii_digit()), "no digit in {p}");
+            assert!(
+                p.chars().any(|c| GEN_SYMBOL.contains(&(c as u8))),
+                "no symbol in {p}"
+            );
+        }
+    }
+
+    /// Ambiguous glyphs stay out. These get read off a terminal and retyped, and
+    /// 0/O or 1/l/I costs more in failed logins than it buys in entropy.
+    #[test]
+    fn generated_password_avoids_ambiguous_characters() {
+        for _ in 0..200 {
+            let p = generate_password();
+            for bad in ['0', 'O', '1', 'l', 'I'] {
+                assert!(!p.contains(bad), "{p} contains ambiguous {bad}");
+            }
+        }
+    }
+
+    /// Nothing that breaks when the value is pasted through a shell on its way
+    /// to a browser.
+    #[test]
+    fn generated_password_has_no_quoting_hazards() {
+        for _ in 0..200 {
+            let p = generate_password();
+            for bad in ['\'', '"', '\\', '`', '$', ' '] {
+                assert!(!p.contains(bad), "{p} contains shell-hostile {bad}");
+            }
+        }
+    }
+
+    /// Two calls must not agree. A generator seeded from a clock or returning a
+    /// constant would sail through the class checks above.
+    #[test]
+    fn generated_passwords_differ() {
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            assert!(seen.insert(generate_password()), "generated a duplicate");
+        }
+    }
+
+    /// The generated password must satisfy the panel's own validator — otherwise
+    /// the reset would hand out something the change-password form rejects.
+    #[test]
+    fn generated_password_passes_validation() {
+        for _ in 0..50 {
+            assert!(validate_password(&generate_password()).is_ok());
+        }
+    }
 
     #[test]
     fn password_boundaries_are_enforced() {


### PR DESCRIPTION
**需要,而且现在这条路径对第三方是不可靠的。**

原来唯一的恢复办法是手改数据库:粘贴一串带 `$` 的 bcrypt 占位符过 shell(转义几乎必错)、**只对 id=1 生效**、而且**匹配不上时什么都不做也什么都不说**。需要它的人按定义就是已经被锁在外面、正在着急的人 —— 最不该让他去调 shell 转义。

```bash
docker exec relay-panel-panel-1 ./relay-panel reset-admin-password [用户名]
```

## 密码为什么是生成的,不是参数传入

命令行参数会进 shell 历史,在多用户机器上还能被 `ps` 看到。所以密码由程序生成、打印一次。

16 位,**四类字符各至少一个**。四个必需字符是先放进去再打乱的,不是"抽 16 个碰运气" —— 从合集里抽 16 个,有实打实的概率抽出一个数字都没有的,而你既然告诉用户"含数字",就得真的有。

随机源是 OS CSPRNG,并做**拒绝采样**:直接 `% len` 会让前 `256 % len` 个字符出现概率明显偏高。

排除了两类字符:

- **易混淆**(`0/O`、`1/l/I`)—— 这串东西是从终端上读出来手敲的
- **shell 敏感**(引号、反斜杠、反引号、`$`、空格)—— 它会被粘贴着穿过 shell 送进浏览器

## 三个行为决策

1. **会吊销该账号所有登录会话**(复用 `admin_reset_password`,自动 bump `token_version`)。如果他进不去的原因是**被别人接管了**,重置的同时必须把对方踢下线。
2. **不强制下次登录改密**。生成的密码强度足够长期使用,而刚被锁在外面的人不该在能看到任何东西之前先被要求再改一次。
3. **写审计记录**,操作人记为「命令行」、`actor_id` 为 None —— shell 命令背后没有已认证用户,编一个进去等于在审计里留假名。

用户名默认 `admin`,可传参 —— 顺带修掉了"只能救 id=1"的限制。

子命令**只存在于 CLI**,永远不接 HTTP 路由。能跑它的人本来就握有数据库,不构成新攻击面。

## 验证

- 516 后端测试(新增 5 条:四类字符齐全、无易混淆字符、无 shell 敏感字符、两次不重复、生成的密码能通过面板自己的校验器 —— 各跑 200 次,因为这些是概率性质,单次采样证明不了什么)
- clippy / fmt / parity 干净
- **真库实测**:全新库执行重置 → `token_version` 0→1、`must_change_password` 保持 0、审计记录已写入、**用生成的密码实际登录成功并拿到 token,且没有被要求改密**
- 确认 `CMD ["./relay-panel"]` 不带参数、compose 也没覆盖 `command`,所以加参数分发不影响正常启动

## 后续

合并后我把说明加到官网「故障排查」页和 README —— 现在那两处还没有"忘记管理员密码怎么办"。
