### PR TITLE
release: v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.2.6] - 2026-08-12
+
+Panel only. The node remains `node-v1.2.1`; this release does not change the
+node protocol, forwarding runtime, installer, or node image.
+
+No database migration is required. Pull the panel image and restart.
+
+### Added
+
+- **Notification settings now have explicit alert rules and delivery history.**
+  Administrators can independently enable offline, recovery, node-version, and
+  repeat-offline alerts. Recent per-channel delivery outcomes are retained and
+  shown in the notification settings page, so a failed test or real alert has a
+  visible reason instead of disappearing into logs.
+
+### Changed
+
+- **Node-table transfer rates stay on one line.** The upload/download column is
+  given enough space on desktop layouts while less important columns contract
+  first, keeping live throughput values readable without disruptive wrapping.
+
+---
+
 ## [1.2.5] - 2026-08-02
 
 Panel only. The node ships separately as `node-v1.2.1` and neither release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.5";
+const COMPILED_APP_VERSION: &str = "1.2.6";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.5}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.6}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)


### PR DESCRIPTION
## 发布内容

- 仅发布面板：`v1.2.6`
- 节点继续保持：`node-v1.2.1`
- 包含 #115：节点列表上传／下载速率不再换行
- 包含 #116：通知告警规则与发送记录

## 发布检查

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `npm ci --no-audit --no-fund`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] `bash scripts/release-check.sh panel 1.2.6`