### PR TITLE
release: v1.2.5 (panel) + node-v1.2.1 (node)

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,7 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
-## [Unreleased]
+## [1.2.1] - 2026-08-02
+
+Node only. Nothing on the wire changed — the config protocol stays at version
+4, so this node runs against any current panel, and upgrading is optional
+unless the node sits somewhere `api.ipify.org` cannot be reached.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
-## [Unreleased]
+## [1.2.5] - 2026-08-02
+
+Panel only. The node ships separately as `node-v1.2.1` and neither release
+requires the other — the config protocol is unchanged at version 4, so any
+current node works with this panel and vice versa.
+
+No schema change and nothing to reconfigure: pull the image and restart.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.4";
+const COMPILED_APP_VERSION: &str = "1.2.5";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.4}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.5}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -57,7 +57,7 @@ services:
     # v1.2: the node image tag is INDEPENDENT of the panel tag. Override
     # RELAYPANEL_NODE_TAG in .env to pin a node version that differs from the
     # panel version.
-    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.0}
+    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.1}
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.2.0"
+SCRIPT_VERSION="1.2.1"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
两条轨一起切，但**是两个独立的发布、两个 tag，互不要求对方** —— 配置协议仍然是 version 4。

## 版本号改动

**面板 1.2.4 → 1.2.5**（`docs/VERSIONS.md` 里的 4 处）
- `crates/panel/Cargo.toml`
- `crates/panel/src/config.rs`（`COMPILED_APP_VERSION`）
- `docker-compose.release.yaml`（`RELAYPANEL_PANEL_TAG` 默认值）
- README 徽章是动态的，无需改

**节点 1.2.0 → 1.2.1**（4 处）
- `crates/node/Cargo.toml`
- `scripts/relay-node-install.sh`（`SCRIPT_VERSION`）
- `docker-compose.release.yaml`（`RELAYPANEL_NODE_TAG` 默认值）
- `CHANGELOG-NODE.md`

`Cargo.lock` 跟着 `cargo check` 更新。

## 内容

**v1.2.5（面板）** —— 离线节点保留 24 小时 + 可手动移除、离线行置灰、仅监控分组不再索要转发配置、类型显示中文且监听类型改名为「出口」、文字对比度达到 WCAG AA、`reset-admin-password` 找回管理员登录。**无 schema 变更**，拉镜像重启即可。

**node-v1.2.1（节点）** —— 公网 IP 探测从 `api.ipify.org` 换成 `api-ipv4.ip.sb`。前者在中国大陆连不上，那些节点会永远在面板上不显示地址。**升级是可选的**，除非节点所在网络访问不到 ipify。

## 预检

```
release-check.sh panel 1.2.5  →  79 OK, 7 WARN, 0 FAIL
release-check.sh node  1.2.1  →  78 OK, 7 WARN, 0 FAIL
```

WARN 全是 README 精简后的措辞提示，非阻塞。

## 全量门禁

- `cargo fmt --check` 干净
- `cargo clippy --workspace --all-targets -D warnings` 干净
- `cargo test --workspace` 646 passed
- `npm run lint` / `npm run typecheck` 干净，`npm test` 250 passed
- `npm run build` 通过

合并后打两个 tag：`v1.2.5` 和 `node-v1.2.1`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)