### PR TITLE
chore(release): panel 1.2.8 / node 1.2.3

### DIFF
--- a/CHANGELOG-NODE.md
+++ b/CHANGELOG-NODE.md
@@ -11,6 +11,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [1.2.3] - 2026-08-27
+
+Node only. Nothing on the wire changed (still protocol version 4), so this
+node runs against any current panel.
+
+**Take this one if you bill by traffic.** Until now a long-lived connection was
+not counted until it closed, so it could move any amount of traffic for free.
+
+### Fixed
+
+- **TCP traffic is counted while the connection is open.** Both copy paths
+  summed bytes into a local and submitted them only when the copy loop ended —
+  i.e. when the connection closed. A long-lived connection therefore
+  contributed NOTHING to its rule's usage for as long as it stayed up.
+
+  That is a billing hole, not a reporting delay. The panel stops forwarding by
+  comparing reported usage against the plan quota, so a persistent connection —
+  a tunnel, a VPN, a long download — could move any amount of traffic while its
+  owner's quota still read zero, and nothing ever had a reason to stop it. The
+  bytes landed in one lump whenever the connection finally ended, potentially
+  long after the user stopped paying for them.
+
+  Both the userspace copy and the Linux zero-copy (splice) path now report each
+  chunk as it moves, so the unreported amount is never more than one in-flight
+  buffer.
+
+  The previous behaviour was documented as a known limitation; it is closer to
+  a defect, and the documentation is updated with this release.
+
 ## [1.2.2] - 2026-08-13
 
 Node only. Nothing on the wire changed — the config protocol stays at version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ independent `v*` / `node-v*` tracks since this release).
 
 ---
 
+## [1.2.8] - 2026-08-27
+
+Panel only. The node ships separately as `node-v1.2.3` — take that one if you
+sell traffic, it closes a billing hole. Neither release requires the other and
+the config protocol is unchanged at version 4.
+
+No database migration. Pull the panel image and restart.
+
+### Changed
+
+- **An audit entry about a device group records the group's NAME, not just its
+  id.** "分组 4 → 1.2.2" only helps somebody who already knows which group 4
+  is, and the log is meant to be read months later — by which point the group
+  may have been renamed, or deleted and its id unresolvable. The name is now
+  captured at write time, exactly as the actor's name already was, with the id
+  kept beside it because names are neither unique nor stable. Applies to
+  upgrading a node, clearing a node's status record, rotating a group token and
+  deleting a group.
+
+  Deleting a group needed the lookup moved ahead of the delete: afterwards the
+  row is gone, and that is the one case where an id-only record can never be
+  interpreted again.
+
+- **A node upgrade is recorded as DISPATCHED, not completed.** The entry is
+  written the moment the command reaches the node's control channel. Everything
+  that can actually fail happens after that, on the node — downloading the
+  binary, verifying its checksum, backing up, swapping — and the node does not
+  report the outcome back, so a failed upgrade and a successful one produced
+  identical rows. The action now reads 下发节点升级 and the detail points at the
+  node's reported version, which is what actually answers "did it work".
+
 ## [1.2.7] - 2026-08-13
 
 Panel only. The node ships separately as `node-v1.2.2`; neither release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "relay-node"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "relay-panel"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relay-node"
 # Keep in sync with scripts/relay-node-install.sh (SCRIPT_VERSION) and the
 # GitHub release tag. `--version` / `-V` read this via env!("CARGO_PKG_VERSION").
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 license.workspace = true
 

