### PR TITLE
fix: surface read API database errors

### DIFF
--- a/crates/panel/src/api/admin/groups.rs
+++ b/crates/panel/src/api/admin/groups.rs
@@ -14,11 +14,13 @@ pub async fn list_groups(
     State(state): State<AppState>,
 ) -> Json<ApiResponse<Vec<DeviceGroup>>> {
     let scope = user.resource_scope();
-    let groups: Vec<DeviceGroup> = state.db.list_groups(&scope).await.unwrap_or_else(|e| {
-        tracing::error!("list_groups: db error: {}", e);
-        Vec::new()
-    });
-    Json(ApiResponse::success(groups))
+    match state.db.list_groups(&scope).await {
+        Ok(groups) => Json(ApiResponse::success(groups)),
+        Err(e) => {
+            tracing::error!("list_groups: db error: {}", e);
+            Json(err(500, "数据库错误"))
+        }
+    }
 }
 
 pub async fn create_group(

--- a/crates/panel/src/api/admin/mod.rs
+++ b/crates/panel/src/api/admin/mod.rs
@@ -1267,6 +1267,23 @@ mod tests {
         assert_eq!(resp.data.unwrap().len(), 2);
     }
 
+    /// A failed repository read must never be rendered as an empty successful
+    /// rules list: the UI would tell an operator that every rule disappeared.
+    #[tokio::test]
+    async fn list_rules_database_error_is_not_an_empty_success() {
+        let (state, pool) = test_state().await;
+        pool.close().await;
+
+        let Json(resp) = list_rules(
+            auth(1, true),
+            Query(ListRulesQuery::default()),
+            State(state),
+        )
+        .await;
+        assert_eq!(resp.code, 500);
+        assert!(resp.data.is_none());
+    }
+
     /// v0.4.20: admin can filter rules by owner_uid query param.
     #[tokio::test]
     async fn list_rules_owner_uid_admin_only() {

--- a/crates/panel/src/api/admin/plans.rs
+++ b/crates/panel/src/api/admin/plans.rs
@@ -107,23 +107,28 @@ pub async fn list_plans(
     // admin-only page; a JOIN-aggregate could replace it if plan counts grow.
     let mut out = Vec::with_capacity(plans.len());
     for plan in plans {
-        let device_group_ids = state
-            .db
-            .list_plan_device_groups(plan.id)
-            .await
-            .unwrap_or_else(|e| {
+        let device_group_ids = match state.db.list_plan_device_groups(plan.id).await {
+            Ok(ids) => ids,
+            Err(e) => {
                 tracing::error!(
                     "list_plans: list_plan_device_groups({}) failed: {}",
                     plan.id,
                     e
                 );
-                Vec::new()
-            });
-        let device_group_names = state
-            .db
-            .list_group_names_by_ids(&device_group_ids)
-            .await
-            .unwrap_or_default();
+                return Json(err(500, "数据库错误"));
+            }
+        };
+        let device_group_names = match state.db.list_group_names_by_ids(&device_group_ids).await {
+            Ok(names) => names,
+            Err(e) => {
+                tracing::error!(
+                    "list_plans: list_group_names_by_ids({}) failed: {}",
+                    plan.id,
+                    e
+                );
+                return Json(err(500, "数据库错误"));
+            }
+        };
         out.push(PlanWithGroups {
             plan,
             device_group_ids,

--- a/crates/panel/src/api/admin/profiles.rs
+++ b/crates/panel/src/api/admin/profiles.rs
@@ -21,15 +21,17 @@ pub async fn list_tunnel_profiles(
     // v0.4.11 PR1: any logged-in user can see available templates (ws/tls_simple,
     // builtin + admin-created custom) for rule selection. No longer restricted
     // to builtin only.
-    let profiles: Vec<TunnelProfile> = state
+    match state
         .db
         .list_profiles(&ProfileScope::AvailableTemplates)
         .await
-        .unwrap_or_else(|e| {
+    {
+        Ok(profiles) => Json(ApiResponse::success(profiles)),
+        Err(e) => {
             tracing::error!("list_tunnel_profiles: db error: {}", e);
-            Vec::new()
-        });
-    Json(ApiResponse::success(profiles))
+            Json(err(500, "数据库错误"))
+        }
+    }
 }
 
 /// v0.4.11 PR1: admin-only endpoint for the tunnel profile management page.
@@ -39,15 +41,17 @@ pub async fn list_admin_tunnel_profiles(
     _admin: AdminOnly,
     State(state): State<AppState>,
 ) -> Json<ApiResponse<Vec<TunnelProfile>>> {
-    let profiles: Vec<TunnelProfile> = state
+    match state
         .db
         .list_profiles(&ProfileScope::ManageableCustomTemplates)
         .await
-        .unwrap_or_else(|e| {
+    {
+        Ok(profiles) => Json(ApiResponse::success(profiles)),
+        Err(e) => {
             tracing::error!("list_admin_tunnel_profiles: db error: {}", e);
-            Vec::new()
-        });
-    Json(ApiResponse::success(profiles))
+            Json(err(500, "数据库错误"))
+        }
+    }
 }
 
 pub async fn create_tunnel_profile(

--- a/crates/panel/src/api/admin/rules.rs
+++ b/crates/panel/src/api/admin/rules.rs
@@ -27,11 +27,13 @@ pub async fn list_rules(
         (true, Some(owner_uid)) => crate::db::repo::ResourceScope::Owner(owner_uid),
         _ => user.resource_scope(),
     };
-    let rules: Vec<ForwardRule> = state.db.list_rules(&scope).await.unwrap_or_else(|e| {
-        tracing::error!("list_rules: db error: {}", e);
-        Vec::new()
-    });
-    Json(ApiResponse::success(rules))
+    match state.db.list_rules(&scope).await {
+        Ok(rules) => Json(ApiResponse::success(rules)),
+        Err(e) => {
+            tracing::error!("list_rules: db error: {}", e);
+            Json(err(500, "数据库错误"))
+        }
+    }
 }
 
 pub async fn create_rule(

--- a/crates/panel/src/api/admin/shop.rs
+++ b/crates/panel/src/api/admin/shop.rs
@@ -36,24 +36,29 @@ pub async fn list_public_plans(
         let device_group_ids = if plan.grant_all_groups {
             Vec::new()
         } else {
-            state
-                .db
-                .list_plan_device_groups(plan.id)
-                .await
-                .unwrap_or_else(|e| {
+            match state.db.list_plan_device_groups(plan.id).await {
+                Ok(ids) => ids,
+                Err(e) => {
                     tracing::error!(
                         "list_public_plans: list_plan_device_groups({}) failed: {}",
                         plan.id,
                         e
                     );
-                    Vec::new()
-                })
+                    return Json(err(500, "数据库错误"));
+                }
+            }
         };
-        let device_group_names = state
-            .db
-            .list_group_names_by_ids(&device_group_ids)
-            .await
-            .unwrap_or_default();
+        let device_group_names = match state.db.list_group_names_by_ids(&device_group_ids).await {
+            Ok(names) => names,
+            Err(e) => {
+                tracing::error!(
+                    "list_public_plans: list_group_names_by_ids({}) failed: {}",
+                    plan.id,
+                    e
+                );
+                return Json(err(500, "数据库错误"));
+            }
+        };
         out.push(PlanWithGroups {
             plan,
             device_group_ids,

--- a/crates/panel/src/api/admin/users.rs
+++ b/crates/panel/src/api/admin/users.rs
@@ -18,11 +18,13 @@ pub async fn list_users(
 ) -> Json<ApiResponse<Vec<UserPublic>>> {
     // SELECT * is safe here — UserPublic has no `password` field, so sqlx
     // simply ignores that column. The hash never reaches the API response.
-    let users: Vec<UserPublic> = state.db.list_users_public().await.unwrap_or_else(|e| {
-        tracing::error!("list_users: db error: {}", e);
-        Vec::new()
-    });
-    Json(ApiResponse::success(users))
+    match state.db.list_users_public().await {
+        Ok(users) => Json(ApiResponse::success(users)),
+        Err(e) => {
+            tracing::error!("list_users: db error: {}", e);
+            Json(err(500, "数据库错误"))
+        }
+    }
 }
 
 /// Admin creates a NON-ADMIN user. Per the v0.4.4 two-tier model, admins can

--- a/crates/panel/src/api/groups.rs
+++ b/crates/panel/src/api/groups.rs
@@ -57,11 +57,13 @@ pub async fn list_shared_groups(
     // v1.0.7: filter to the groups the user is authorized for. The authorized
     // set already expands all_device_groups (→ every inbound group); an
     // unassigned non-admin gets an empty set and sees nothing.
-    let authorized = state
-        .db
-        .authorized_device_group_ids(user.user_id)
-        .await
-        .unwrap_or_default();
+    let authorized = match state.db.authorized_device_group_ids(user.user_id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::error!("list_shared_groups: authorization lookup failed: {}", e);
+            return db_error();
+        }
+    };
     let filtered: Vec<_> = all_groups
         .into_iter()
         .filter(|g| authorized.contains(&g.id))
@@ -105,11 +107,16 @@ pub async fn list_shared_node_summary(
     let groups = if user.admin {
         groups
     } else {
-        let authorized = state
-            .db
-            .authorized_device_group_ids(user.user_id)
-            .await
-            .unwrap_or_default();
+        let authorized = match state.db.authorized_device_group_ids(user.user_id).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::error!(
+                    "list_shared_node_summary: authorization lookup failed: {}",
+                    e
+                );
+                return db_error();
+            }
+        };
         groups
             .into_iter()
             .filter(|g| !g.hidden && authorized.contains(&g.id))

--- a/crates/panel/src/api/stats.rs
+++ b/crates/panel/src/api/stats.rs
@@ -92,7 +92,7 @@ pub async fn get_stats(
     State(state): State<AppState>,
     Query(q): Query<StatsQuery>,
 ) -> Json<ApiResponse<Vec<Statistic>>> {
-    let stats: Vec<Statistic> = state
+    let stats: Vec<Statistic> = match state
         .db
         .query_stats(
             q.stat_type.as_deref(),
@@ -101,10 +101,17 @@ pub async fn get_stats(
             q.to.as_deref(),
         )
         .await
-        .unwrap_or_else(|e| {
+    {
+        Ok(stats) => stats,
+        Err(e) => {
             tracing::error!("get_stats: db error: {}", e);
-            Vec::new()
-        });
+            return Json(ApiResponse {
+                code: 500,
+                message: "数据库错误".into(),
+                data: None,
+            });
+        }
+    };
 
     Json(ApiResponse::success(stats))
 }
@@ -263,15 +270,17 @@ pub async fn get_node_status(
     // drops the row, while an admin keeps it with a fallback name.
     let scope = user.resource_scope();
 
-    let rows: Vec<(String, String)> =
-        state
-            .db
-            .scan_prefix("node_status:")
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!("get_node_status: scan_prefix failed: {}", e);
-                Vec::new()
+    let rows: Vec<(String, String)> = match state.db.scan_prefix("node_status:").await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("get_node_status: scan_prefix failed: {}", e);
+            return Json(ApiResponse {
+                code: 500,
+                message: "数据库错误".into(),
+                data: None,
             });
+        }
+    };
 
     let mut statuses: Vec<serde_json::Value> = Vec::new();
     // v0.4.15 PR3: stamp `online` on every admin row using the SAME source of

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -47,6 +47,8 @@ export default function Dashboard() {
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const [showChangelog, setShowChangelog] = useState(false);
   const [versionRefreshing, setVersionRefreshing] = useState(false);
+  // See load(): a failed read must not be counted as zero.
+  const [loadFailed, setLoadFailed] = useState(false);
 
   const load = async () => {
     try {
@@ -55,13 +57,25 @@ export default function Dashboard() {
         api.get<unknown, ApiEnvelope<ForwardRule[]>>('/rules'),
         api.get<unknown, ApiEnvelope<DeviceGroup[]>>('/groups'),
       ]);
-      setStats({
-        users: users.data?.length || 0,
-        rules: rules.data?.length || 0,
-        groups: groups.data?.length || 0,
-      });
-      setRuleList(rules.data || []);
-    } catch { /* ignore */ }
+      // These reads report a database failure as `code: 500` with `data: null`
+      // inside a 200 response. Counting a null payload would put "0 users,
+      // 0 rules, 0 groups" on the dashboard — the most alarming possible way
+      // to render an outage, and wrong. Keep the last known numbers and say
+      // that the refresh failed instead.
+      if (users.code !== 0 || rules.code !== 0 || groups.code !== 0) {
+        setLoadFailed(true);
+      } else {
+        setLoadFailed(false);
+        setStats({
+          users: users.data?.length || 0,
+          rules: rules.data?.length || 0,
+          groups: groups.data?.length || 0,
+        });
+        setRuleList(rules.data || []);
+      }
+    } catch {
+      setLoadFailed(true);
+    }
 
     try {
       const nodeStatus = await api.get<unknown, ApiEnvelope<NodeStatus[]>>('/nodes');
@@ -203,6 +217,15 @@ export default function Dashboard() {
 
   return (
     <>
+      {loadFailed && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 16 }}
+          title={t('loadFailed')}
+          description={t('loadFailedRetry')}
+        />
+      )}
       {versionInfo?.check_failed && (
         <Alert
           type="warning"

--- a/frontend/src/pages/Groups.test.tsx
+++ b/frontend/src/pages/Groups.test.tsx
@@ -35,6 +35,39 @@ beforeEach(() => {
   });
 });
 
+// ── A failed read reports `code: 500` with `data: null` inside a 200 response,
+// so the axios success path runs. Rendering that as an empty table would tell
+// an operator their groups are gone, and invite them to recreate groups that
+// still exist.
+describe('a database error is not an empty group list', () => {
+  it('shows a load failure instead of an empty table', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/groups') {
+        return Promise.resolve({ code: 500, message: '数据库错误', data: null });
+      }
+      return Promise.resolve(ok([]));
+    });
+    render(<Groups />);
+    await waitFor(() => expect(screen.getByText('loadFailed')).toBeInTheDocument());
+    expect(screen.getByText('loadFailedRetry')).toBeInTheDocument();
+  });
+
+  it('shows a load failure when the request itself rejects', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/groups') return Promise.reject(new Error('network down'));
+      return Promise.resolve(ok([]));
+    });
+    render(<Groups />);
+    await waitFor(() => expect(screen.getByText('loadFailed')).toBeInTheDocument());
+  });
+
+  it('shows no failure banner on a healthy read', async () => {
+    render(<Groups />);
+    await waitFor(() => expect(screen.getByText('g1')).toBeInTheDocument());
+    expect(screen.queryByText('loadFailed')).toBeNull();
+  });
+});
+
 // ── v1.2.5: a monitor-only group forwards nothing and never reaches a regular
 // user, so connect host / port range / rate / hidden are inert on it. The forms
 // stop asking for them, and nothing inert gets written to the DB.

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -48,6 +48,8 @@ export default function Groups() {
   const [rotating, setRotating] = useState<DeviceGroup | null>(null);
   const [confirmName, setConfirmName] = useState('');
   const [rotateBusy, setRotateBusy] = useState(false);
+  // See load(): a failed read must not be shown as an empty group list.
+  const [loadFailed, setLoadFailed] = useState(false);
   const [createForm] = Form.useForm();
   const [editForm] = Form.useForm();
 
@@ -67,7 +69,15 @@ export default function Groups() {
     setLoading(true);
     try {
       const g = await api.get<unknown, ApiEnvelope<DeviceGroup[]>>('/groups');
-      setGroups(g.data || []);
+      // `code: 500` arrives inside a 200 response with `data: null`, so without
+      // this check a database outage renders as "no groups" — and from here an
+      // operator would go create duplicates of groups that still exist.
+      if (g.code !== 0) {
+        setLoadFailed(true);
+      } else {
+        setLoadFailed(false);
+        setGroups(g.data || []);
+      }
       if (isAdmin) {
         try {
           const u = await api.get<unknown, ApiEnvelope<User[]>>('/admin/users');
@@ -85,6 +95,8 @@ export default function Groups() {
           setNodes(n.data || []);
         } catch { setNodes([]); }
       }
+    } catch {
+      setLoadFailed(true);
     } finally { setLoading(false); }
   }, [isAdmin]);
 
@@ -421,6 +433,15 @@ export default function Groups() {
           <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>{t('addGroup')}</Button>
         </Space>
       </div>
+      {loadFailed && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 12 }}
+          title={t('loadFailed')}
+          description={t('loadFailedRetry')}
+        />
+      )}
       <Table
         dataSource={groups}
         columns={columns}

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -68,6 +68,11 @@ export default function Rules() {
   // user then sees a load-failure notice and rule creation is blocked, instead
   // of a misleading empty inbound dropdown.
   const [sharedLoadFailed, setSharedLoadFailed] = useState(false);
+  // The backend reports a failed read as `code: 500` inside a 200 response, so
+  // the axios success path runs and `res.data` is null. Without this flag
+  // `setRules(res.data || [])` renders a database outage as "you have no
+  // rules" — the one thing the list must never claim.
+  const [listLoadFailed, setListLoadFailed] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
   // v1.0.7: a regular user's own traffic quota (admins read each owner's quota
   // from `users` instead). Used to flag rules whose owner is out of traffic —
@@ -108,12 +113,26 @@ export default function Rules() {
       // user → use filterOwnerUid; regular user → backend filters automatically.
       const ownerUid = filterOwnerUid ?? (isAdmin ? (user?.id ?? null) : null);
       const rulesUrl = ownerUid ? `/rules?owner_uid=${ownerUid}` : '/rules';
+      // The rejection is caught here rather than in a `catch` block: this body
+      // is inside a useCallback, and adding try/catch/finally around it trips
+      // react-hooks/preserve-manual-memoization (the React Compiler cannot
+      // preserve the memoization through that shape).
       const [r, g] = await Promise.all([
         api.get<unknown, ApiEnvelope<ForwardRule[]>>(rulesUrl),
         api.get<unknown, ApiEnvelope<DeviceGroup[]>>('/groups'),
-      ]);
-      setRules(r.data || []);
-      setGroups(g.data || []);
+      ]).catch(() => [null, null] as [null, null]);
+      // A failed read keeps whatever is already on screen rather than blanking
+      // it: the rows are still the last known truth, and replacing them with an
+      // empty table is exactly the false statement this guard exists to stop.
+      // Not an early return — the reads below are independent, and a rules
+      // failure should not also cost the user their inbound-group list.
+      if (!r || !g || r.code !== 0 || g.code !== 0) {
+        setListLoadFailed(true);
+      } else {
+        setListLoadFailed(false);
+        setRules(r.data || []);
+        setGroups(g.data || []);
+      }
       if (isAdmin) {
         try {
           const u = await api.get<unknown, ApiEnvelope<User[]>>('/admin/users');
@@ -958,6 +977,15 @@ const IMPORT_DEFAULTS = {
       {/* v0.4.12 PR1: a regular user whose shared-lines fetch failed sees a
           load-failure notice; rule creation is disabled above so they can't
           submit against an empty/unknown inbound list. */}
+      {listLoadFailed && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 12 }}
+          title={t('loadFailed')}
+          description={t('loadFailedRetry')}
+        />
+      )}
       {!isAdmin && sharedLoadFailed && (
         <Alert
           type="error"

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -113,26 +113,33 @@ export default function Rules() {
       // user → use filterOwnerUid; regular user → backend filters automatically.
       const ownerUid = filterOwnerUid ?? (isAdmin ? (user?.id ?? null) : null);
       const rulesUrl = ownerUid ? `/rules?owner_uid=${ownerUid}` : '/rules';
-      // The rejection is caught here rather than in a `catch` block: this body
-      // is inside a useCallback, and adding try/catch/finally around it trips
-      // react-hooks/preserve-manual-memoization (the React Compiler cannot
-      // preserve the memoization through that shape).
-      const [r, g] = await Promise.all([
+      // allSettled, not all: these are two independent reads and each one's
+      // result must survive the other failing. `Promise.all` rejects on the
+      // first rejection and discards the sibling's value, so a failed /rules
+      // also threw away a perfectly good group list — which is the list the
+      // create-rule form needs, leaving an admin with an empty inbound picker
+      // on a page whose only problem was the rules query.
+      //
+      // The rejection is handled here rather than in a `catch` block because
+      // this body is inside a useCallback, and wrapping it in try/catch/finally
+      // trips react-hooks/preserve-manual-memoization.
+      const [rulesRes, groupsRes] = await Promise.allSettled([
         api.get<unknown, ApiEnvelope<ForwardRule[]>>(rulesUrl),
         api.get<unknown, ApiEnvelope<DeviceGroup[]>>('/groups'),
-      ]).catch(() => [null, null] as [null, null]);
-      // A failed read keeps whatever is already on screen rather than blanking
-      // it: the rows are still the last known truth, and replacing them with an
-      // empty table is exactly the false statement this guard exists to stop.
-      // Not an early return — the reads below are independent, and a rules
-      // failure should not also cost the user their inbound-group list.
-      if (!r || !g || r.code !== 0 || g.code !== 0) {
-        setListLoadFailed(true);
-      } else {
-        setListLoadFailed(false);
-        setRules(r.data || []);
-        setGroups(g.data || []);
-      }
+      ]);
+      // A read that failed keeps whatever is already on screen rather than
+      // blanking it: the rows are still the last known truth, and replacing
+      // them with an empty table is the false statement this guard exists to
+      // stop. Each list is applied on its own.
+      const rules = rulesRes.status === 'fulfilled' && rulesRes.value.code === 0
+        ? rulesRes.value
+        : null;
+      const groups = groupsRes.status === 'fulfilled' && groupsRes.value.code === 0
+        ? groupsRes.value
+        : null;
+      if (rules) setRules(rules.data || []);
+      if (groups) setGroups(groups.data || []);
+      setListLoadFailed(!rules || !groups);
       if (isAdmin) {
         try {
           const u = await api.get<unknown, ApiEnvelope<User[]>>('/admin/users');

--- a/frontend/src/pages/RulesPage.test.tsx
+++ b/frontend/src/pages/RulesPage.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('../api/client', () => ({
+  default: { get: mockGet, post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
+vi.mock('../auth/useAuth', () => ({ useAuth: mockUseAuth }));
+
+import Rules from './Rules';
+
+const ok = <T,>(data: T) => ({ code: 0, message: 'ok', data });
+
+const rule = (over: Record<string, unknown> = {}) => ({
+  id: 1, name: 'r1', uid: 1, listen_port: 10001, device_group_in: 7,
+  target_addr: '1.2.3.4', target_port: 80, protocol: 'tcp', paused: false,
+  targets: [{ host: '1.2.3.4', port: 80, enabled: true, position: 1, id: 1, rule_id: 1 }],
+  ...over,
+});
+const group = (over: Record<string, unknown> = {}) => ({
+  id: 7, name: 'hk-line', group_type: 'in', token: 'tok', uid: 1,
+  connect_host: '1.2.3.4', port_range: '10000-65535', rate: 1.0, hidden: false,
+  ...over,
+});
+
+const renderPage = () => render(<MemoryRouter><Rules /></MemoryRouter>);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockUseAuth.mockReset();
+  mockUseAuth.mockReturnValue({ isAdmin: true, user: { id: 1, username: 'admin' } });
+});
+
+/** Route the two independent list reads separately so each can fail alone. */
+function routes({ rules, groups }: { rules?: unknown; groups?: unknown }) {
+  mockGet.mockImplementation((url: string) => {
+    if (url.startsWith('/rules')) {
+      return rules instanceof Error ? Promise.reject(rules) : Promise.resolve(rules);
+    }
+    if (url === '/groups') {
+      return groups instanceof Error ? Promise.reject(groups) : Promise.resolve(groups);
+    }
+    return Promise.resolve(ok([]));
+  });
+}
+
+// ── /rules and /groups are two independent reads. They were fetched with
+// Promise.all, which rejects on the FIRST rejection and discards the sibling's
+// value — so a failed /rules also threw away a good group list, leaving the
+// create-rule form with an empty inbound picker for a problem that had nothing
+// to do with groups.
+/**
+ * Assert the loaded groups reached the create-rule form's inbound picker.
+ *
+ * This is the consequence that matters: the picker is the only place `groups`
+ * surfaces when the rules table is empty, and an admin who cannot choose an
+ * inbound group cannot create a rule at all.
+ */
+async function inboundPickerOffers(name: string) {
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole('button', { name: /addRule/ }));
+  const picker = await screen.findByLabelText('inboundGroup');
+  await user.click(picker);
+  await waitFor(() => expect(screen.getByTitle(name)).toBeInTheDocument());
+}
+
+describe('a failed list read does not discard the other list', () => {
+  it('keeps the groups when only /rules fails', async () => {
+    routes({
+      rules: { code: 500, message: '数据库错误', data: null },
+      groups: ok([group()]),
+    });
+    renderPage();
+    // The failure is reported...
+    await waitFor(() => expect(screen.getByText('loadFailed')).toBeInTheDocument());
+    // ...and the group list still made it through.
+    await inboundPickerOffers('hk-line');
+  });
+
+  it('keeps the groups when the /rules request itself rejects', async () => {
+    routes({ rules: new Error('network down'), groups: ok([group()]) });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('loadFailed')).toBeInTheDocument());
+    await inboundPickerOffers('hk-line');
+  });
+
+  it('keeps the rules when only /groups fails', async () => {
+    routes({ rules: ok([rule()]), groups: { code: 500, message: '数据库错误', data: null } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('loadFailed')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('r1')).toBeInTheDocument());
+  });
+
+  it('reports no failure and shows both when each read succeeds', async () => {
+    routes({ rules: ok([rule()]), groups: ok([group()]) });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('r1')).toBeInTheDocument());
+    expect(screen.queryByText('loadFailed')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Return an explicit 500 response when administrative list/read queries fail.
- Cover rules, groups, users, profiles, plans and their group metadata, public plans, shared-group authorization, stats, and node-status reads.
- Add a closed-pool regression test so a database outage cannot look like a valid empty rules list.

## Verification
- cargo fmt --check
- cargo test -p relay-panel (522 passed)
- cargo clippy -p relay-panel --all-targets -- -D warnings
- git diff --check