### PR TITLE
fix: reconcile plan entitlements

### DIFF
--- a/crates/panel/src/db/error.rs
+++ b/crates/panel/src/db/error.rs
@@ -21,6 +21,10 @@ pub enum DbError {
     /// Detected by the in-transaction conflict pre-check; the partial unique
     /// indexes on forward_rules are the DB-layer backstop.
     PortConflict,
+    /// A state transition would exceed the owner's active-rule allowance.
+    /// This is distinct from creation returning 0 rows: callers need to tell
+    /// an existing paused rule from a missing rule when a resume is rejected.
+    QuotaExceeded,
     /// FOREIGN KEY constraint violation. SQLite code "787", PostgreSQL "23503".
     ForeignKeyViolation,
     /// A required row was not found (for fetch_one-or-None patterns that are
@@ -36,6 +40,7 @@ impl std::fmt::Display for DbError {
         match self {
             DbError::UniqueViolation => write!(f, "unique constraint violation"),
             DbError::PortConflict => write!(f, "listen_port conflict on inbound group"),
+            DbError::QuotaExceeded => write!(f, "active rule quota exceeded"),
             DbError::ForeignKeyViolation => write!(f, "foreign key constraint violation"),
             DbError::NotFound => write!(f, "not found"),
             DbError::Other(e) => write!(f, "database error: {}", e),

--- a/crates/panel/src/db/pg_repo/rules.rs
+++ b/crates/panel/src/db/pg_repo/rules.rs
@@ -786,6 +786,65 @@ impl RuleRepository for PgRepository {
             q = q.bind(uid);
         }
 
+        if paused == Some(false) {
+            // PostgreSQL has concurrent writers, so lock the owner row before
+            // the target rule and count. This matches buy_plan's lock order
+            // (user → rules) and serializes resume with quota-guarded creation
+            // for that user; no pair of requests can pass a stale active count.
+            let mut tx = self.pool.begin().await?;
+            let owner: Option<(i64,)> = match scope.owner_id() {
+                None => {
+                    sqlx::query_as("SELECT uid FROM forward_rules WHERE id = $1")
+                        .bind(id)
+                        .fetch_optional(&mut *tx)
+                        .await?
+                }
+                Some(uid) => {
+                    sqlx::query_as("SELECT uid FROM forward_rules WHERE id = $1 AND uid = $2")
+                        .bind(id)
+                        .bind(uid)
+                        .fetch_optional(&mut *tx)
+                        .await?
+                }
+            };
+            let Some((uid,)) = owner else {
+                tx.commit().await?;
+                return Ok(0);
+            };
+            let max_rules: i32 = sqlx::query_scalar(
+                "SELECT COALESCE(max_rules, 0) FROM users WHERE id = $1 FOR UPDATE",
+            )
+            .bind(uid)
+            .fetch_one(&mut *tx)
+            .await?;
+            let is_paused: Option<(bool,)> = sqlx::query_as(
+                "SELECT paused FROM forward_rules WHERE id = $1 AND uid = $2 FOR UPDATE",
+            )
+            .bind(id)
+            .bind(uid)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let Some((is_paused,)) = is_paused else {
+                tx.commit().await?;
+                return Ok(0);
+            };
+            if is_paused {
+                let active_rules: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM forward_rules WHERE uid = $1 AND paused = FALSE",
+                )
+                .bind(uid)
+                .fetch_one(&mut *tx)
+                .await?;
+                if max_rules > 0 && active_rules >= i64::from(max_rules) {
+                    tx.rollback().await?;
+                    return Err(DbError::QuotaExceeded);
+                }
+            }
+            let result = q.execute(&mut *tx).await?;
+            tx.commit().await?;
+            return Ok(result.rows_affected());
+        }
+
         let result = q.execute(&self.pool).await?;
         Ok(result.rows_affected())
     }

--- a/crates/panel/src/db/pg_repo/settings.rs
+++ b/crates/panel/src/db/pg_repo/settings.rs
@@ -502,6 +502,43 @@ impl PlanRepository for PgRepository {
             }
         }
 
