### PR TITLE
fix(node): count TCP traffic while the connection is open

### DIFF
--- a/crates/node/src/forwarder/splice.rs
+++ b/crates/node/src/forwarder/splice.rs
@@ -99,7 +99,14 @@ fn shutdown_write(fd: RawFd) {
 /// Pump one direction, `src → dst`, with splice via a private pipe. Returns the
 /// total bytes moved. On return (EOF or error) the destination's write half is
 /// shut down so the peer sees EOF and the opposite pump can finish too.
-async fn pump(src: &TcpStream, dst: &TcpStream) -> io::Result<u64> {
+///
+/// v1.2.8: `on_bytes` fires on every successful splice INTO the destination,
+/// so bytes are reportable as they move. The return value used to be the only
+/// output, which meant a caller could not bill a connection until it ended — a
+/// long-lived tunnel moved unlimited traffic while its owner's quota read zero.
+/// With the callback the unreported amount is never more than one in-flight
+/// chunk.
+async fn pump(src: &TcpStream, dst: &TcpStream, on_bytes: impl Fn(u64)) -> io::Result<u64> {
     let pipe = Pipe::new()?;
     let src_fd = src.as_raw_fd();
     let dst_fd = dst.as_raw_fd();
@@ -133,6 +140,7 @@ async fn pump(src: &TcpStream, dst: &TcpStream) -> io::Result<u64> {
                     Ok(m) => {
                         left -= m;
                         total += m as u64;
+                        on_bytes(m as u64);
                     }
                     Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
                     Err(e) => return Err(e),
@@ -155,12 +163,17 @@ async fn pump(src: &TcpStream, dst: &TcpStream) -> io::Result<u64> {
 /// The streams are wrapped in `Arc` so both pump tasks can drive readiness on
 /// them concurrently (`readable`/`writable`/`try_io` take `&self`); the raw fds
 /// stay valid for the whole operation because the `Arc`s outlive both pumps.
-pub async fn zero_copy_bidirectional(a: TcpStream, b: TcpStream) -> io::Result<(u64, u64)> {
+pub async fn zero_copy_bidirectional(
+    a: TcpStream,
+    b: TcpStream,
+    on_up: impl Fn(u64),
+    on_down: impl Fn(u64),
+) -> io::Result<(u64, u64)> {
     let a = Arc::new(a);
     let b = Arc::new(b);
     let (a_up, b_up) = (a.clone(), b.clone());
-    let ab = pump(&a_up, &b_up); // a → b
-    let ba = pump(&b, &a); // b → a
+    let ab = pump(&a_up, &b_up, on_up); // a → b
+    let ba = pump(&b, &a, on_down); // b → a
     let (r_ab, r_ba) = tokio::join!(ab, ba);
     Ok((r_ab?, r_ba?))
 }
@@ -192,7 +205,9 @@ mod tests {
         let relay_task = tokio::spawn(async move {
             let (client, _) = relay.accept().await.unwrap();
             let upstream = TcpStream::connect(target_addr).await.unwrap();
-            zero_copy_bidirectional(client, upstream).await.unwrap()
+            zero_copy_bidirectional(client, upstream, |_| {}, |_| {})
+                .await
+                .unwrap()
         });
 
         // Client: send, receive the echo, close.
@@ -230,10 +245,23 @@ mod tests {
 
         let relay = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let relay_addr = relay.local_addr().unwrap();
+        // v1.2.8: record every callback so we can prove reporting is
+        // INCREMENTAL. A payload this size spans several pipe-fulls, so a
+        // correct implementation reports more than once; the old
+        // count-once-at-the-end shape would show exactly one call.
+        let ticks = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+        let ticks_up = ticks.clone();
         let relay_task = tokio::spawn(async move {
             let (client, _) = relay.accept().await.unwrap();
             let upstream = TcpStream::connect(target_addr).await.unwrap();
-            zero_copy_bidirectional(client, upstream).await.unwrap()
+            zero_copy_bidirectional(
+                client,
+                upstream,
+                move |n| ticks_up.lock().unwrap().push(n),
+                |_| {},
+            )
+            .await
+            .unwrap()
         });
 
         let mut client = TcpStream::connect(relay_addr).await.unwrap();
@@ -250,6 +278,17 @@ mod tests {
             received,
             payload.len() as u64,
             "target must receive all bytes"
+        );
+        let reported = ticks.lock().unwrap().clone();
+        assert!(
+            reported.len() > 1,
+            "bytes must be reported as they move, not once at the end (got {} call(s))",
+            reported.len()
+        );
+        assert_eq!(
+            reported.iter().sum::<u64>(),
+            payload.len() as u64,
+            "the reported chunks must add up to exactly what was forwarded"
         );
         assert_eq!(up, payload.len() as u64, "up count must equal payload size");
     }

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -256,13 +256,28 @@ async fn handle_tcp_connection(
     // userspace copy's CPU cost is negligible. Byte counts still come back from
     // the splice return values, so billing is unaffected. Non-Linux always uses
     // the userspace copy below.
+    // v1.2.8: one handle per connection, taken BEFORE the copy starts. Both
+    // paths below report through it on every chunk, so a connection's bytes are
+    // billable while it is still open. They used to be summed into a local and
+    // submitted once at close, which meant a persistent connection moved
+    // unlimited traffic without ever touching its owner's quota.
+    let bytes = counter.handle(rule_id).await;
+
     #[cfg(target_os = "linux")]
     if matches!(rate_limit, RateLimit::Unlimited) {
-        match super::splice::zero_copy_bidirectional(inbound, outbound).await {
-            // (up = client→target, down = target→client) — same attribution as
-            // the userspace path's counter.add(rule_id, up, down).
-            Ok((up, down)) => counter.add(rule_id, up, down).await,
-            Err(e) => tracing::debug!("TCP splice forward (rule {}): {}", rule_id, e),
+        // (up = client→target, down = target→client) — the same attribution the
+        // userspace path uses below.
+        let up_sink = bytes.clone();
+        let down_sink = bytes.clone();
+        if let Err(e) = super::splice::zero_copy_bidirectional(
+            inbound,
+            outbound,
+            move |n| up_sink.add_upload(n),
+            move |n| down_sink.add_download(n),
+        )
+        .await
+        {
+            tracing::debug!("TCP splice forward (rule {}): {}", rule_id, e);
         }
         return Ok(());
     }
@@ -278,13 +293,12 @@ async fn handle_tcp_connection(
     let (mut ri, mut wi) = inbound.into_split();
     let (mut ro, mut wo) = outbound.into_split();
 
-    let counter_up = counter.clone();
-    let counter_down = counter.clone();
+    let counter_up = bytes.clone();
+    let counter_down = bytes;
     let rl_up = rate_limit.clone();
     let rl_down = rate_limit;
 
     let upload = Box::pin(async move {
-        let mut total = 0u64;
         // v1.0.8: 32 KiB copy buffer (this userspace path is only used by
         // rate-limited rules, which are capped anyway; the unlimited fast path
         // uses splice above). Heap-allocated as part of this Box::pin'd future,
@@ -300,13 +314,11 @@ async fn handle_tcp_connection(
             if wo.write_all(&buf[..n]).await.is_err() {
                 break;
             }
-            total += n as u64;
+            counter_up.add_upload(n as u64);
         }
-        counter_up.add(rule_id, total, 0).await;
         let _ = wo.shutdown().await;
     });
     let download = Box::pin(async move {
-        let mut total = 0u64;
         // v1.0.8: 32 KiB copy buffer (see the upload side above).
         let mut buf = [0u8; 32 * 1024];
         loop {
@@ -319,9 +331,8 @@ async fn handle_tcp_connection(
             if wi.write_all(&buf[..n]).await.is_err() {
                 break;
             }
-            total += n as u64;
+            counter_down.add_download(n as u64);
         }
-        counter_down.add(rule_id, 0, total).await;
         let _ = wi.shutdown().await;
     });
 
@@ -392,6 +403,86 @@ mod tests {
             b"ping-through-relay",
             "relay must echo the target"
         );
+    }
+
+    /// v1.2.8: a connection's bytes must be billable WHILE IT IS STILL OPEN.
+    ///
+    /// Both copy paths used to sum into a local and submit once the connection
+    /// closed, so a persistent connection contributed nothing to its rule's
+    /// usage for as long as it stayed up. A tunnel could move any amount of
+    /// traffic while the owner's quota read zero, and the panel — which stops
+    /// forwarding on reported usage — never had a reason to stop it. The bytes
+    /// landed only at close, potentially long after the user stopped paying.
+    ///
+    /// The target here deliberately stays open after echoing, and the client
+    /// never closes: the counter must already hold the traffic.
+    #[tokio::test]
+    async fn traffic_is_counted_while_the_connection_is_still_open() {
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        // Echo once, then HOLD the connection open (no shutdown, no drop).
+        let target_task = tokio::spawn(async move {
+            if let Ok((mut s, _)) = target.accept().await {
+                let mut b = vec![0u8; 1024];
+                if let Ok(n) = s.read(&mut b).await {
+                    let _ = s.write_all(&b[..n]).await;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                drop(s);
+            }
+        });
+
+        let listener = bind_tcp_listener(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+        let selector = Arc::new(TargetSelector::new(LoadBalanceStrategy::First, 1));
+        let counter = Arc::new(TrafficCounter::new());
+        let connections = Arc::new(ConnectionTracker::new());
+        let runtime = crate::forwarder::gate::RuleRuntime::new();
+        tokio::spawn(serve_tcp_listener(
+            listener,
+            vec![target_addr.to_string()],
+            selector,
+            // Unlimited so Linux takes the splice path and every other platform
+            // takes the userspace copy — this must hold on both.
+            RateLimit::Unlimited,
+            counter.clone(),
+            connections,
+            7,
+            None,
+            runtime.gate(None),
+        ));
+        let _runtime = runtime;
+
+        let mut client = TcpStream::connect(listen_addr).await.unwrap();
+        let payload = b"bytes-that-must-be-billed-before-close";
+        client.write_all(payload).await.unwrap();
+        let mut got = vec![0u8; 64];
+        let n = client.read(&mut got).await.unwrap();
+        assert_eq!(&got[..n], payload, "relay must echo the target");
+
+        // The connection is STILL OPEN here — neither side has closed. Poll the
+        // counter briefly: the copy tasks report from a separate task, so allow
+        // a moment for the scheduler without allowing "eventually at close".
+        let mut seen = None;
+        for _ in 0..50 {
+            let snap = counter.snapshot().await;
+            if let Some(e) = snap.entries.iter().find(|e| e.rule_id == 7) {
+                if e.upload > 0 && e.download > 0 {
+                    seen = Some((e.upload, e.download));
+                    break;
+                }
+            }
+            drop(snap);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let (up, down) = seen.expect(
+            "traffic must be counted while the connection is open, not only when it closes",
+        );
+        assert_eq!(up, payload.len() as u64, "upload = client bytes forwarded");
+        assert_eq!(down, payload.len() as u64, "download = echoed bytes back");
+
+        target_task.abort();
     }
 
     /// v1.2.0: the cap is enforced at accept. Connections up to the cap forward

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -418,6 +418,23 @@ mod tests {
     /// never closes: the counter must already hold the traffic.
     #[tokio::test]
     async fn traffic_is_counted_while_the_connection_is_still_open() {
+        // Unlimited: on Linux this is the splice path.
+        assert_counts_before_close(RateLimit::Unlimited, 7).await;
+    }
+
+    /// The same contract on the OTHER forwarding path.
+    ///
+    /// On Linux an unlimited rule takes splice, so the test above never
+    /// exercises the userspace copy there — and Linux is what CI runs. A
+    /// rate-limited rule cannot use splice (bytes must reach userspace to be
+    /// throttled), so this covers the copy loop on every platform.
+    #[tokio::test]
+    async fn traffic_is_counted_while_open_on_the_rate_limited_path() {
+        // A cap high enough not to slow the test, low enough to be Limited.
+        assert_counts_before_close(RateLimit::new(Some(100_000_000), Some(100_000_000)), 8).await;
+    }
+
+    async fn assert_counts_before_close(rate_limit: RateLimit, rule_id: i64) {
         let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let target_addr = target.local_addr().unwrap();
         // Echo once, then HOLD the connection open (no shutdown, no drop).
@@ -442,12 +459,10 @@ mod tests {
             listener,
             vec![target_addr.to_string()],
             selector,
-            // Unlimited so Linux takes the splice path and every other platform
-            // takes the userspace copy — this must hold on both.
-            RateLimit::Unlimited,
+            rate_limit,
             counter.clone(),
             connections,
-            7,
+            rule_id,
             None,
             runtime.gate(None),
         ));
@@ -466,7 +481,7 @@ mod tests {
         let mut seen = None;
         for _ in 0..50 {
             let snap = counter.snapshot().await;
-            if let Some(e) = snap.entries.iter().find(|e| e.rule_id == 7) {
+            if let Some(e) = snap.entries.iter().find(|e| e.rule_id == rule_id) {
                 if e.upload > 0 && e.download > 0 {
                     seen = Some((e.upload, e.download));
                     break;

--- a/crates/node/src/reporter.rs
+++ b/crates/node/src/reporter.rs
@@ -16,6 +16,26 @@ use tokio::sync::{Mutex, RwLock};
 /// per-packet add() path can clone-free `fetch_add` after a shared read lock.
 type RuleCounters = Arc<(AtomicU64, AtomicU64)>;
 
+/// A per-rule counter held for the lifetime of ONE connection.
+///
+/// Handed out by [`TrafficCounter::handle`]. Both methods are plain atomic
+/// adds — no lock, no `await` — so a copy loop can report every chunk the
+/// instant it moves instead of batching until the connection closes.
+#[derive(Clone)]
+pub struct RuleCounterHandle(RuleCounters);
+
+impl RuleCounterHandle {
+    /// client → target.
+    pub fn add_upload(&self, n: u64) {
+        self.0 .0.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// target → client.
+    pub fn add_download(&self, n: u64) {
+        self.0 .1.fetch_add(n, Ordering::Relaxed);
+    }
+}
+
 pub struct TrafficCounter {
     // rule_id -> (upload, download) as lock-free atomic counters. Keyed by rule
     // id (not listen port) so traffic is attributed to the right rule even when
@@ -52,6 +72,42 @@ impl TrafficCounter {
             .or_insert_with(|| Arc::new((AtomicU64::new(0), AtomicU64::new(0))));
         c.0.fetch_add(upload, Ordering::Relaxed);
         c.1.fetch_add(download, Ordering::Relaxed);
+    }
+
+    /// Acquire a long-lived handle to one rule's counters.
+    ///
+    /// v1.2.8: this exists so a TCP connection can report bytes AS THEY MOVE
+    /// rather than accumulating them in a local and submitting once at close.
+    /// Both copy loops used to do the latter, which meant a long-lived
+    /// connection contributed NOTHING to the rule's usage until it ended -- a
+    /// persistent tunnel could move hundreds of gigabytes while the owner's
+    /// quota still read zero, so the panel never stopped it. The bytes landed
+    /// only when the connection finally closed, possibly long after the user
+    /// had stopped paying for them.
+    ///
+    /// Returning the `Arc` (rather than calling `add` per chunk) keeps the hot
+    /// path lock-free AND non-async: the map lock is taken once when the
+    /// connection starts, and every later chunk is a plain `fetch_add`. That is
+    /// strictly cheaper than the old per-chunk `add`, which took a read lock
+    /// every time.
+    ///
+    /// Note on `prune_rule`: a handle taken before a prune keeps writing into
+    /// an Arc the map no longer holds, so those bytes are dropped rather than
+    /// resurrecting a pruned rule_id. That is what we want -- a stale rule_id
+    /// in a traffic batch makes the panel reject the WHOLE batch.
+    pub async fn handle(&self, rule_id: i64) -> RuleCounterHandle {
+        {
+            let map = self.data.read().await;
+            if let Some(c) = map.get(&rule_id) {
+                return RuleCounterHandle(c.clone());
+            }
+        }
+        let mut map = self.data.write().await;
+        let c = map
+            .entry(rule_id)
+            .or_insert_with(|| Arc::new((AtomicU64::new(0), AtomicU64::new(0))))
+            .clone();
+        RuleCounterHandle(c)
     }
 
     /// Take a snapshot and return a guard whose `commit()` subtracts exactly

--- a/crates/node/src/reporter.rs
+++ b/crates/node/src/reporter.rs
@@ -387,8 +387,7 @@ pub async fn report_traffic(config: &NodeConfig, counter: &TrafficCounter) {
     // the moment a connection OPENS rather than when it closes, so an idle but
     // still-open connection holds a 0/0 entry — without this filter such a node
     // would POST a batch of zeroes every cycle, forever. Only the UPLOAD is
-    // filtered: the snapshot still commits every entry, and subtracting zero is
-    // a no-op that lets the strong_count cleanup in `commit` run as usual.
+    // filtered; the snapshot still commits every entry.
     let reports: Vec<TrafficEntry> = snap
         .entries
         .iter()
@@ -397,6 +396,14 @@ pub async fn report_traffic(config: &NodeConfig, counter: &TrafficCounter) {
         .collect();
     tracing::debug!("report_traffic: {} entries to report", reports.len());
     if reports.is_empty() {
+        // Commit before returning. There is nothing to send, but the snapshot
+        // still has to be applied: subtracting zero is a no-op that lets the
+        // strong_count cleanup in `commit` drop entries whose connection has
+        // closed. Returning without it would strand a 0/0 entry for every rule
+        // that ever had a connection open and transfer nothing, and nothing
+        // else would ever clear it — a batch of only zeroes is exactly the case
+        // that reaches this branch.
+        snap.commit().await;
         return;
     }
 
@@ -1256,6 +1263,49 @@ mod tests {
         assert!(
             !counter.has_rule(11).await,
             "a fully reported rule with no live connection must not stay in the map"
+        );
+    }
+
+    /// A connection that opens, moves nothing and closes must leave no entry
+    /// behind after one reporting cycle.
+    ///
+    /// Taking the handle at connection START means such a connection creates a
+    /// 0/0 entry. Those are filtered out of the upload — and the filter is what
+    /// makes this reachable: when EVERY entry is zero there is nothing to send,
+    /// and an early return would skip the commit that removes them. Nothing
+    /// else clears a zero entry, so each one would sit in the map until the
+    /// rule left the config.
+    #[tokio::test]
+    async fn an_idle_connection_leaves_no_counter_entry_behind() {
+        let counter = TrafficCounter::new();
+        {
+            // Connection opens, transfers nothing, closes.
+            let _conn = counter.handle(21).await;
+        }
+        assert!(
+            counter.has_rule(21).await,
+            "opening a connection is what creates the entry — otherwise this test proves nothing"
+        );
+
+        // One reporting cycle. panel_url is unreachable on purpose: with only
+        // zero entries the function must return before it ever tries to POST.
+        let config = NodeConfig {
+            panel_url: "http://127.0.0.1:1".into(),
+            token: "t".into(),
+            poll_interval: 10,
+            tls_cert_path: None,
+            tls_key_path: None,
+            network_interface: "auto".into(),
+            listen_ipv4: "0.0.0.0".into(),
+            listen_ipv6: "::".into(),
+            outbound_interface: "auto".into(),
+            outbound_bind_ipv4: None,
+        };
+        report_traffic(&config, &counter).await;
+
+        assert!(
+            !counter.has_rule(21).await,
+            "a zero entry with no live connection must be cleared by the reporting cycle"
         );
     }
 

--- a/crates/node/src/reporter.rs
+++ b/crates/node/src/reporter.rs
@@ -186,7 +186,22 @@ impl TrafficSnapshot<'_> {
                 let prev_up = c.0.fetch_sub(e.upload, Ordering::Relaxed);
                 let prev_down = c.1.fetch_sub(e.download, Ordering::Relaxed);
                 // new == 0 iff prev == snapshotted (no adds since the snapshot).
-                prev_up == e.upload && prev_down == e.download
+                //
+                // v1.2.8: draining to zero is NOT enough to remove the entry.
+                // A live connection holds a RuleCounterHandle — an Arc to this
+                // very counter — and removing the map's copy would orphan it:
+                // every later byte would land in an Arc nothing reads, and that
+                // connection would stop being billed for the rest of its life.
+                // That is this release's own long-connection hole, re-created
+                // at a poll boundary, and it would hit exactly the long-lived
+                // connections the change exists to fix.
+                //
+                // strong_count == 1 means the map is the only owner, so no
+                // connection can still be writing. The check is conservative in
+                // the safe direction: a handle dropped concurrently can leave
+                // the count momentarily high, which only keeps a zeroed entry
+                // around until the next cycle.
+                prev_up == e.upload && prev_down == e.download && Arc::strong_count(c) == 1
             } else {
                 false
             };
@@ -368,14 +383,24 @@ pub async fn report_traffic(config: &NodeConfig, counter: &TrafficCounter) {
     // debug, not info: this runs every poll cycle (default 10s) and would
     // flood the log at info level on a healthy node. Only the per-request
     // HTTP status below is worth keeping visible.
-    tracing::debug!("report_traffic: {} entries to report", snap.entries.len());
-    if snap.entries.is_empty() {
+    // v1.2.8: skip entries with nothing in them. A rule now gets its counter
+    // the moment a connection OPENS rather than when it closes, so an idle but
+    // still-open connection holds a 0/0 entry — without this filter such a node
+    // would POST a batch of zeroes every cycle, forever. Only the UPLOAD is
+    // filtered: the snapshot still commits every entry, and subtracting zero is
+    // a no-op that lets the strong_count cleanup in `commit` run as usual.
+    let reports: Vec<TrafficEntry> = snap
+        .entries
+        .iter()
+        .filter(|e| e.upload > 0 || e.download > 0)
+        .cloned()
+        .collect();
+    tracing::debug!("report_traffic: {} entries to report", reports.len());
+    if reports.is_empty() {
         return;
     }
 
-    let report = TrafficReport {
-        reports: snap.entries.clone(),
-    };
+    let report = TrafficReport { reports };
 
     let url = format!("{}/api/v1/node/report_traffic", config.panel_url);
     let client = reqwest::Client::new();
@@ -1175,6 +1200,62 @@ mod tests {
         assert_eq!(
             resolve_network_interface("").is_some(),
             resolve_network_interface("auto").is_some(),
+        );
+    }
+
+    /// A handle held across a successful report must keep counting.
+    ///
+    /// `commit()` removes a rule's map entry once its counters reach zero. A
+    /// live connection holds an Arc to that entry, so removing it orphans the
+    /// handle: every later byte lands in an Arc nothing reads, and the
+    /// connection stops being billed for the rest of its life. That is the
+    /// original long-connection hole re-created at a poll boundary — and it
+    /// bites precisely the connections this change exists to fix, because they
+    /// are the ones alive across a report.
+    #[tokio::test]
+    async fn a_handle_keeps_counting_after_its_rule_was_reported_and_drained() {
+        let counter = TrafficCounter::new();
+        // A connection opens and forwards some bytes.
+        let conn = counter.handle(9).await;
+        conn.add_upload(1_000);
+        conn.add_download(2_000);
+
+        // A reporting cycle uploads them and the panel ACKs, so they are
+        // subtracted. Nothing arrived in between, so the entry drains to zero.
+        let snap = counter.snapshot().await;
+        assert_eq!(snap.entries.len(), 1);
+        snap.commit().await;
+
+        // The connection is STILL OPEN and forwards more.
+        conn.add_upload(500);
+        conn.add_download(700);
+
+        let after = counter.snapshot().await;
+        let entry = after
+            .entries
+            .iter()
+            .find(|e| e.rule_id == 9)
+            .expect("traffic after a report must still be attributed to the rule");
+        assert_eq!(entry.upload, 500);
+        assert_eq!(entry.download, 700);
+    }
+
+    /// The counterpart: once no connection holds the rule any more, a drained
+    /// entry IS removed. The strong_count guard must not turn into a leak that
+    /// keeps a row per rule the node ever forwarded.
+    #[tokio::test]
+    async fn a_drained_rule_is_removed_once_no_connection_holds_it() {
+        let counter = TrafficCounter::new();
+        {
+            let conn = counter.handle(11).await;
+            conn.add_upload(42);
+        } // connection closes here — the handle drops
+
+        let snap = counter.snapshot().await;
+        snap.commit().await;
+        assert!(
+            !counter.has_rule(11).await,
+            "a fully reported rule with no live connection must not stay in the map"
         );
     }
 


### PR DESCRIPTION
## 问题

两条 TCP 拷贝路径都是把字节累加到局部变量，**等拷贝循环结束（也就是连接关闭）才提交**给流量计数器。

`tcp.rs:305/324`（用户态）和 `tcp.rs:264`（splice）都是这个形状：

```rust
loop {
    let n = ro.read(&mut buf).await;
    total += n as u64;          // 只累加本地
}
counter_down.add(rule_id, 0, total).await;   // ← 断开才提交
```

**这是漏钱，不是延迟问题。** 面板是靠「已上报用量 vs 套餐额度」来停转发的，所以一条持久连接（隧道、VPN、大文件下载）可以一直跑，而owner的额度**始终显示 0**，没有任何东西有理由停它。那笔量要等连接终于断了才一次性落账 —— 那时候人可能早不付费了。

官网把它写成一条「已知限制」，但性质更接近缺陷。

## 改法

两条路径都改成**按块上报**：

- 用户态拷贝：每转发一个缓冲就记一次
- splice 的 `pump` 收一个 `on_bytes` 回调，每次成功 splice 进目标端就触发 —— 未上报量永远不超过一个在途块

管道是新加的 `TrafficCounter::handle(rule_id) -> RuleCounterHandle`，每条连接取一次。它把计数器内部本来就存着的 per-rule `Arc<(AtomicU64, AtomicU64)>` 交出去，所以热路径是**纯 `fetch_add`，不加锁也不 `await`** —— 比它替换掉的旧 `add()`（每次都要拿读锁）更便宜。

选这个而不是「定期 flush 阈值」，是因为它**彻底消除累积**，而不是把未计量压到某个上限。

## 一个值得点名的行为

在 `prune_rule` 之后仍持有 handle 的连接，会写进一个 map 已经不再持有的 Arc —— 那些字节被丢弃，而不是让一个已删除的 rule_id 复活。这是安全的方向：**批次里出现陈旧 rule_id 会让面板拒绝整批流量上报**。

## 验证

- 回归测试：转发完之后**保持连接不关**，断言计数器里已经有这笔量。**Mutation check 过** —— 把代码改回「关闭才提交」，测试如期红（`traffic must be counted while the connection is open, not only when it closes`）
- splice 测试额外断言：1 MiB 载荷跨多个 pipe-full 时回调**触发多于一次**，且各块之和恰好等于转发总量
- `cargo test -p relay-node` 109 passed、clippy `-D warnings` 干净、fmt 干净

## ⚠️ 本地未验证的部分

`splice.rs` 是 Linux-only，我在 Windows 上**编译不到**（`cargo check --target x86_64-unknown-linux-gnu` 卡在 ring 的 build script，需要目标平台 C 工具链）。逐行审过改动，但**CI 是这条路径的第一次真实检验**。

## 发布影响

这是节点侧改动，要发 `node-v*` 才生效。已有节点升级前仍然是老行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)