### PR TITLE
release: v1.2.7 (panel) + node-v1.2.2 (node)

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,6 +11,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.2.2] - 2026-08-13
+
+Node only. Nothing on the wire changed — the config protocol stays at version
+4, so this node runs against any current panel.
+
+Worth taking if you run UDP rules with more than one target.
+
+### Fixed
+
+- **A UDP session now falls through to a standby when the primary target fails.**
+  Only the first resolved target was ever attempted, so a target that refused
+  the connection dropped the session's first datagram instead of trying the
+  backups the rule configures.
+
+- **A local bind failure is no longer blamed on the targets.** Binding the
+  outbound socket happens once per session, before target selection. It fails
+  when `OUTBOUND_BIND_IPV4` names an address the host no longer has — a NIC
+  rename or a changed DHCP lease — which says nothing about any target's health.
+  Attempting it per candidate reported that one local fault to the circuit
+  breaker once per target and tripped all of them, and replaced the precise
+  "failed to bind outbound" diagnostic with a message accusing the targets.
+
+### Changed
+
+- **Targets are resolved lazily**, one at a time as their turn comes, instead of
+  all up front. This runs on the listener's receive loop for every new session,
+  so a rule with three DNS targets and a healthy primary was paying three
+  lookups where one would do — and stalling the whole port on a cold cache for
+  two standbys it never used.
+
 ## [1.2.1] - 2026-08-02
 
 Node only. Nothing on the wire changed — the config protocol stays at version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,71 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.2.7] - 2026-08-13
+
+Panel only. The node ships separately as `node-v1.2.2`; neither release
+requires the other and the config protocol is unchanged at version 4.
+
+No database migration. Pull the panel image and restart.
+
+**Read this one before upgrading if you sell plans**: a plan purchase now
+enforces its rule limit against rules that ALREADY exist, so buying a smaller
+plan pauses the buyer's newest excess rules immediately. See below.
+
+### Changed
+
+- **A plan's rule limit now applies to rules that already exist.** It was
+  enforced only when creating a rule, so a user who downgraded kept every rule
+  they had already made and the smaller plan bought them nothing. Buying a plan
+  now keeps the oldest active rules and pauses the newest excess ones.
+
+  The paused rules are marked like a manual pause on purpose: a later upgrade
+  does **not** silently reopen those ports. The user resumes them when they want
+  them back.
+
+  Manual resume is held to the same limit — otherwise a downgrade could be
+  undone one on/off switch at a time. Resuming past the limit now fails with a
+  clear message instead of quietly succeeding.
+
+  An admin editing `max_rules` directly on the user page is deliberately NOT
+  reconciled: that path stays "applies to new rules only".
+
+- **Registration copies the selected plan's line authorization**, not just its
+  quotas. A user could previously register onto a plan and then find they were
+  not authorized for any of the lines that plan advertises.
+
+- **A failed database read is no longer reported as an empty list.** Admin list
+  endpoints (rules, groups, users, plans, profiles, stats, node status) returned
+  an empty success on a database error, so an outage looked exactly like "you
+  have no rules" — and an operator acting on that would go and recreate things
+  that still existed. They now return an explicit error, and the pages show a
+  load-failure notice while keeping whatever was already on screen.
+
+- **Rule filters live in the URL.** The group filter and the search box were
+  component state, so a refresh dropped them and a filtered view could not be
+  linked to anyone. `group` and `q` now join the existing `owner_uid`, so the
+  whole filter set is one shareable address. Typing does not push a history
+  entry per keystroke.
+
+- **Row actions on the rules table name their rule.** Every row's buttons
+  carried the same visible word, so a screen reader announced an
+  undifferentiated list of them — including "delete". The visible labels are
+  unchanged; only the accessible name is now qualified.
+
+### Fixed
+
+- **A rejected rule resume no longer wedges the SQLite writer.** The resume path
+  opens a write transaction and returned early on error without rolling back,
+  handing the pooled connection back while it still held SQLite's write lock.
+  Every later write in the process then blocked and failed until the process
+  restarted. Reachable from an ordinary edit: resuming a rule while also moving
+  its port onto one already in use.
+
+- **A failed rules read no longer empties the inbound-group picker.** The two
+  lists were fetched together, so one failing discarded the other's result —
+  leaving an admin unable to create a rule for a problem that had nothing to do
+  with groups.
+
 ## [1.2.6] - 2026-08-12
 
 Panel only. The node remains `node-v1.2.1`; this release does not change the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.6";
+const COMPILED_APP_VERSION: &str = "1.2.7";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.6}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.7}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -57,7 +57,7 @@ services:
     # v1.2: the node image tag is INDEPENDENT of the panel tag. Override
     # RELAYPANEL_NODE_TAG in .env to pin a node version that differs from the
     # panel version.
-    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.1}
+    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.2}
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.2.1"
+SCRIPT_VERSION="1.2.2"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
两条轨一起切，两个 tag，互不要求对方 —— 配置协议仍是 version 4。  ## 版本号（`docs/VERSIONS.md` 的两组 4 处）  **面板 1.2.6 → 1.2.7**：`crates/panel/Cargo.toml`、`config.rs` 的 `COMPILED_APP_VERSION`、`docker-compose.release.yaml` 的 `RELAYPANEL_PANEL_TAG`（README 徽章是动态的）  **节点 1.2.1 → 1.2.2**：`crates/node/Cargo.toml`、`relay-node-install.sh` 的 `SCRIPT_VERSION`、`RELAYPANEL_NODE_TAG`、`CHANGELOG-NODE.md`  `Cargo.lock` 跟着 `cargo check` 更新。  ## 内容  本轮合入的 4 个 PR（#118 #119 #120 #121）**都没有写 changelog**，所以两份 changelog 是在这个提交里补的。  **v1.2.7（面板）** —— 套餐规则上限对已有规则生效、注册继承套餐线路授权、读接口错误不再渲染成空列表、规则筛选进 URL、行操作可访问名带规则名；修复 resume 失败卡死 SQLite 写锁、以及规则读取失败连带清空入口分组选择器。无 schema 变更。  **node-v1.2.2（节点）** —— UDP 主目标失败时故障转移到备用、bind 每会话一次（本地 bind 故障不再算到所有目标头上）、目标惰性解析。  ## 升级提示

套餐降级后，如果现有启用规则数量超过新套餐上限，系统会保留最早创建的规则并暂停其余规则。后续升级套餐不会自动恢复这些规则，以避免在未确认的情况下重新开放端口；需要时可由用户手动恢复。  ## 预检  ``` release-check.sh panel 1.2.7  →  79 OK, 7 WARN, 0 FAIL release-check.sh node  1.2.2  →  78 OK, 7 WARN, 0 FAIL ```  ## 全量门禁  - `cargo fmt --check` / `cargo clippy --workspace --all-targets -D warnings` 干净 - `cargo test --workspace` 661 passed - 前端 `npm run lint` 干净、`npm test` 268 passed、`npm run build` 通过  合并后打两个 tag：`v1.2.7` 和 `node-v1.2.2`。  🤖 Generated with [Claude Code](https://claude.com/claude-code)