### PR TITLE
fix(nodes): keep throughput values on one line

### DIFF
--- a/frontend/src/components/nodes/NodeDesktopTable.tsx
+++ b/frontend/src/components/nodes/NodeDesktopTable.tsx
@@ -29,6 +29,21 @@ interface Props {
   onDelete?: (row: NodeDisplayRow) => void;
 }
 
+// Keep high-variance transfer figures readable before spending horizontal room
+// on the short status columns. The table already scrolls horizontally, so a
+// little extra width is preferable to splitting a rate such as "994.56 KB/s"
+// across two lines.
+export const nodeDesktopColumnWidths = {
+  status: 78,
+  nodeVersion: 90,
+  nodeUpgrade: 68,
+  cpu: 80,
+  mem: 96,
+  disk: 96,
+  rate: 192,
+  traffic: 172,
+} as const;
+
 /** Desktop table for one group's nodes. Both admin and user share the same
  *  columns — the permission difference is in the data source (admin reads
  *  /nodes, user reads /nodes/shared) and the detail drawer. */
@@ -37,7 +52,7 @@ export function NodeDesktopTable({ rows, panelProtocol, latestNodeVersion, nodeV
 
   const columns = [
     {
-      title: t('status'), key: 'status', width: 84, fixed: 'left' as const,
+      title: t('status'), key: 'status', width: nodeDesktopColumnWidths.status, fixed: 'left' as const,
       render: (_: unknown, r: NodeDisplayRow) => {
         const v = r.config_protocol_version;
         if (v != null && panelProtocol > 0 && v !== panelProtocol) {
@@ -50,7 +65,7 @@ export function NodeDesktopTable({ rows, panelProtocol, latestNodeVersion, nodeV
     // v1.2: compared against the latest NODE release (latestNodeVersion), not
     // the panel version.
     {
-      title: t('nodeVersion'), dataIndex: 'node_version', key: 'node_version', width: 100,
+      title: t('nodeVersion'), dataIndex: 'node_version', key: 'node_version', width: nodeDesktopColumnWidths.nodeVersion,
       render: (v: string | null) => {
         if (!v) return <Typography.Text type="secondary">-</Typography.Text>;
         // v1.2: if the node-version check failed, we can't vouch for any
@@ -67,7 +82,7 @@ export function NodeDesktopTable({ rows, panelProtocol, latestNodeVersion, nodeV
     // neutral state (PR5). Protocol-incompatible and a failed lookup both take
     // priority over version status.
     ...(onUpgrade ? [{
-      title: t('nodeUpgrade'), key: 'upgrade', width: 72,
+      title: t('nodeUpgrade'), key: 'upgrade', width: nodeDesktopColumnWidths.nodeUpgrade,
       render: (_: unknown, r: NodeDisplayRow) => {
         const { state } = resolveNodeUpgrade(r, latestNodeVersion, panelProtocol, nodeVersionCheckFailed);
         switch (state) {
@@ -112,27 +127,27 @@ export function NodeDesktopTable({ rows, panelProtocol, latestNodeVersion, nodeV
       render: (v: number) => <span className="rp-mono">{v || 0}</span>,
     },
     {
-      title: 'CPU', key: 'cpu', width: 84,
+      title: 'CPU', key: 'cpu', width: nodeDesktopColumnWidths.cpu,
       render: (_: unknown, r: NodeDisplayRow) => <NodeResourceBar value={r.cpu} tooltip={`CPU: ${formatPercent(r.cpu)}`} />,
     },
     {
-      title: t('mem'), key: 'mem', width: 100,
+      title: t('mem'), key: 'mem', width: nodeDesktopColumnWidths.mem,
       render: (_: unknown, r: NodeDisplayRow) => <NodeResourceBar value={r.mem} tooltip={`${t('mem')}: ${formatPercent(r.mem)}`} />,
     },
     {
-      title: t('disk'), key: 'disk', width: 100,
+      title: t('disk'), key: 'disk', width: nodeDesktopColumnWidths.disk,
       render: (_: unknown, r: NodeDisplayRow) => <NodeDiskBar usagePercent={r.disk_usage_percent} used={r.disk_used} total={r.disk_total} mount={r.disk_mount} t={t} />,
     },
     {
-      title: `${t('uploadRate')}/${t('downloadRate')}`, key: 'rate', width: 140,
+      title: `${t('uploadRate')}/${t('downloadRate')}`, key: 'rate', width: nodeDesktopColumnWidths.rate,
       render: (_: unknown, r: NodeDisplayRow) => (
-        <span className="rp-mono">{formatBps(r.upload_bps)} / {formatBps(r.download_bps)}</span>
+        <span className="rp-mono rp-node-throughput">{formatBps(r.upload_bps)} / {formatBps(r.download_bps)}</span>
       ),
     },
     {
-      title: `${t('totalUpload')}/${t('totalDownload')}`, key: 'traffic', width: 150,
+      title: `${t('totalUpload')}/${t('totalDownload')}`, key: 'traffic', width: nodeDesktopColumnWidths.traffic,
       render: (_: unknown, r: NodeDisplayRow) => (
-        <span className="rp-mono">{formatBytes(r.boot_upload_bytes)} / {formatBytes(r.boot_download_bytes)}</span>
+        <span className="rp-mono rp-node-throughput">{formatBytes(r.boot_upload_bytes)} / {formatBytes(r.boot_download_bytes)}</span>
       ),
     },
     {

--- a/frontend/src/components/nodes/NodeDesktopTable.tsx
+++ b/frontend/src/components/nodes/NodeDesktopTable.tsx
@@ -8,6 +8,7 @@ import { formatBps, formatBytes, formatUptime, formatPercent } from '../../utils
 import { versionRelation, versionTagColor } from '../../utils/version';
 import { NetworkCell } from './shared';
 import { resolveNodeUpgrade } from './upgrade';
+import { nodeDesktopColumnWidths } from './tableLayout';
 
 interface Props {
   rows: NodeDisplayRow[];
@@ -28,21 +29,6 @@ interface Props {
    *  the next report (within ~10s) recreates it. Absent for the user view. */
   onDelete?: (row: NodeDisplayRow) => void;
 }
-
-// Keep high-variance transfer figures readable before spending horizontal room
-// on the short status columns. The table already scrolls horizontally, so a
-// little extra width is preferable to splitting a rate such as "994.56 KB/s"
-// across two lines.
-export const nodeDesktopColumnWidths = {
-  status: 78,
-  nodeVersion: 90,
-  nodeUpgrade: 68,
-  cpu: 80,
-  mem: 96,
-  disk: 96,
-  rate: 192,
-  traffic: 172,
-} as const;
 
 /** Desktop table for one group's nodes. Both admin and user share the same
  *  columns — the permission difference is in the data source (admin reads

--- a/frontend/src/components/nodes/NodeGroupSection.test.tsx
+++ b/frontend/src/components/nodes/NodeGroupSection.test.tsx
@@ -4,6 +4,7 @@ import type { Tfn } from './types';
 import type { NodeDisplayRow } from '../../api/types';
 import { statusTag } from './shared';
 import { NodeGroupSection } from './NodeGroupSection';
+import { nodeDesktopColumnWidths } from './NodeDesktopTable';
 
 // A fake t() that echoes the key — assertions match on the i18n KEY, not on a
 // translated string, so the tests don't break when wording changes.
@@ -57,6 +58,31 @@ describe('NodeGroupSection mobile vs desktop', () => {
       <NodeGroupSection rows={placeholder} panelProtocol={0} latestNodeVersion="1.1.0" nodeVersionCheckFailed={false} isMobile={false} t={t} openDetail={vi.fn()} />,
     );
     expect(screen.getByText('noNodeReportingInGroup')).toBeInTheDocument();
+  });
+});
+
+describe('Node desktop table throughput layout', () => {
+  it('prioritizes the upload/download rate column without widening the short status columns', () => {
+    expect(nodeDesktopColumnWidths.rate).toBeGreaterThanOrEqual(192);
+    expect(nodeDesktopColumnWidths.status).toBeLessThan(84);
+    expect(nodeDesktopColumnWidths.nodeVersion).toBeLessThan(100);
+    expect(nodeDesktopColumnWidths.nodeUpgrade).toBeLessThan(72);
+  });
+
+  it('keeps transfer values on one line', () => {
+    const { container } = render(
+      <NodeGroupSection
+        rows={[row({ online: true, upload_bps: 1018430, download_bps: 60110, boot_upload_bytes: 123456789, boot_download_bytes: 987654321 })]}
+        panelProtocol={0}
+        latestNodeVersion="1.1.0"
+        nodeVersionCheckFailed={false}
+        isMobile={false}
+        t={t}
+        openDetail={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelectorAll('.rp-node-throughput')).toHaveLength(2);
   });
 });
 

--- a/frontend/src/components/nodes/NodeGroupSection.test.tsx
+++ b/frontend/src/components/nodes/NodeGroupSection.test.tsx
@@ -4,7 +4,7 @@ import type { Tfn } from './types';
 import type { NodeDisplayRow } from '../../api/types';
 import { statusTag } from './shared';
 import { NodeGroupSection } from './NodeGroupSection';
-import { nodeDesktopColumnWidths } from './NodeDesktopTable';
+import { nodeDesktopColumnWidths } from './tableLayout';
 
 // A fake t() that echoes the key — assertions match on the i18n KEY, not on a
 // translated string, so the tests don't break when wording changes.

--- a/frontend/src/components/nodes/tableLayout.ts
+++ b/frontend/src/components/nodes/tableLayout.ts
@@ -1,0 +1,14 @@
+// Keep high-variance transfer figures readable before spending horizontal room
+// on the short status columns. The table already scrolls horizontally, so a
+// little extra width is preferable to splitting a rate such as "994.56 KB/s"
+// across two lines.
+export const nodeDesktopColumnWidths = {
+  status: 78,
+  nodeVersion: 90,
+  nodeUpgrade: 68,
+  cpu: 80,
+  mem: 96,
+  disk: 96,
+  rate: 192,
+  traffic: 172,
+} as const;

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -213,6 +213,13 @@ html, body, #root {
   font-size: 12px;
 }
 
+/* Transfer values are a single measurement. Breaking between a number and its
+   unit (for example, "60.11" / "KB/s") makes the node table harder to scan.
+   The desktop table already supplies horizontal scrolling for narrower views. */
+.rp-node-throughput {
+  white-space: nowrap;
+}
+
 /* v0.4.17: country-flag pill wrapper. Outer layer sizes & rounds the slot;
  *  the inner .fi (from flag-icons) is pinned to a fixed flag size so the
  *  library's own .fi rules never disturb the surrounding table layout. */


### PR DESCRIPTION
## Summary
- Give the upload/download rate column enough room for complete values.
- Keep transfer-rate and cumulative-traffic measurements on one line.
- Rebalance only the short status and resource columns, while retaining horizontal scrolling for narrow displays.

## Validation
- `npm test` — 26 files, 252 tests passed
- `npm run typecheck`
- `npm run build`