### PR TITLE
fix(node): detect the public IP from an endpoint reachable in China

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,6 +11,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Public-IP detection no longer uses ipify.** `api.ipify.org` is unreachable
+  from mainland China, so on a node there the probe timed out every 30 minutes
+  forever and the panel showed no address for it — and therefore no country
+  flag and no region — while the node was otherwise perfectly online. The
+  defaults are now `api-ipv4.ip.sb` / `api-ipv6.ip.sb`, which answer from both
+  sides.
+
+  Both defaults must stay **family-pinned**, and a test now enforces it. The two
+  probes validate the address family and discard a mismatch, so a dual-stack
+  endpoint — one that replies with whichever family the connection happened to
+  use — makes the IPv4 probe intermittently throw its answer away. That failure
+  appears only on dual-stack hosts and only sometimes, which is why it is worth
+  a test rather than a comment.
+
+  Existing nodes keep working unchanged and can be fixed without upgrading, by
+  setting `PUBLIC_IPV4_CHECK_URL` in `/opt/relay-node/relay-node.env` and
+  restarting. The installer now writes both variables as commented examples.
+
 ## [1.2.0] - 2026-07-21
 
 ### Added

--- a/crates/node/src/reporter.rs
+++ b/crates/node/src/reporter.rs
@@ -1014,18 +1014,35 @@ enum IpFamily {
     V6,
 }
 
+/// v1.2.1: the default endpoints, one per family.
+///
+/// These MUST be family-pinned hostnames. Both probes validate the family and
+/// DISCARD a mismatch (see `parse_ip_for_family`), so a dual-stack endpoint —
+/// one that answers over whichever family the connection used and returns that
+/// address — makes the IPv4 probe intermittently receive an IPv6 and throw it
+/// away, leaving the panel showing no address at all. It fails only on
+/// dual-stack hosts and only sometimes, which is the worst way for it to fail.
+/// `api.ip.sb/ip` is exactly such an endpoint; `api-ipv4` / `api-ipv6` are its
+/// pinned variants. A test below pins this.
+///
+/// Changed from ipify in v1.2.1: `api.ipify.org` is unreachable from mainland
+/// China, where the probe simply timed out every 30 minutes forever and the
+/// node's IP (and therefore its flag and region) stayed blank on the panel.
+const DEFAULT_IPV4_CHECK_URL: &str = "https://api-ipv4.ip.sb/ip";
+const DEFAULT_IPV6_CHECK_URL: &str = "https://api-ipv6.ip.sb/ip";
+
 /// v0.4.15: spawn TWO independent background tasks — one for IPv4, one for
 /// IPv6. Each checks once at start then every 30 min. A failure in one family
 /// never clears the other. Env overrides (later wins):
-///   IPv4: PUBLIC_IPV4_CHECK_URL → PUBLIC_IP_CHECK_URL → default ipify.org
-///   IPv6: PUBLIC_IPV6_CHECK_URL → default api6.ipify.org
+///   IPv4: PUBLIC_IPV4_CHECK_URL → PUBLIC_IP_CHECK_URL → DEFAULT_IPV4_CHECK_URL
+///   IPv6: PUBLIC_IPV6_CHECK_URL → DEFAULT_IPV6_CHECK_URL
 /// IPv6 failures are quiet (no IPv6 is normal on many hosts).
 pub fn spawn_public_ip_refresher(metrics: Arc<NodeMetrics>) {
     let v4_url = std::env::var("PUBLIC_IPV4_CHECK_URL")
         .or_else(|_| std::env::var("PUBLIC_IP_CHECK_URL"))
-        .unwrap_or_else(|_| "https://api.ipify.org".to_string());
+        .unwrap_or_else(|_| DEFAULT_IPV4_CHECK_URL.to_string());
     let v6_url = std::env::var("PUBLIC_IPV6_CHECK_URL")
-        .unwrap_or_else(|_| "https://api6.ipify.org".to_string());
+        .unwrap_or_else(|_| DEFAULT_IPV6_CHECK_URL.to_string());
 
     let m4 = metrics.clone();
     tokio::spawn(async move { run_family_refresher(m4, v4_url, IpFamily::V4, false).await });
@@ -1297,5 +1314,47 @@ mod tests {
         // An HTML error page or rate-limit text must not parse as an IP.
         assert_eq!(parse_ip_for_family("<html>429</html>", &IpFamily::V4), None);
         assert_eq!(parse_ip_for_family("not-an-ip", &IpFamily::V6), None);
+    }
+
+    /// v1.2.1: the defaults must be FAMILY-PINNED hostnames, and the two must
+    /// differ.
+    ///
+    /// This is the invariant that pairs with `parse_ip_for_family`: a probe
+    /// discards an answer from the wrong family, so pointing both probes at a
+    /// dual-stack endpoint (`api.ip.sb/ip`, `api.ipify.org` reached over v6)
+    /// makes the v4 probe intermittently throw its answer away and the panel
+    /// show no address. It breaks only on dual-stack hosts and only sometimes,
+    /// so a unit test is the only place it gets caught cheaply.
+    ///
+    /// Asserting on the shape rather than the exact URL keeps the endpoint
+    /// swappable — what must not change is that each one names its family.
+    #[test]
+    fn default_check_urls_are_family_pinned() {
+        assert_ne!(
+            DEFAULT_IPV4_CHECK_URL, DEFAULT_IPV6_CHECK_URL,
+            "one endpoint for both families cannot be family-pinned"
+        );
+        let host4 = DEFAULT_IPV4_CHECK_URL
+            .trim_start_matches("https://")
+            .split('/')
+            .next()
+            .unwrap();
+        let host6 = DEFAULT_IPV6_CHECK_URL
+            .trim_start_matches("https://")
+            .split('/')
+            .next()
+            .unwrap();
+        assert!(
+            host4.contains("ipv4") || host4.contains("-v4") || host4.contains("4."),
+            "IPv4 default must name its family, got {host4}"
+        );
+        assert!(
+            host6.contains("ipv6") || host6.contains("-v6") || host6.contains("6."),
+            "IPv6 default must name its family, got {host6}"
+        );
+        // Both must be HTTPS: the response decides what the panel displays as
+        // this node's identity, and plain HTTP lets any on-path party set it.
+        assert!(DEFAULT_IPV4_CHECK_URL.starts_with("https://"));
+        assert!(DEFAULT_IPV6_CHECK_URL.starts_with("https://"));
     }
 }

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -454,6 +454,21 @@ if [ ! -f "$ENV_FILE" ]; then
 #   OUTBOUND_INTERFACE=ens18         # node resolves this NIC's IPv4 to bind
 #   OUTBOUND_BIND_IPV4=10.0.2.61     # or pin the exact source IPv4 (overrides above)
 
