### PR TITLE
docs: use a documentation IP in the example panel URL

### DIFF
--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -37,7 +37,7 @@ pub struct Config {
     pub jwt_secret: String,
     pub public_dir: String,
     /// The public-facing panel URL that nodes should connect to.
-    /// e.g. "http://45.149.92.10:18888" or "https://panel.example.com".
+    /// e.g. "http://203.0.113.10:18888" or "https://panel.example.com".
     /// If empty, the frontend falls back to window.location.origin.
     pub public_panel_url: String,
     /// Whether public self-registration (/auth/register) is allowed.

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -90,7 +90,7 @@ if [ -z "$NODE_TOKEN" ]; then
     fail "Missing required option: -t/--token. Get it from the panel's Device Groups page."
 fi
 if [ -z "$PANEL_URL" ]; then
-    fail "Missing required option: -u/--url. Example: http://45.149.92.10:18888"
+    fail "Missing required option: -u/--url. Example: http://203.0.113.10:18888"
 fi
 
 # ---------- Platform check ----------


### PR DESCRIPTION
示例地址用的是一个真实可达的主机地址，出现在两处：

- `crates/panel/src/config.rs:40` —— `PUBLIC_PANEL_URL` 的文档注释
- `scripts/relay-node-install.sh:93` —— 不带 `-u` 运行时打印的报错

任何人读源码、或者漏填参数跑一次安装脚本，都会看到它。示例不该放一个活的地址。

改成 `203.0.113.10`（RFC 5737 文档专用段），保证永远不会路由到任何地方，同时仍然保留报错想演示的 `ip:port` 形态。

顺带扫过仓库里其余的公网 IP，剩下的都是明显的占位（`2.2.2.2` / `9.9.9.9` 之类）和 `example.com` 的地址，不涉及可识别信息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)