+        // Reconcile existing active rules after group authorization has been
+        // finalized. A positive max_rules keeps the oldest active rules and
+        // pauses the newest excess rules; zero remains the unlimited sentinel.
+        if plan_max_rules > 0 {
+            let active_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM forward_rules WHERE uid = $1 AND paused = FALSE",
+            )
+            .bind(user_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let excess = active_count.saturating_sub(i64::from(plan_max_rules));
+            if excess > 0 {
+                // Keep auto_paused=FALSE so an upgrade never silently reopens
+                // a port that this limit reconciliation paused.
+                let paused = sqlx::query(
+                    "UPDATE forward_rules SET paused = TRUE, auto_paused = FALSE \
+                     WHERE id IN ( \
+                         SELECT id FROM forward_rules \
+                         WHERE uid = $1 AND paused = FALSE \
+                         ORDER BY id DESC LIMIT $2 \
+                     )",
+                )
+                .bind(user_id)
+                .bind(excess)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+                tracing::warn!(
+                    "buy_plan: user {} purchased plan {}, {} newest rule(s) paused to enforce max_rules={}",
+                    user_id,
+                    plan_id,
+                    paused,
+                    plan_max_rules
+                );
+            }
+        }
+
         tx.commit().await?;
         Ok(())
     }

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -2177,6 +2177,62 @@ async fn pg_new_user_has_no_device_groups_by_default() {
     cleanup(&db).await;
 }
 
+/// PostgreSQL parity: registration must inherit the selected plan's line
+/// authorization together with its quotas.
+#[tokio::test]
+async fn pg_insert_user_from_plan_inherits_plan_group_authorization() {
+    let Some(db) = repo("registration_plan_groups").await else {
+        return;
+    };
+    seed_device_group(&db, 60, 1).await;
+
+    let restricted_plan = db
+        .create_plan_with_groups(
+            "restricted",
+            5,
+            1_000,
+            "0",
+            "data",
+            0,
+            false,
+            false,
+            "",
+            false,
+            &[60],
+        )
+        .await
+        .unwrap();
+    db.insert_user_from_plan("restricted-user", "hash", restricted_plan)
+        .await
+        .unwrap();
+    let restricted = db
+        .find_by_username("restricted-user")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!restricted.all_device_groups);
+    assert_eq!(
+        db.list_user_device_groups(restricted.id).await.unwrap(),
+        vec![60],
+        "a restricted plan grants exactly its configured lines at registration (PG)"
+    );
+
+    let all_plan = db
+        .create_plan_with_groups("all", 5, 1_000, "0", "data", 0, false, false, "", true, &[])
+        .await
+        .unwrap();
+    db.insert_user_from_plan("all-user", "hash", all_plan)
+        .await
+        .unwrap();
+    let all = db.find_by_username("all-user").await.unwrap().unwrap();
+    assert!(
+        all.all_device_groups,
+        "an all-lines plan grants all lines immediately (PG)"
+    );
+    assert!(db.list_user_device_groups(all.id).await.unwrap().is_empty());
+    cleanup(&db).await;
+}
+
 // ── v0.4.10 PR4: token_version + must_change_password (PG parity) ──
 
 #[tokio::test]
@@ -2835,6 +2891,69 @@ async fn pg_rule_update_rule_fields_partial_update() {
             .await
             .unwrap();
     assert!(dgo.0.is_none(), "device_group_out must be cleared (PG)");
+    cleanup(&db).await;
+}
+
+/// PostgreSQL must enforce the resume quota under the same user-row lock used
+/// by rule creation. CI supplies TEST_PG_URL, so this contract runs there even
+/// though local developer machines may skip it.
+#[tokio::test]
+async fn pg_rule_resume_respects_max_rules() {
+    let Some(db) = repo("rule_resume_quota").await else {
+        return;
+    };
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (1, 'gin', 'in', 'tok-1', 1)")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE users SET max_rules = 1 WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    for (id, port, paused) in [(100, 20_000, false), (101, 20_001, true)] {
+        sqlx::query(
+            "INSERT INTO forward_rules \
+             (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+             VALUES ($1, $2, 1, $3, 1, '127.0.0.1', 80, $4)",
+        )
+        .bind(id)
+        .bind(format!("rule-{id}"))
+        .bind(port)
+        .bind(paused)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    let result = db
+        .update_rule_fields(
+            101,
+            &ResourceScope::All,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+        )
+        .await;
+    assert!(
+        matches!(result, Err(DbError::QuotaExceeded)),
+        "a full plan must reject manual resume, got {result:?}"
+    );
+    let paused: bool = sqlx::query_scalar("SELECT paused FROM forward_rules WHERE id = 101")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(paused, "quota-rejected resume must not modify the rule");
     cleanup(&db).await;
 }
 
@@ -4243,6 +4362,59 @@ async fn pg_migration_does_not_pause_cross_owner_shared_inbound_rules() {
         !paused.0,
         "cross-owner shared inbound rule must NOT be paused (PG)"
     );
