### PR TITLE
feat(rules): put the filters in the URL, and name row actions by rule

### DIFF
--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -55,7 +55,7 @@ function downloadText(filename: string, text: string) {
 export default function Rules() {
   const { t } = useI18n();
   const { isAdmin, user } = useAuth();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   // v0.4.20: admin can manage another user's rules via /rules?owner_uid=X.
   const filterOwnerUid: number | null = isAdmin
     ? (parseInt(searchParams.get('owner_uid') || '') || null)
@@ -92,12 +92,38 @@ export default function Rules() {
   const [diagnosing, setDiagnosing] = useState<ForwardRule | null>(null);
   const [diagnoseLoading, setDiagnoseLoading] = useState(false);
   const [diagnoseResult, setDiagnoseResult] = useState<DiagnoseResponse | null>(null);
-  // v0.4.9: group-name column + filter. selectedGroup === null means "all".
-  // (Explicit null, not !selectedGroup, so a future id of 0 wouldn't be falsy.)
-  const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
+  // v1.2.7: the filters live in the URL, not in component state.
+  //
+  // They used to be plain useState, so a refresh dropped them and a link to
+  // "the rules on the HK line matching 8443" could not be sent to anyone —
+  // which is exactly the thing an operator wants to paste into a ticket. The
+  // page already read owner_uid from the query string; group and search now
+  // join it so the whole filter set is one shareable address.
+  //
+  // v0.4.9: selectedGroup === null means "all". Explicit null, not
+  // !selectedGroup, so a future group id of 0 would not read as falsy.
+  const selectedGroup: number | null = parseInt(searchParams.get('group') || '') || null;
   // Client-side filter over the already-loaded rules — /rules returns the whole
   // (owner-scoped) set, so searching needs no round-trip.
-  const [ruleSearch, setRuleSearch] = useState('');
+  const ruleSearch = searchParams.get('q') || '';
+
+  /**
+   * Write one filter into the query string, preserving the others.
+   *
+   * `replace` so typing in the search box does not push a history entry per
+   * keystroke — Back should leave the page, not walk the search term backwards
+   * one character at a time. An empty value drops the key entirely rather than
+   * leaving `?q=` behind.
+   */
+  const setFilter = useCallback((key: 'group' | 'q', value: string | null) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      if (value) next.set(key, value);
+      else next.delete(key);
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
 
   const load = useCallback(async () => {
@@ -675,19 +701,26 @@ const IMPORT_DEFAULTS = {
     { title: t('traffic'), dataIndex: 'traffic_used', key: 'traffic_used', render: (v: number) => formatBytes(v) },
     {
       title: t('action'), key: 'action', width: 260,
+      // v1.2.7: every action carries an accessible name that names its RULE.
+      // The visible text alone ("编辑") is identical on every row, so tabbing
+      // this table with a screen reader announced the same word once per rule
+      // with nothing to distinguish them — and "delete" is not a button you
+      // want to press on faith. The visible label stays short; only the
+      // accessible name is qualified.
       render: (_: unknown, r: ForwardRule) => (
         <Space>
           <Button
             size="small" type="text"
             icon={r.paused ? <PlayCircleOutlined /> : <PauseCircleOutlined />}
+            aria-label={`${r.paused ? t('resume') : t('pause')} ${r.name}`}
             onClick={() => handleTogglePause(r)}
           >
             {r.paused ? t('resume') : t('pause')}
           </Button>
-          <Button size="small" type="text" icon={<EditOutlined />} onClick={() => handleEdit(r)}>{t('edit')}</Button>
-          <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => handleCopy(r)}>{t('copy')}</Button>
+          <Button size="small" type="text" icon={<EditOutlined />} aria-label={`${t('edit')} ${r.name}`} onClick={() => handleEdit(r)}>{t('edit')}</Button>
+          <Button size="small" type="text" icon={<CopyOutlined />} aria-label={`${t('copy')} ${r.name}`} onClick={() => handleCopy(r)}>{t('copy')}</Button>
           {/* v0.4.9: diagnosis is TCP-only — disable for pure-UDP rules. */}
-          <Button size="small" type="text" icon={<MedicineBoxOutlined />} disabled={r.protocol === 'udp'} onClick={() => handleDiagnose(r)} title={r.protocol === 'udp' ? t('diagnoseUdpUnsupported') : t('diagnose')}>{t('diagnose')}</Button>
+          <Button size="small" type="text" icon={<MedicineBoxOutlined />} disabled={r.protocol === 'udp'} aria-label={`${t('diagnose')} ${r.name}`} onClick={() => handleDiagnose(r)} title={r.protocol === 'udp' ? t('diagnoseUdpUnsupported') : t('diagnose')}>{t('diagnose')}</Button>
           {/* v1.2.0: restart drops every live connection on this rule, so it is
               behind a confirm (diagnose is read-only and isn't). Disabled while
               paused — there are no listeners to restart. */}
@@ -703,13 +736,14 @@ const IMPORT_DEFAULTS = {
               type="text"
               icon={<ThunderboltOutlined />}
               disabled={r.paused}
+              aria-label={`${t('restart')} ${r.name}`}
               title={r.paused ? t('restartPausedHint') : t('restart')}
             >
               {t('restart')}
             </Button>
           </Popconfirm>
           <Popconfirm title={t('deleteRuleConfirm')} onConfirm={() => handleDelete(r.id)}>
-            <Button danger size="small" type="text">{t('delete')}</Button>
+            <Button danger size="small" type="text" aria-label={`${t('delete')} ${r.name}`}>{t('delete')}</Button>
           </Popconfirm>
         </Space>
       ),
@@ -912,8 +946,9 @@ const IMPORT_DEFAULTS = {
             allowClear
             prefix={<SearchOutlined />}
             placeholder={t('searchRulePlaceholder')}
+            aria-label={t('searchRulePlaceholder')}
             value={ruleSearch}
-            onChange={(e) => { setRuleSearch(e.target.value); setSelectedRowKeys([]); }}
+            onChange={(e) => { setFilter('q', e.target.value); setSelectedRowKeys([]); }}
             style={{ width: 220 }}
           />
           {/* v0.4.9: filter by inbound group. Only groups that actually have
@@ -922,8 +957,9 @@ const IMPORT_DEFAULTS = {
             style={{ minWidth: 180 }}
             allowClear
             placeholder={t('filterByGroup')}
+            aria-label={t('filterByGroup')}
             value={selectedGroup ?? undefined}
-            onChange={(v: number | undefined) => { setSelectedGroup(v ?? null); setSelectedRowKeys([]); }}
+            onChange={(v: number | undefined) => { setFilter('group', v == null ? null : String(v)); setSelectedRowKeys([]); }}
             options={Array.from(new Set(rules.map(r => r.device_group_in)))
               .map(gid => {
                 const g = groupMap.get(gid);

--- a/frontend/src/pages/RulesPage.test.tsx
+++ b/frontend/src/pages/RulesPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 
 const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
 vi.mock('../api/client', () => ({
@@ -15,7 +15,7 @@ import Rules from './Rules';
 const ok = <T,>(data: T) => ({ code: 0, message: 'ok', data });
 
 const rule = (over: Record<string, unknown> = {}) => ({
-  id: 1, name: 'r1', uid: 1, listen_port: 10001, device_group_in: 7,
+  id: 1, name: 'hk-web', uid: 1, listen_port: 10001, device_group_in: 7,
   target_addr: '1.2.3.4', target_port: 80, protocol: 'tcp', paused: false,
   targets: [{ host: '1.2.3.4', port: 80, enabled: true, position: 1, id: 1, rule_id: 1 }],
   ...over,
@@ -26,13 +26,19 @@ const group = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
-const renderPage = () => render(<MemoryRouter><Rules /></MemoryRouter>);
+/** Surfaces the current query string so URL state can be asserted directly. */
+function UrlProbe() {
+  const loc = useLocation();
+  return <div data-testid="qs">{loc.search}</div>;
+}
 
-beforeEach(() => {
-  mockGet.mockReset();
-  mockUseAuth.mockReset();
-  mockUseAuth.mockReturnValue({ isAdmin: true, user: { id: 1, username: 'admin' } });
-});
+const renderPage = (initial = '/rules') =>
+  render(
+    <MemoryRouter initialEntries={[initial]}>
+      <Rules />
+      <UrlProbe />
+    </MemoryRouter>,
+  );
 
 /** Route the two independent list reads separately so each can fail alone. */
 function routes({ rules, groups }: { rules?: unknown; groups?: unknown }) {
@@ -47,11 +53,17 @@ function routes({ rules, groups }: { rules?: unknown; groups?: unknown }) {
   });
 }
 
-// ── /rules and /groups are two independent reads. They were fetched with
-// Promise.all, which rejects on the FIRST rejection and discards the sibling's
-// value — so a failed /rules also threw away a good group list, leaving the
-// create-rule form with an empty inbound picker for a problem that had nothing
-// to do with groups.
+beforeEach(() => {
+  mockGet.mockReset();
+  mockUseAuth.mockReset();
+  mockUseAuth.mockReturnValue({ isAdmin: true, user: { id: 1, username: 'admin' } });
+  // Default: two rules on two different groups, both reads healthy.
+  routes({
+    rules: ok([rule(), rule({ id: 2, name: 'jp-game', listen_port: 10002, device_group_in: 8 })]),
+    groups: ok([group(), group({ id: 8, name: 'jp-line' })]),
+  });
+});
+
 /**
  * Assert the loaded groups reached the create-rule form's inbound picker.
  *
@@ -67,6 +79,11 @@ async function inboundPickerOffers(name: string) {
   await waitFor(() => expect(screen.getByTitle(name)).toBeInTheDocument());
 }
 
+// ── /rules and /groups are two independent reads. They were fetched with
+// Promise.all, which rejects on the FIRST rejection and discards the sibling's
+// value — so a failed /rules also threw away a good group list, leaving the
+// create-rule form with an empty inbound picker for a problem that had nothing
+// to do with groups.
 describe('a failed list read does not discard the other list', () => {
   it('keeps the groups when only /rules fails', async () => {
     routes({
@@ -91,13 +108,90 @@ describe('a failed list read does not discard the other list', () => {
     routes({ rules: ok([rule()]), groups: { code: 500, message: '数据库错误', data: null } });
     renderPage();
     await waitFor(() => expect(screen.getByText('loadFailed')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('r1')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
   });
 
   it('reports no failure and shows both when each read succeeds', async () => {
     routes({ rules: ok([rule()]), groups: ok([group()]) });
     renderPage();
-    await waitFor(() => expect(screen.getByText('r1')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
     expect(screen.queryByText('loadFailed')).toBeNull();
+  });
+});
+
+// ── v1.2.7: the filters live in the URL. They were component state, so a
+// refresh dropped them and the filtered view could not be linked to anyone.
+describe('rule filters are URL state', () => {
+  it('restores the search term from the query string on first render', async () => {
+    renderPage('/rules?q=jp');
+    await waitFor(() => expect(screen.getByText('jp-game')).toBeInTheDocument());
+    expect(screen.queryByText('hk-web')).toBeNull();
+  });
+
+  it('restores the group filter from the query string', async () => {
+    renderPage('/rules?group=8');
+    await waitFor(() => expect(screen.getByText('jp-game')).toBeInTheDocument());
+    expect(screen.queryByText('hk-web')).toBeNull();
+  });
+
+  it('writes the search term into the URL as it is typed', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
+    await user.type(screen.getByLabelText('searchRulePlaceholder'), 'jp');
+    await waitFor(() => expect(screen.getByTestId('qs').textContent).toBe('?q=jp'));
+  });
+
+  it('drops the key instead of leaving an empty one behind', async () => {
+    const user = userEvent.setup();
+    renderPage('/rules?q=jp');
+    await waitFor(() => expect(screen.getByText('jp-game')).toBeInTheDocument());
+    await user.clear(screen.getByLabelText('searchRulePlaceholder'));
+    await waitFor(() => expect(screen.getByTestId('qs').textContent).toBe(''));
+  });
+
+  it('keeps owner_uid when a filter changes', async () => {
+    // owner_uid is how an admin arrives from the users page; losing it would
+    // silently switch which account's rules are being managed.
+    const user = userEvent.setup();
+    renderPage('/rules?owner_uid=5');
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
+    await user.type(screen.getByLabelText('searchRulePlaceholder'), 'jp');
+    await waitFor(() => {
+      const qs = new URLSearchParams(screen.getByTestId('qs').textContent || '');
+      expect(qs.get('owner_uid')).toBe('5');
+      expect(qs.get('q')).toBe('jp');
+    });
+  });
+});
+
+// ── Every row's action buttons carry the same visible word ("编辑"), so the
+// accessible name has to say which rule, or a screen reader announces an
+// undifferentiated list of them — including "delete".
+describe('row actions name their rule', () => {
+  it('gives each action an accessible name containing the rule name', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
+    for (const action of ['edit', 'copy', 'delete', 'diagnose', 'restart', 'pause']) {
+      expect(
+        screen.getByRole('button', { name: `${action} hk-web` }),
+        `${action} must be addressable on hk-web`,
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: `${action} jp-game` })).toBeInTheDocument();
+    }
+  });
+
+  it('names the resume action on a paused rule', async () => {
+    routes({ rules: ok([rule({ paused: true })]), groups: ok([group()]) });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'resume hk-web' })).toBeInTheDocument();
+  });
+
+  it('labels the two filter controls', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('hk-web')).toBeInTheDocument());
+    expect(screen.getByLabelText('searchRulePlaceholder')).toBeInTheDocument();
+    expect(screen.getByLabelText('filterByGroup')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
规则页两处独立的改进。

## 1. 筛选条件写进 URL

分组筛选和搜索框原来是组件 state —— 刷新就没了，筛完的视图也发不给别人。「香港线路上匹配 8443 的规则」不是一个能粘进工单的东西。

页面本来就从 query string 读 `owner_uid`，现在 `group` 和 `q` 也进去了，整套筛选条件是一个可分享的地址。

几个刻意的取舍：

- **`replace: true`** —— 打字不会每敲一个字符压一条历史。返回键应该离开页面，而不是把搜索词一个字一个字倒退回去。浏览器实测：敲两个字符，**历史条目增加 0**。
- **空值删除 key**，不留 `?q=` 这种尾巴。
- **`owner_uid` 在任何筛选变化时都保留** —— 这个参数决定「在管谁的规则」，弄丢了会静默切换账号。实测 `?owner_uid=1` 打字后变成 `?owner_uid=1&q=jp`。

## 2. 行操作按可访问名区分规则

每行的操作按钮可见文字都一样。用读屏软件 Tab 过表格，听到的是「编辑、编辑、编辑……」，没有任何信息说这是哪条规则 —— 而「删除」不是一个可以凭感觉按下去的按钮。

现在每个操作的可访问名都带上规则名，可见文字不变：

```
暂停 hk-web / 编辑 hk-web / 复制 hk-web / 诊断 hk-web / 重启 hk-web / 删除 hk-web
暂停 hk-api / 编辑 hk-api / ...
```

两个筛选控件也补了 `aria-label`。

**这些按钮本来就键盘可达**（是带可见文字的真 `<Button>`，不是图标 div），所以这一条是关于「叫什么名字」，不是焦点顺序 —— 原始建议里的「补键盘可达」部分核下来并不成立。

## 验证

- 8 个新测试，`npm test` 261 passed，typecheck / lint 干净
- **两处都做了 mutation check**：去掉一个 `aria-label` → 对应测试红；把删除 key 改成留空值 → 对应测试红
- 本地起服务用真数据点过：`?group=2` 只剩 1 行且筛选框回显「日本线路」，`?owner_uid=1` 打字后参数共存，行按钮的 `aria-label` 逐行确认

> 顺带记一笔：探测 antd Select 回显时我先用了 `.ant-select-selection-item` 拿到空值，差点误判成 bug —— antd v6 改成了 `.ant-select-content`。和之前 `.ant-progress-bg` → `.ant-progress-track` 是同一类陷阱。

## 冲突提醒

这个分支从 main 切出，和 **#119 都改 `Rules.tsx`**。两者都动了 `load()` 附近和文件头部的 state 声明，**先合哪个另一个都要 rebase**。合完第一个告诉我，我来处理另一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)