+# ── v1.2.1: public-IP detection endpoints ──
+# The node does NOT read its own NIC: it asks an external service what source
+# address the outside sees, which is what makes a NAT'd host (private NIC IP,
+# mapped elastic IP) report the right address. The answer becomes the IP and
+# country flag shown on the panel; failure shows "-" and never affects
+# forwarding. Re-checked every 30 minutes, so restart to apply a change.
+#
+# Override only if the defaults are unreachable from this server. Whatever you
+# point these at MUST return a BARE IP and MUST be family-pinned — the node
+# discards an answer from the wrong family, so a dual-stack endpoint (one that
+# replies with whichever family you connected over) leaves the address blank on
+# dual-stack hosts. Test with: curl -s --max-time 5 <url>
+#   PUBLIC_IPV4_CHECK_URL=https://ipv4.icanhazip.com
+#   PUBLIC_IPV6_CHECK_URL=https://ipv6.icanhazip.com
+
 # ── TLS Simple certificate configuration (v0.4.1) ──
 # Uncomment and set these to enable TLS Simple ingress on this node.
 # The cert must be PEM format (fullchain recommended); the key must be PEM


### PR DESCRIPTION
一个节点在面板上「在线」、版本号正常、更新检查绿勾，但**网络列一直是 `-`**，没有 IP 也没有国旗。

## 原因

日志里是整齐的一串，每 30 分钟一次：

```
WARN relay_node::reporter: public_ip: check failed: error sending request for url (https://api.ipify.org/)
```

`api.ipify.org` 从中国大陆基本连不上。探测只在成功时才覆盖已存的值，所以一次都没成功过的节点从装好那天起就一直是 `-`，不会自己好。

**容易误判的点**:节点**不读本机网卡**,它是发 HTTP 请求问外部服务「我的出口 IP 是多少」。所以 NAT 机器(网卡上只有内网 IP、公网走弹性 IP 映射)本来就能正确识别 —— 探测返回的就是外面看到的那个地址。失败是**请求发不出去**,和有没有公网 IP 无关。

## 改动

默认端点换成 `api-ipv4.ip.sb` / `api-ipv6.ip.sb`，境内境外都实测过：

| 端点 | 大陆主机 | 国际出口 |
|---|---|---|
| `api.ipify.org` | ✗ 超时 | ✓ 0.385s |
| `api-ipv4.ip.sb/ip` | ✓ | ✓ 0.147s |
| `ipv4.icanhazip.com` | ✓ | ✓ 0.148s |

## 为什么加了个测试而不是写注释

默认值**必须是固定协议族的域名**。两个探测器会校验协议族并**丢弃**不符的回答（`parse_ip_for_family`），所以指向一个「同时支持 v4/v6」的端点 —— 也就是按你连过来的协议族回你那一个地址，`api.ip.sb/ip` 正是这种 —— 会让 v4 探测器时不时把答案扔掉。

**只在双栈机器上、而且只是偶尔出错**，是最难查的那种失败。已做 mutation check：把默认值换成 `api.ip.sb/ip`，测试如期失败（`IPv4 default must name its family, got api.ip.sb`）。

顺带断言了必须 HTTPS —— 这个响应决定面板上显示的节点身份，明文 HTTP 等于让路径上任何人来设置它。

## 现有节点不用升级

`PUBLIC_IPV4_CHECK_URL` 优先级仍然最高，改 `relay-node.env` 重启即可。所以安装脚本现在把这两个变量作为注释示例写进去，并写明了固定协议族的要求。

## 验证

- `cargo test -p relay-node`：16 passed（新测试单独跑过）
- `cargo clippy -p relay-node --all-targets -D warnings`：干净
- `cargo fmt --check`：干净
- `bash -n scripts/relay-node-install.sh`：通过；heredoc 里新增的行确认原样输出且保持注释

## 发布提醒

这是**节点侧**改动，要发 `node-v*` 才生效。

官网故障排查页另外加了「节点在线但网络列没有 IP」一条（中英文），**按当前线上的行为写**（默认还是 ipify + 教改 env），等 `node-v1.2.1` 发布后再更新那一段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)