+    cleanup(&db).await;
+}
+
+/// PostgreSQL parity for max-rule downgrade reconciliation. The paused rules
+/// must remain paused after a later upgrade until the user resumes them.
+#[tokio::test]
+async fn pg_buy_plan_pauses_newest_rules_above_new_max_without_auto_resume() {
+    let Some(db) = repo("buy_plan_limit_reconcile").await else {
+        return;
+    };
+    let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 0, "0", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    for (id, port) in [(100, 20_000), (101, 20_001), (102, 20_002)] {
+        sqlx::query(
+            "INSERT INTO forward_rules \
+             (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+             VALUES ($1, $2, $3, $4, 50, '127.0.0.1', 80, FALSE)",
+        )
+        .bind(id)
+        .bind(format!("rule-{id}"))
+        .bind(alice)
+        .bind(port)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    db.buy_plan(alice, pid, "lower", 0, 0, 1, 0, false, false, &[50], &[50])
+        .await
+        .unwrap();
+    let after_downgrade: Vec<(i64, bool, bool)> = sqlx::query_as(
+        "SELECT id, paused, auto_paused FROM forward_rules WHERE uid = $1 ORDER BY id",
+    )
+    .bind(alice)
+    .fetch_all(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        after_downgrade,
+        vec![(100, false, false), (101, true, false), (102, true, false)]
+    );
+
+    db.buy_plan(alice, pid, "higher", 0, 0, 3, 0, false, false, &[50], &[50])
+        .await
+        .unwrap();
+    let after_upgrade: Vec<(i64, bool, bool)> = sqlx::query_as(
+        "SELECT id, paused, auto_paused FROM forward_rules WHERE uid = $1 ORDER BY id",
+    )
+    .bind(alice)
+    .fetch_all(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(after_upgrade, after_downgrade);
     cleanup(&db).await;
 }
 

--- a/crates/panel/src/db/pg_repo/tests.rs
+++ b/crates/panel/src/db/pg_repo/tests.rs
@@ -2957,6 +2957,84 @@ async fn pg_rule_resume_respects_max_rules() {
     cleanup(&db).await;
 }
 
+/// PostgreSQL parity for "a failed resume leaves no open transaction".
+///
+/// PG gets this for free — the resume path uses `pool.begin()`, whose
+/// `Transaction` rolls back on drop — whereas SQLite hand-rolls BEGIN IMMEDIATE
+/// on a pooled connection and needs an explicit ROLLBACK on every error path.
+/// The contract is pinned on both backends anyway, so it does not rest on which
+/// transaction API each side happens to use today.
+#[tokio::test]
+async fn pg_rule_resume_rolls_back_when_the_update_fails() {
+    let Some(db) = repo("rule_resume_rollback").await else {
+        return;
+    };
+    sqlx::query("INSERT INTO device_groups (id, name, group_type, token, uid) VALUES (1, 'gin', 'in', 'tok-1', 1)")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    // Unlimited, so the quota check passes and we reach the UPDATE — this test
+    // is about the failure path, not the quota.
+    sqlx::query("UPDATE users SET max_rules = 0 WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    for (id, port, paused) in [(100, 20_000, false), (101, 20_001, true)] {
+        sqlx::query(
+            "INSERT INTO forward_rules \
+             (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+             VALUES ($1, $2, 1, $3, 1, '127.0.0.1', 80, $4)",
+        )
+        .bind(id)
+        .bind(format!("rule-{id}"))
+        .bind(port)
+        .bind(paused)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    // Resume rule 101 AND move it onto rule 100's port: the partial unique
+    // index rejects the UPDATE from inside the open transaction.
+    let result = db
+        .update_rule_fields(
+            101,
+            &ResourceScope::All,
+            None,
+            Some(20_000),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "moving a rule onto a taken port must fail, got {result:?}"
+    );
+
+    // The pool must still be usable: a leaked transaction would hold the row
+    // locks its FOR UPDATE reads took until the connection is recycled.
+    sqlx::query("UPDATE forward_rules SET name = 'after' WHERE id = 100")
+        .execute(&db.pool)
+        .await
+        .expect("a failed resume must not leave its transaction open");
+    let paused: bool = sqlx::query_scalar("SELECT paused FROM forward_rules WHERE id = 101")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(paused, "the rejected resume must not have been applied");
+    cleanup(&db).await;
+}
+
 /// overflow entry rejects and rolls back (no data written).
 #[tokio::test]
 async fn pg_traffic_batch_single_entry_overflow_rejects_and_rolls_back() {

--- a/crates/panel/src/db/pg_repo/users.rs
+++ b/crates/panel/src/db/pg_repo/users.rs
@@ -96,22 +96,50 @@ impl UserRepository for PgRepository {
         password_hash: &str,
         plan_id: i64,
     ) -> Result<u64, DbError> {
-        // Atomic INSERT...SELECT: copies the plan's quota fields into the new
-        // user row in one statement. PG positional params can be reused, so
-        // $3 serves both the plan_id column value AND the WHERE filter (unlike
-        // SQLite's positional ? which must be bound once per occurrence).
-        // 0 rows_affected = plan missing → caller fails the registration.
-        let result = sqlx::query(
-            "INSERT INTO users (username, password, plan_id, max_rules, traffic_limit, speed_limit, ip_limit) \
-             SELECT $1, $2, $3, max_rules, traffic, speed_limit, ip_limit \
-             FROM plans WHERE id = $3",
+        // Keep quota and plan authorization in one transaction. PostgreSQL's
+        // default READ COMMITTED isolation would give the INSERT and grant
+        // SELECT independent snapshots, allowing a concurrent plan edit to
+        // create a user with the old grant_all_groups flag but the new group
+        // list (or vice versa). A repeatable-read transaction makes both
+        // statements consume one coherent plan snapshot.
+        //
+        // `RETURNING` preserves the existing missing-plan contract (None → 0
+        // rows) while supplying the new user id for its explicit line grants.
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            .execute(&mut *tx)
+            .await?;
+        let inserted: Option<(i64,)> = sqlx::query_as(
+            "INSERT INTO users \
+             (username, password, plan_id, max_rules, traffic_limit, speed_limit, ip_limit, all_device_groups) \
+             SELECT $1, $2, $3, max_rules, traffic, speed_limit, ip_limit, grant_all_groups \
+             FROM plans WHERE id = $3 \
+             RETURNING id",
         )
         .bind(username)
         .bind(password_hash)
         .bind(plan_id)
-        .execute(&self.pool)
+        .fetch_optional(&mut *tx)
         .await?;
-        Ok(result.rows_affected())
+        let Some((user_id,)) = inserted else {
+            tx.commit().await?;
+            return Ok(0);
+        };
+
+        sqlx::query(
+            "INSERT INTO user_device_groups (user_id, device_group_id) \
+             SELECT $1, pdg.device_group_id \
+             FROM plan_device_groups pdg \
+             JOIN plans p ON p.id = pdg.plan_id \
+             WHERE pdg.plan_id = $2 AND p.grant_all_groups = FALSE",
+        )
+        .bind(user_id)
+        .bind(plan_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(1)
     }
 
     async fn update_password(&self, id: i64, new_hash: &str) -> Result<u64, DbError> {

--- a/crates/panel/src/db/sqlite_repo/rules.rs
+++ b/crates/panel/src/db/sqlite_repo/rules.rs
@@ -743,6 +743,54 @@ impl RuleRepository for SqliteRepository {
             q = q.bind(uid);
         }
 
+        if paused == Some(false) {
+            // A manual resume is a state transition into the same active-rule
+            // pool guarded by insert_quota_guarded. SQLite needs BEGIN
+            // IMMEDIATE here: a deferred read/count followed by UPDATE would
+            // let two resume requests both pass the count before either writes.
+            let mut conn = self.pool.acquire().await?;
+            sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+            let target: Option<(i64, bool)> = match scope.owner_id() {
+                None => {
+                    sqlx::query_as("SELECT uid, paused FROM forward_rules WHERE id = ?")
+                        .bind(id)
+                        .fetch_optional(&mut *conn)
+                        .await?
+                }
+                Some(uid) => {
+                    sqlx::query_as("SELECT uid, paused FROM forward_rules WHERE id = ? AND uid = ?")
+                        .bind(id)
+                        .bind(uid)
+                        .fetch_optional(&mut *conn)
+                        .await?
+                }
+            };
+            let Some((uid, is_paused)) = target else {
+                sqlx::query("COMMIT").execute(&mut *conn).await?;
+                return Ok(0);
+            };
+            if is_paused {
+                let max_rules: i32 =
+                    sqlx::query_scalar("SELECT COALESCE(max_rules, 0) FROM users WHERE id = ?")
+                        .bind(uid)
+                        .fetch_one(&mut *conn)
+                        .await?;
+                let active_rules: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM forward_rules WHERE uid = ? AND paused = 0",
+                )
+                .bind(uid)
+                .fetch_one(&mut *conn)
+                .await?;
+                if max_rules > 0 && active_rules >= i64::from(max_rules) {
+                    sqlx::query("ROLLBACK").execute(&mut *conn).await?;
+                    return Err(DbError::QuotaExceeded);
+                }
+            }
+            let result = q.execute(&mut *conn).await?;
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            return Ok(result.rows_affected());
+        }
+
         let result = q.execute(&self.pool).await?;
         Ok(result.rows_affected())
     }

--- a/crates/panel/src/db/sqlite_repo/rules.rs
+++ b/crates/panel/src/db/sqlite_repo/rules.rs
@@ -750,44 +750,78 @@ impl RuleRepository for SqliteRepository {
             // let two resume requests both pass the count before either writes.
             let mut conn = self.pool.acquire().await?;
             sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+
+            // Every statement below MUST go through try_! rather than `?`.
+            // BEGIN IMMEDIATE takes SQLite's write lock, and a bare `?` would
+            // return the connection to the pool with that transaction still
+            // open — sqlx only auto-rollbacks a `Transaction`, not a hand-rolled
+            // BEGIN on a PoolConnection. Every later write in the process would
+            // then block for busy_timeout and fail SQLITE_BUSY, and the next
+            // BEGIN IMMEDIATE on that pooled connection would error with
+            // "cannot start a transaction within a transaction". The UPDATE at
+            // the end makes this reachable in normal use: it can fail on the
+            // partial unique index when a resume also moves listen_port onto a
+            // port that is already taken. Same macro shape as
+            // insert_quota_guarded / create_rule_atomic above.
+            macro_rules! try_ {
+                ($conn:expr, $expr:expr) => {
+                    match $expr {
+                        Ok(v) => v,
+                        Err(e) => {
+                            let _ = sqlx::query("ROLLBACK").execute(&mut *$conn).await;
+                            return Err(DbError::from(e));
+                        }
+                    }
+                };
+            }
+
             let target: Option<(i64, bool)> = match scope.owner_id() {
-                None => {
+                None => try_!(
+                    conn,
                     sqlx::query_as("SELECT uid, paused FROM forward_rules WHERE id = ?")
                         .bind(id)
                         .fetch_optional(&mut *conn)
-                        .await?
-                }
-                Some(uid) => {
-                    sqlx::query_as("SELECT uid, paused FROM forward_rules WHERE id = ? AND uid = ?")
-                        .bind(id)
-                        .bind(uid)
-                        .fetch_optional(&mut *conn)
-                        .await?
-                }
+                        .await
+                ),
+                Some(uid) => try_!(
+                    conn,
+                    sqlx::query_as(
+                        "SELECT uid, paused FROM forward_rules WHERE id = ? AND uid = ?"
+                    )
+                    .bind(id)
+                    .bind(uid)
+                    .fetch_optional(&mut *conn)
+                    .await
+                ),
             };
             let Some((uid, is_paused)) = target else {
-                sqlx::query("COMMIT").execute(&mut *conn).await?;
+                try_!(conn, sqlx::query("COMMIT").execute(&mut *conn).await);
                 return Ok(0);
             };
             if is_paused {
-                let max_rules: i32 =
+                let max_rules: i32 = try_!(
+                    conn,
                     sqlx::query_scalar("SELECT COALESCE(max_rules, 0) FROM users WHERE id = ?")
                         .bind(uid)
                         .fetch_one(&mut *conn)
-                        .await?;
-                let active_rules: i64 = sqlx::query_scalar(
-                    "SELECT COUNT(*) FROM forward_rules WHERE uid = ? AND paused = 0",
-                )
-                .bind(uid)
-                .fetch_one(&mut *conn)
-                .await?;
+                        .await
+                );
+                let active_rules: i64 = try_!(
+                    conn,
+                    sqlx::query_scalar(
+                        "SELECT COUNT(*) FROM forward_rules WHERE uid = ? AND paused = 0",
+                    )
+                    .bind(uid)
+                    .fetch_one(&mut *conn)
+                    .await
+                );
                 if max_rules > 0 && active_rules >= i64::from(max_rules) {
-                    sqlx::query("ROLLBACK").execute(&mut *conn).await?;
+                    let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
                     return Err(DbError::QuotaExceeded);
                 }
             }
-            let result = q.execute(&mut *conn).await?;
-            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            let result = try_!(conn, q.execute(&mut *conn).await);
+            try_!(conn, sqlx::query("COMMIT").execute(&mut *conn).await);
             return Ok(result.rows_affected());
         }
 

--- a/crates/panel/src/db/sqlite_repo/settings.rs
+++ b/crates/panel/src/db/sqlite_repo/settings.rs
@@ -492,6 +492,44 @@ impl PlanRepository for SqliteRepository {
             }
         }
 
+        // A lower rule limit must apply to rules that already exist, not only
+        // future creates. Keep the oldest active rules and pause the newest
+        // excess rules last, after any authorization-driven auto-resume above.
+        // max_rules=0 means unlimited, matching insert_quota_guarded.
+        if plan_max_rules > 0 {
+            let active_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM forward_rules WHERE uid = ? AND paused = 0",
+            )
+            .bind(user_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let excess = active_count.saturating_sub(i64::from(plan_max_rules));
+            if excess > 0 {
+                // auto_paused stays 0 deliberately: these ports need an
+                // explicit user resume after a later upgrade.
+                let paused = sqlx::query(
+                    "UPDATE forward_rules SET paused = 1, auto_paused = 0 \
+                     WHERE id IN ( \
+                         SELECT id FROM forward_rules \
+                         WHERE uid = ? AND paused = 0 \
+                         ORDER BY id DESC LIMIT ? \
+                     )",
+                )
+                .bind(user_id)
+                .bind(excess)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+                tracing::warn!(
+                    "buy_plan: user {} purchased plan {}, {} newest rule(s) paused to enforce max_rules={}",
+                    user_id,
+                    plan_id,
+                    paused,
+                    plan_max_rules
+                );
+            }
+        }
+
         tx.commit().await?;
         Ok(())
     }

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -1295,6 +1295,86 @@ async fn rule_resume_respects_max_rules() {
     assert!(paused, "quota-rejected resume must not modify the rule");
 }
 
+/// A resume whose UPDATE fails must leave no open transaction behind.
+///
+/// The resume path runs BEGIN IMMEDIATE on a pooled connection, which holds
+/// SQLite's write lock. sqlx only auto-rollbacks a `Transaction`, not a
+/// hand-rolled BEGIN on a PoolConnection, so an early return without ROLLBACK
+/// would hand the connection back to the pool still inside a write transaction
+/// and wedge every later write in the process. The reachable trigger is a
+/// resume that also moves listen_port onto a port that is already taken.
+#[tokio::test]
+async fn rule_resume_rolls_back_when_the_update_fails() {
+    let db = repo().await;
+    seed_group(&db, 1).await;
+    // max_rules stays unlimited so the quota check passes and we reach the
+    // UPDATE — this test is about the failure path, not the quota.
+    sqlx::query("UPDATE users SET max_rules = 0 WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    for (id, port, paused) in [(100, 20_000, 0), (101, 20_001, 1)] {
+        sqlx::query(
+            "INSERT INTO forward_rules \
+             (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+             VALUES (?, ?, 1, ?, 1, '127.0.0.1', 80, ?)",
+        )
+        .bind(id)
+        .bind(format!("rule-{id}"))
+        .bind(port)
+        .bind(paused)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    // Resume rule 101 AND move it onto rule 100's port: the partial unique
+    // index rejects the UPDATE from inside the open transaction.
+    let result = db
+        .update_rule_fields(
+            101,
+            &ResourceScope::All,
+            None,         // name
+            Some(20_000), // listen_port — collides with rule 100
+            None,         // protocol
+            None,         // public_transport
+            None,         // node_transport
+            None,         // entry_transport
+            None,         // route_mode
+            None,         // ws_path
+            None,         // device_group_in
+            None,         // device_group_out
+            None,         // forward_mode
+            None,         // target_addr
+            None,         // target_port
+            Some(false),  // paused → resume
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "moving a rule onto a taken port must fail, got {result:?}"
+    );
+
+    // Probe the connection's transaction state directly. A plain write would
+    // prove nothing here: this harness runs max_connections(1), so a leaked
+    // transaction is still on the only connection and the write would silently
+    // join it and succeed. A second BEGIN IMMEDIATE, by contrast, fails with
+    // "cannot start a transaction within a transaction" exactly when the
+    // previous one was never closed — which in production is the state that
+    // holds the write lock against every other pooled connection.
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&db.pool)
+        .await
+        .expect("a failed resume must not leave its transaction open");
+    sqlx::query("ROLLBACK").execute(&db.pool).await.unwrap();
+
+    let paused: bool = sqlx::query_scalar("SELECT paused FROM forward_rules WHERE id = 101")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(paused, "the rejected resume must not have been applied");
+}
+
 #[tokio::test]
 async fn rule_list_active_for_config_filters_banned_paused_overquota() {
     let db = repo().await;

--- a/crates/panel/src/db/sqlite_repo/tests.rs
+++ b/crates/panel/src/db/sqlite_repo/tests.rs
@@ -1238,6 +1238,63 @@ async fn rule_update_rule_fields_partial_update() {
     assert!(dgo.0.is_none(), "device_group_out must be cleared");
 }
 
+/// A paused rule cannot be manually resumed once the owner's active-rule
+/// allowance is already full. This is the same quota invariant as creation:
+/// otherwise a plan downgrade could be bypassed one on/off switch at a time.
+#[tokio::test]
+async fn rule_resume_respects_max_rules() {
+    let db = repo().await;
+    seed_group(&db, 1).await;
+    sqlx::query("UPDATE users SET max_rules = 1 WHERE id = 1")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    for (id, port, paused) in [(100, 20_000, 0), (101, 20_001, 1)] {
+        sqlx::query(
+            "INSERT INTO forward_rules \
+             (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+             VALUES (?, ?, 1, ?, 1, '127.0.0.1', 80, ?)",
+        )
+        .bind(id)
+        .bind(format!("rule-{id}"))
+        .bind(port)
+        .bind(paused)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    let result = db
+        .update_rule_fields(
+            101,
+            &ResourceScope::All,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+        )
+        .await;
+    assert!(
+        matches!(result, Err(DbError::QuotaExceeded)),
+        "a full plan must reject manual resume, got {result:?}"
+    );
+    let paused: bool = sqlx::query_scalar("SELECT paused FROM forward_rules WHERE id = 101")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(paused, "quota-rejected resume must not modify the rule");
+}
+
 #[tokio::test]
 async fn rule_list_active_for_config_filters_banned_paused_overquota() {
     let db = repo().await;
@@ -2290,6 +2347,63 @@ async fn new_user_has_no_device_groups_by_default() {
     assert!(
         db.is_user_restricted(carol.id).await.unwrap(),
         "a non-admin without all_device_groups is restricted (cannot forward)"
+    );
+}
+
+/// Registration must inherit the selected plan's authorization in the same
+/// transaction as its quotas. Otherwise a user can own a plan but cannot create
+/// a forwarding rule on any of the lines that plan advertises.
+#[tokio::test]
+async fn insert_user_from_plan_inherits_plan_group_authorization() {
+    let db = repo().await;
+    seed_device_group(&db, 60, 1).await;
+
+    let restricted_plan = db
+        .create_plan_with_groups(
+            "restricted",
+            5,
+            1_000,
+            "0",
+            "data",
+            0,
+            false,
+            false,
+            "",
+            false,
+            &[60],
+        )
+        .await
+        .unwrap();
+    db.insert_user_from_plan("restricted-user", "hash", restricted_plan)
+        .await
+        .unwrap();
+    let restricted = db
+        .find_by_username("restricted-user")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!restricted.all_device_groups);
+    assert_eq!(
+        db.list_user_device_groups(restricted.id).await.unwrap(),
+        vec![60],
+        "a restricted plan grants exactly its configured lines at registration"
+    );
+
+    let all_plan = db
+        .create_plan_with_groups("all", 5, 1_000, "0", "data", 0, false, false, "", true, &[])
+        .await
+        .unwrap();
+    db.insert_user_from_plan("all-user", "hash", all_plan)
+        .await
+        .unwrap();
+    let all = db.find_by_username("all-user").await.unwrap().unwrap();
+    assert!(
+        all.all_device_groups,
+        "an all-lines plan grants all lines immediately"
+    );
+    assert!(
+        db.list_user_device_groups(all.id).await.unwrap().is_empty(),
+        "all-lines access is represented by the flag, not stale explicit grants"
     );
 }
 
@@ -4195,6 +4309,61 @@ async fn expiry_does_not_revoke_granted_groups() {
         db.list_user_device_groups(alice).await.unwrap(),
         vec![50],
         "expiry must not revoke granted device groups"
+    );
+}
+
+/// A lower plan limit must stop the newest active rules immediately. They are
+/// intentionally marked like a manual pause so a later upgrade cannot reopen
+/// ports without an explicit user action.
+#[tokio::test]
+async fn buy_plan_pauses_newest_rules_above_new_max_without_auto_resume() {
+    let db = repo().await;
+    let (alice, pid) = seed_buyer_and_plan(&db, "100.00", 0, "0", 0, false).await;
+    seed_device_group(&db, 50, alice).await;
+    for (id, port) in [(100, 20_000), (101, 20_001), (102, 20_002)] {
+        sqlx::query(
+            "INSERT INTO forward_rules \
+             (id, name, uid, listen_port, device_group_in, target_addr, target_port, paused) \
+             VALUES (?, ?, ?, ?, 50, '127.0.0.1', 80, 0)",
+        )
+        .bind(id)
+        .bind(format!("rule-{id}"))
+        .bind(alice)
+        .bind(port)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    db.buy_plan(alice, pid, "lower", 0, 0, 1, 0, false, false, &[50], &[50])
+        .await
+        .unwrap();
+    let after_downgrade: Vec<(i64, bool, bool)> = sqlx::query_as(
+        "SELECT id, paused, auto_paused FROM forward_rules WHERE uid = ? ORDER BY id",
+    )
+    .bind(alice)
+    .fetch_all(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        after_downgrade,
+        vec![(100, false, false), (101, true, false), (102, true, false)],
+        "the earliest active rule stays up; newest excess rules are retained but paused"
+    );
+
+    db.buy_plan(alice, pid, "higher", 0, 0, 3, 0, false, false, &[50], &[50])
+        .await
+        .unwrap();
+    let after_upgrade: Vec<(i64, bool, bool)> = sqlx::query_as(
+        "SELECT id, paused, auto_paused FROM forward_rules WHERE uid = ? ORDER BY id",
+    )
+    .bind(alice)
+    .fetch_all(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        after_upgrade, after_downgrade,
+        "an upgrade must not reopen paused ports"
     );
 }
 

--- a/crates/panel/src/db/sqlite_repo/users.rs
+++ b/crates/panel/src/db/sqlite_repo/users.rs
@@ -95,22 +95,48 @@ impl UserRepository for SqliteRepository {
         password_hash: &str,
         plan_id: i64,
     ) -> Result<u64, DbError> {
-        // Atomic INSERT...SELECT: copies the plan's quota fields into the new
-        // user row in one statement. If the plan doesn't exist the SELECT
-        // yields no row → 0 rows_affected (caller fails the registration).
-        // Note the column mapping: plans.traffic → users.traffic_limit.
+        // Registration must not produce a user who has the plan's quota but
+        // none of that plan's line authorization. Keep the user row and its
+        // grants on one transaction: a missing plan still yields 0 rows and a
+        // failed grant insert rolls the user creation back.
+        let mut tx = self.pool.begin().await?;
         let result = sqlx::query(
-            "INSERT INTO users (username, password, plan_id, max_rules, traffic_limit, speed_limit, ip_limit) \
-             SELECT ?, ?, ?, max_rules, traffic, speed_limit, ip_limit \
+            "INSERT INTO users \
+             (username, password, plan_id, max_rules, traffic_limit, speed_limit, ip_limit, all_device_groups) \
+             SELECT ?, ?, ?, max_rules, traffic, speed_limit, ip_limit, grant_all_groups \
              FROM plans WHERE id = ?",
         )
         .bind(username)
         .bind(password_hash)
         .bind(plan_id)
         .bind(plan_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
-        Ok(result.rows_affected())
+        if result.rows_affected() == 0 {
+            tx.commit().await?;
+            return Ok(0);
+        }
+
+        let (user_id,): (i64,) = sqlx::query_as("SELECT id FROM users WHERE username = ?")
+            .bind(username)
+            .fetch_one(&mut *tx)
+            .await?;
+        // An all-lines plan is represented exclusively by all_device_groups;
+        // do not retain explicit rows even if legacy plan data contains them.
+        sqlx::query(
+            "INSERT INTO user_device_groups (user_id, device_group_id) \
+             SELECT ?, pdg.device_group_id \
+             FROM plan_device_groups pdg \
+             JOIN plans p ON p.id = pdg.plan_id \
+             WHERE pdg.plan_id = ? AND p.grant_all_groups = 0",
+        )
+        .bind(user_id)
+        .bind(plan_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(1)
     }
 
     async fn update_password(&self, id: i64, new_hash: &str) -> Result<u64, DbError> {

--- a/crates/panel/src/service/rules.rs
+++ b/crates/panel/src/service/rules.rs
@@ -948,6 +948,9 @@ pub async fn update_rule(
             Ok(())
         }
         Err(DbError::UniqueViolation | DbError::PortConflict) => Err(UpdateRuleError::PortConflict),
+        Err(DbError::QuotaExceeded) => Err(UpdateRuleError::BadRequest(
+            "当前套餐的启用规则数量已达上限".to_string(),
+        )),
         Err(e) => {
             tracing::error!("update_rule {}: update_rule_fields failed: {}", id, e);
             Err(UpdateRuleError::Database(e))


### PR DESCRIPTION
## Summary
- Copy a selected plan's device-group authorization when registering a user.
- Pause newest excess active rules immediately after a lower rule limit takes effect; upgrades do not auto-resume them.
- Enforce the same active-rule quota on manual resume, with SQLite and PostgreSQL transaction serialization.
- Use one PostgreSQL REPEATABLE READ plan snapshot during registration.

## Verification
- cargo fmt --check
- cargo test -p relay-panel (527 passed locally; PostgreSQL contract tests run in CI when TEST_PG_URL is configured)
- cargo clippy -p relay-panel --all-targets -- -D warnings
- git diff --check