--- a/crates/node/src/forwarder/splice.rs
+++ b/crates/node/src/forwarder/splice.rs
@@ -100,7 +100,7 @@ fn shutdown_write(fd: RawFd) {
 /// total bytes moved. On return (EOF or error) the destination's write half is
 /// shut down so the peer sees EOF and the opposite pump can finish too.
 ///
-/// v1.2.8: `on_bytes` fires on every successful splice INTO the destination,
+/// v1.2.3: `on_bytes` fires on every successful splice INTO the destination,
 /// so bytes are reportable as they move. The return value used to be the only
 /// output, which meant a caller could not bill a connection until it ended — a
 /// long-lived tunnel moved unlimited traffic while its owner's quota read zero.
@@ -245,7 +245,7 @@ mod tests {
 
         let relay = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let relay_addr = relay.local_addr().unwrap();
-        // v1.2.8: record every callback so we can prove reporting is
+        // v1.2.3: record every callback so we can prove reporting is
         // INCREMENTAL. A payload this size spans several pipe-fulls, so a
         // correct implementation reports more than once; the old
         // count-once-at-the-end shape would show exactly one call.

--- a/crates/node/src/forwarder/tcp.rs
+++ b/crates/node/src/forwarder/tcp.rs
@@ -256,7 +256,7 @@ async fn handle_tcp_connection(
     // userspace copy's CPU cost is negligible. Byte counts still come back from
     // the splice return values, so billing is unaffected. Non-Linux always uses
     // the userspace copy below.
-    // v1.2.8: one handle per connection, taken BEFORE the copy starts. Both
+    // v1.2.3: one handle per connection, taken BEFORE the copy starts. Both
     // paths below report through it on every chunk, so a connection's bytes are
     // billable while it is still open. They used to be summed into a local and
     // submitted once at close, which meant a persistent connection moved
@@ -405,7 +405,7 @@ mod tests {
         );
     }
 
-    /// v1.2.8: a connection's bytes must be billable WHILE IT IS STILL OPEN.
+    /// v1.2.3: a connection's bytes must be billable WHILE IT IS STILL OPEN.
     ///
     /// Both copy paths used to sum into a local and submit once the connection
     /// closed, so a persistent connection contributed nothing to its rule's

--- a/crates/node/src/reporter.rs
+++ b/crates/node/src/reporter.rs
@@ -76,7 +76,7 @@ impl TrafficCounter {
 
     /// Acquire a long-lived handle to one rule's counters.
     ///
-    /// v1.2.8: this exists so a TCP connection can report bytes AS THEY MOVE
+    /// v1.2.3: this exists so a TCP connection can report bytes AS THEY MOVE
     /// rather than accumulating them in a local and submitting once at close.
     /// Both copy loops used to do the latter, which meant a long-lived
     /// connection contributed NOTHING to the rule's usage until it ended -- a
@@ -187,7 +187,7 @@ impl TrafficSnapshot<'_> {
                 let prev_down = c.1.fetch_sub(e.download, Ordering::Relaxed);
                 // new == 0 iff prev == snapshotted (no adds since the snapshot).
                 //
-                // v1.2.8: draining to zero is NOT enough to remove the entry.
+                // v1.2.3: draining to zero is NOT enough to remove the entry.
                 // A live connection holds a RuleCounterHandle — an Arc to this
                 // very counter — and removing the map's copy would orphan it:
                 // every later byte would land in an Arc nothing reads, and that
@@ -383,7 +383,7 @@ pub async fn report_traffic(config: &NodeConfig, counter: &TrafficCounter) {
     // debug, not info: this runs every poll cycle (default 10s) and would
     // flood the log at info level on a healthy node. Only the per-request
     // HTTP status below is worth keeping visible.
-    // v1.2.8: skip entries with nothing in them. A rule now gets its counter
+    // v1.2.3: skip entries with nothing in them. A rule now gets its counter
     // the moment a connection OPENS rather than when it closes, so an idle but
     // still-open connection holds a 0/0 entry — without this filter such a node
     // would POST a batch of zeroes every cycle, forever. Only the UPLOAD is

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-panel"
-version = "1.2.7"
+version = "1.2.8"
 edition = "2021"
 license.workspace = true
 

--- a/crates/panel/src/config.rs
+++ b/crates/panel/src/config.rs
@@ -15,7 +15,7 @@ const INSECURE_JWT_SECRET: &str = "change-me-jwt-secret";
 /// Overridable at runtime via the `APP_VERSION` env var — used by CI to inject
 /// the version into the Docker image without rebuilding. If the env var is
 /// unset, the compiled-in default below is used.
-const COMPILED_APP_VERSION: &str = "1.2.7";
+const COMPILED_APP_VERSION: &str = "1.2.8";
 
 /// Resolve the effective app version: the `APP_VERSION` env var if set,
 /// otherwise the compiled-in default. Cached for the process lifetime.

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -21,7 +21,7 @@ services:
     # (RELAYPANEL_PANEL_TAG) and node tag (RELAYPANEL_NODE_TAG) may differ — a
     # panel upgrade does NOT require pulling a new node image. Override either
     # in .env to pin a specific version.
-    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.7}
+    image: ghcr.io/moeshinx/relay-panel-panel:${RELAYPANEL_PANEL_TAG:-1.2.8}
     ports:
       # RELAYPANEL_WEB_MODE controls how the panel port is published:
       #   direct         → 0.0.0.0:18888:18888  (public, default)
@@ -57,7 +57,7 @@ services:
     # v1.2: the node image tag is INDEPENDENT of the panel tag. Override
     # RELAYPANEL_NODE_TAG in .env to pin a node version that differs from the
     # panel version.
-    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.2}
+    image: ghcr.io/moeshinx/relay-panel-node:${RELAYPANEL_NODE_TAG:-1.2.3}
     profiles:
       - node
     network_mode: host

--- a/scripts/relay-node-install.sh
+++ b/scripts/relay-node-install.sh
@@ -34,7 +34,7 @@ cd / 2>/dev/null || true
 
 # Bump this when releasing a new version. The binary is downloaded from
 # GitHub Releases assets.
-SCRIPT_VERSION="1.2.2"
+SCRIPT_VERSION="1.2.3"
 REPO="MoeShinX/relay-panel"
 
 GREEN='\033[0;32m'


### PR DESCRIPTION
Version bump + changelogs for the two tracks.

- panel `1.2.7` → `1.2.8` (Cargo.toml, `COMPILED_APP_VERSION`, release compose tag)
- node `1.2.2` → `1.2.3` (Cargo.toml, installer `SCRIPT_VERSION`, release compose tag)

Also corrects seven node-side comments left over from #123 that were labelled
`v1.2.8`. The long-connection billing fix is a NODE change, and the node track's
next version is `1.2.3` — `1.2.8` is a panel version. The tracks are independent,
so the wrong label would have sent anyone reading the source looking for the fix
in a node release that will never exist.

**Panel 1.2.8** — audit records now name the group instead of only its id, and an
upgrade dispatch says what it dispatched (the version) and that the result is the
node's reported version, not the panel's word.

**Node 1.2.3** — TCP traffic is counted while a connection is open. Both copy
paths previously submitted their byte count only when the copy loop ended, so a
long-lived connection contributed nothing to its rule's usage for as long as it
stayed up. Since the panel stops forwarding by comparing reported usage against
the quota, such a connection could move any amount of traffic while the quota
still read zero. Nothing on the wire changed (protocol 4), so a 1.2.3 node runs
against any current panel.

`release-check.sh` is clean for both: panel 79 OK / 0 FAIL, node 78 OK / 0 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)